### PR TITLE
only run CI against the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: build
 
 on:
     push:
+      branches:
+        - main
     pull_request:
+      branches:
+        - main
 
 jobs:
   clippy_check:


### PR DESCRIPTION
We were running the CI twice for PR's because we'd trigger one for the push and one for the PR.