### PR TITLE
make linguist ignore vmlinux.h

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/bpf/vmlinux.h linguist-generated


### PR DESCRIPTION
systing was showing up as mostly c because of vmilnux.h, fix this.