### PR TITLE
Intern everything in stack recorder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         run: ./.github/workflows/install_deps.sh
 
       - name: Clippy Check (no features)
-        run: cargo clippy --no-default-features -- -D warnings
+        run: cargo clippy --no-default-features --all-targets -- -D warnings
 
       - name: Clippy Check (pystacks)
-        run: cargo clippy --features pystacks -- -D warnings
+        run: cargo clippy --features pystacks --all-targets -- -D warnings
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
       - name: Install Deps.
         run: ./.github/workflows/install_deps.sh
 
-      - name: Clippy Check (no features)
-        run: cargo clippy --no-default-features --all-targets -- -D warnings
+      - uses: Swatinem/rust-cache@v2
 
-      - name: Clippy Check (pystacks)
-        run: cargo clippy --features pystacks --all-targets -- -D warnings
+      - name: Clippy Check
+        run: |
+          cargo clippy --all-targets --no-default-features -- -D warnings
+          cargo clippy --all-targets --features pystacks -- -D warnings
 
   build:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ cargo test
 
 ### 5. Run Clippy (Linter)
 ```bash
-cargo clippy -- -D warnings
+cargo clippy --all-targets -- -D warnings
 ```
 
 ## Project Information
@@ -47,7 +47,7 @@ cargo clippy -- -D warnings
 3. Build with default features: `cargo build`
 4. Build with pystacks feature: `cargo build --features pystacks`
 5. Run all tests: `cargo test`
-6. Run clippy for linting: `cargo clippy -- -D warnings`
+6. Run clippy for linting: `cargo clippy --all-targets -- -D warnings`
 
 All commands must pass before considering the work complete.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,31 +4,31 @@ This file contains project-specific instructions for Claude Code when working on
 
 ## Build Commands
 
-When making changes to this project, always run the following commands in order:
+When making changes to this project, run the following commands to validate your work:
 
-### 1. Format Code
-```bash
-cargo fmt
-```
-
-### 2. Build (Default Features)
+### 1. Build (Default Features)
 ```bash
 cargo build
 ```
 
-### 3. Build with pystacks feature
+### 2. Build with pystacks feature
 ```bash
 cargo build --features pystacks
 ```
 
-### 4. Run Tests
+### 3. Run Tests
 ```bash
 cargo test
 ```
 
-### 5. Run Clippy (Linter)
+### 4. Run Clippy (Linter)
 ```bash
 cargo clippy --all-targets -- -D warnings
+```
+
+### 5. Format Code (BEFORE COMMITTING)
+```bash
+cargo fmt
 ```
 
 ## Project Information
@@ -43,13 +43,13 @@ cargo clippy --all-targets -- -D warnings
 ## Development Workflow
 
 1. Make your code changes
-2. Run `cargo fmt` to format the code
-3. Build with default features: `cargo build`
-4. Build with pystacks feature: `cargo build --features pystacks`
-5. Run all tests: `cargo test`
-6. Run clippy for linting: `cargo clippy --all-targets -- -D warnings`
+2. Build with default features: `cargo build`
+3. Build with pystacks feature: `cargo build --features pystacks`
+4. Run all tests: `cargo test`
+5. Run clippy for linting: `cargo clippy --all-targets -- -D warnings`
+6. **Run `cargo fmt` before committing** to ensure consistent formatting
 
-All commands must pass before considering the work complete.
+**Note:** All commands must pass before considering the work complete. Running `cargo fmt` is MANDATORY before any commit to prevent whitespace errors.
 
 ## Testing Strategy
 
@@ -62,3 +62,14 @@ All commands must pass before considering the work complete.
 - Use `cargo fmt` for consistent formatting
 - Follow Rust idioms and best practices
 - Address all clippy warnings
+
+## Before Committing
+
+**MANDATORY pre-commit checklist:**
+1. Run `cargo build` - must compile without errors
+2. Run `cargo build --features pystacks` - must compile with features
+3. Run `cargo test` - all tests must pass
+4. Run `cargo clippy --all-targets -- -D warnings` - no warnings allowed
+5. **Run `cargo fmt`** - apply formatting to prevent whitespace errors
+
+⚠️ **IMPORTANT**: Always run `cargo fmt` as the LAST step before committing to ensure consistent formatting.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,12 +636,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,16 +1032,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,16 +1151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,29 +1176,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1534,15 +1485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,12 +1651,6 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1911,7 +1847,6 @@ dependencies = [
  "sysinfo",
  "tracing",
  "tracing-subscriber",
- "workerpool",
 ]
 
 [[package]]
@@ -2540,16 +2475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "workerpool"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27acc04c753780224f8f6c565db754da04d687b93150c258a4ddb3c4682543d3"
-dependencies = [
- "num_cpus",
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ serde_json = "1.0.140"
 sysinfo = "0.33.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "time"] }
-workerpool = "1.2.1"
 
 [features]
 generate-vmlinux-header = []

--- a/src/events.rs
+++ b/src/events.rs
@@ -1587,7 +1587,7 @@ mod tests {
             ts: 1000,
             ..Default::default()
         };
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 1;
         event.ts = 2000;
         recorder.handle_event(event);
@@ -1768,10 +1768,10 @@ mod tests {
             ts: 1000,
             ..Default::default()
         };
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 1;
         event.ts = 2000;
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 2;
         event.ts = 3000;
         recorder.handle_event(event);
@@ -1867,19 +1867,19 @@ mod tests {
             ts: 1000,
             ..Default::default()
         };
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 1;
         event.ts = 2000;
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 2;
         event.ts = 3000;
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 0;
         event.ts = 4000;
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 1;
         event.ts = 5000;
-        recorder.handle_event(event.clone());
+        recorder.handle_event(event);
         event.cookie = 2;
         event.ts = 6000;
         recorder.handle_event(event);

--- a/src/perf_recorder.rs
+++ b/src/perf_recorder.rs
@@ -133,10 +133,7 @@ mod tests {
             packets[1].track_descriptor().counter.unit(),
             Unit::UNIT_COUNT
         );
-        assert_eq!(
-            packets[1].track_descriptor().counter.is_incremental(),
-            false
-        );
+        assert!(!packets[1].track_descriptor().counter.is_incremental());
         assert_eq!(
             packets[2].track_event().track_uuid(),
             packets[1].track_descriptor().uuid()

--- a/src/pystacks/stack_walker.rs
+++ b/src/pystacks/stack_walker.rs
@@ -151,7 +151,7 @@ impl StackWalkerRun {
         &self,
         frame_map: &mut HashMap<u64, Vec<LocalFrame>>,
         global_func_manager: &Arc<crate::stack_recorder::GlobalFunctionManager>,
-        id_counter: &mut Arc<AtomicUsize>,
+        id_counter: &Arc<AtomicUsize>,
         python_stack_markers: &mut Vec<u64>,
         stack: &[PyAddr],
     ) {
@@ -356,7 +356,7 @@ impl StackWalkerRun {
         &self,
         _frame_map: &mut HashMap<u64, Vec<LocalFrame>>,
         _global_func_manager: &Arc<crate::stack_recorder::GlobalFunctionManager>,
-        _id_counter: &mut Arc<AtomicUsize>,
+        _id_counter: &Arc<AtomicUsize>,
         _python_stack_markers: &mut Vec<u64>,
         _stack: &[PyAddr],
     ) {

--- a/src/pystacks/stack_walker.rs
+++ b/src/pystacks/stack_walker.rs
@@ -1,7 +1,6 @@
 use crate::stack_recorder::{LocalFrame, Stack};
 use crate::systing::types::stack_event;
 use libbpf_rs::Object;
-use perfetto_protos::profile_common::InternedString;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::AtomicUsize;
@@ -151,7 +150,7 @@ impl StackWalkerRun {
     pub fn pystacks_to_frames_mapping(
         &self,
         frame_map: &mut HashMap<u64, Vec<LocalFrame>>,
-        func_map: &mut HashMap<String, InternedString>,
+        global_func_manager: &Arc<crate::stack_recorder::GlobalFunctionManager>,
         id_counter: &mut Arc<AtomicUsize>,
         python_stack_markers: &mut Vec<u64>,
         stack: &[PyAddr],
@@ -169,7 +168,7 @@ impl StackWalkerRun {
 
             add_frame(
                 frame_map,
-                func_map,
+                global_func_manager,
                 id_counter,
                 frame.addr.symbol_id.into(),
                 0,
@@ -187,14 +186,10 @@ impl StackWalkerRun {
     pub fn user_stack_to_python_calls(
         &self,
         frame_map: &mut HashMap<u64, Vec<LocalFrame>>,
-        func_map: &mut HashMap<String, InternedString>,
+        global_func_manager: &Arc<crate::stack_recorder::GlobalFunctionManager>,
         python_calls: &mut Vec<u64>,
     ) {
-        let python_call_iids: Vec<_> = func_map
-            .iter()
-            .filter(|(key, value)| key.starts_with("_PyEval_EvalFrame") && value.iid.is_some())
-            .map(|(_, value)| value.iid.unwrap())
-            .collect();
+        let python_call_iids = global_func_manager.get_function_ids_matching("_PyEval_EvalFrame");
 
         for (key, values) in frame_map {
             for value in values {
@@ -360,7 +355,7 @@ impl StackWalkerRun {
     pub fn pystacks_to_frames_mapping(
         &self,
         _frame_map: &mut HashMap<u64, Vec<LocalFrame>>,
-        _func_map: &mut HashMap<String, InternedString>,
+        _global_func_manager: &Arc<crate::stack_recorder::GlobalFunctionManager>,
         _id_counter: &mut Arc<AtomicUsize>,
         _python_stack_markers: &mut Vec<u64>,
         _stack: &[PyAddr],
@@ -372,7 +367,7 @@ impl StackWalkerRun {
     pub fn user_stack_to_python_calls(
         &self,
         _frame_map: &mut HashMap<u64, Vec<LocalFrame>>,
-        _func_map: &mut HashMap<String, InternedString>,
+        _global_func_manager: &Arc<crate::stack_recorder::GlobalFunctionManager>,
         _python_calls: &mut Vec<u64>,
     ) {
         // Stub implementation when pystacks feature is disabled

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -381,8 +381,8 @@ mod tests {
     #[test]
     fn test_handle_event() {
         let mut recorder = SchedEventRecorder::default();
-        let prev_comm = CStr::from_bytes_with_nul(b"prev\0").unwrap();
-        let next_comm = CStr::from_bytes_with_nul(b"next\0").unwrap();
+        let prev_comm = c"prev";
+        let next_comm = c"next";
 
         let mut event = task_event {
             r#type: event_type::SCHED_SWITCH,
@@ -397,8 +397,8 @@ mod tests {
             },
             ..Default::default()
         };
-        copy_to_comm(&mut event.next.comm, &next_comm);
-        copy_to_comm(&mut event.prev.comm, &prev_comm);
+        copy_to_comm(&mut event.next.comm, next_comm);
+        copy_to_comm(&mut event.prev.comm, prev_comm);
         recorder.handle_event(event);
         assert_eq!(recorder.compact_sched.len(), 1);
         assert!(recorder.compact_sched.contains_key(&0));
@@ -406,8 +406,8 @@ mod tests {
         event.ts = 2000;
         event.next.tgidpid = 5678;
         event.prev.tgidpid = 1234;
-        copy_to_comm(&mut event.next.comm, &prev_comm);
-        copy_to_comm(&mut event.prev.comm, &next_comm);
+        copy_to_comm(&mut event.next.comm, prev_comm);
+        copy_to_comm(&mut event.prev.comm, next_comm);
         recorder.handle_event(event);
 
         assert_eq!(recorder.compact_sched.len(), 1);
@@ -438,7 +438,7 @@ mod tests {
     #[test]
     fn test_wakeup_new() {
         let mut recorder = SchedEventRecorder::default();
-        let next_comm = CStr::from_bytes_with_nul(b"next\0").unwrap();
+        let next_comm = c"next";
 
         let mut event = task_event {
             r#type: event_type::SCHED_WAKEUP_NEW,
@@ -451,7 +451,7 @@ mod tests {
             next_prio: 10,
             ..Default::default()
         };
-        copy_to_comm(&mut event.next.comm, &next_comm);
+        copy_to_comm(&mut event.next.comm, next_comm);
         recorder.handle_event(event);
 
         assert_eq!(recorder.compact_sched.len(), 0);
@@ -478,7 +478,7 @@ mod tests {
     #[test]
     fn test_irq_handler_events() {
         let mut recorder = SchedEventRecorder::default();
-        let next_comm = CStr::from_bytes_with_nul(b"irq_handler\0").unwrap();
+        let next_comm = c"irq_handler";
 
         let mut event = task_event {
             r#type: event_type::SCHED_IRQ_ENTER,
@@ -491,7 +491,7 @@ mod tests {
             },
             ..Default::default()
         };
-        copy_to_comm(&mut event.next.comm, &next_comm);
+        copy_to_comm(&mut event.next.comm, next_comm);
         recorder.handle_event(event);
 
         assert_eq!(recorder.compact_sched.len(), 0);
@@ -518,7 +518,7 @@ mod tests {
     #[test]
     fn test_irq_exit_handler_events() {
         let mut recorder = SchedEventRecorder::default();
-        let next_comm = CStr::from_bytes_with_nul(b"irq_handler\0").unwrap();
+        let next_comm = c"irq_handler";
 
         let mut event = task_event {
             r#type: event_type::SCHED_IRQ_EXIT,
@@ -531,7 +531,7 @@ mod tests {
             },
             ..Default::default()
         };
-        copy_to_comm(&mut event.next.comm, &next_comm);
+        copy_to_comm(&mut event.next.comm, next_comm);
         recorder.handle_event(event);
 
         assert_eq!(recorder.compact_sched.len(), 0);
@@ -619,7 +619,7 @@ mod tests {
     #[test]
     fn test_process_exit_event() {
         let mut recorder = SchedEventRecorder::default();
-        let prev_comm = CStr::from_bytes_with_nul(b"prev\0").unwrap();
+        let prev_comm = c"prev";
 
         let mut event = task_event {
             r#type: event_type::SCHED_PROCESS_EXIT,
@@ -631,7 +631,7 @@ mod tests {
             prev_prio: 10,
             ..Default::default()
         };
-        copy_to_comm(&mut event.prev.comm, &prev_comm);
+        copy_to_comm(&mut event.prev.comm, prev_comm);
         recorder.handle_event(event);
 
         assert_eq!(recorder.compact_sched.len(), 0);

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -396,7 +396,7 @@ impl crate::SystingEvent for SysInfoEvent {
 mod tests {
     use super::*;
     use std::sync::{Mutex, RwLock};
-    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+    use sysinfo::System;
 
     fn create_test_task_info(tgid: u32, pid: u32, comm: &str) -> task_info {
         let mut task = task_info {

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -856,7 +856,7 @@ mod tests {
             generate_trace_packets(&stacks, &interned_stacks, &resolved_info, &mut id_counter);
 
         // Should still have at least one packet with interned data
-        assert!(packets.len() >= 1);
+        assert!(!packets.is_empty());
 
         // First packet should be interned data
         assert!(packets[0].interned_data.is_some());

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -36,23 +36,17 @@ pub struct Stack {
     pub py_stack: Vec<PyAddr>,
 }
 
+/// Helper function to filter and reverse a stack trace
+/// Removes zero addresses and reverses the order
+fn filter_and_reverse_stack(stack: &[u64]) -> Vec<u64> {
+    stack.iter().rev().filter(|x| **x > 0).copied().collect()
+}
+
 impl Stack {
     pub fn new(kernel_stack: &[u64], user_stack: &[u64], py_stack: &[PyAddr]) -> Self {
-        let my_kernel_stack = kernel_stack
-            .iter()
-            .rev()
-            .filter(|x| **x > 0)
-            .copied()
-            .collect();
-        let my_user_stack = user_stack
-            .iter()
-            .rev()
-            .filter(|x| **x > 0)
-            .copied()
-            .collect();
         Stack {
-            kernel_stack: my_kernel_stack,
-            user_stack: my_user_stack,
+            kernel_stack: filter_and_reverse_stack(kernel_stack),
+            user_stack: filter_and_reverse_stack(user_stack),
             py_stack: py_stack.to_vec(),
         }
     }

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -81,7 +81,10 @@ impl GlobalFunctionManager {
 
     /// Get or create a function IID for the given name
     pub fn get_or_create_function(&self, name: &str) -> u64 {
-        let mut functions = self.global_functions.write().unwrap();
+        let mut functions = self
+            .global_functions
+            .write()
+            .expect("Failed to acquire write lock on global_functions");
         if let Some(interned) = functions.get(name) {
             return interned.iid();
         }
@@ -543,7 +546,12 @@ fn generate_sample_packets(
         packet.set_timestamp(stack.ts_start);
 
         let mut sample = PerfSample::default();
-        sample.set_callstack_iid(callstack_map.get(&stack.stack).unwrap().iid());
+        sample.set_callstack_iid(
+            callstack_map
+                .get(&stack.stack)
+                .expect("Stack should exist in callstack_map after deduplication")
+                .iid(),
+        );
         sample.set_pid(tgid);
         sample.set_tid(pid);
         packet.set_perf_sample(sample);


### PR DESCRIPTION
## Summary
- Refactored stack recording to intern all strings (function names, file paths, DSO paths) to reduce memory usage and improve performance
- Added comprehensive interning infrastructure with thread-safe string storage
- Updated Python stack walker to use interned strings consistently

## Test plan
- [ ] Run `cargo build` - verify compilation
- [ ] Run `cargo build --features pystacks` - verify compilation with features
- [ ] Run `cargo test` - verify all tests pass
- [ ] Run `cargo clippy --all-targets -- -D warnings` - verify no warnings
- [ ] Run `cargo fmt` - verify formatting

🤖 Generated with [Claude Code](https://claude.ai/code)