### PR TITLE
Reduce memory overhead for long/busy traces

### DIFF
--- a/src/network_recorder.rs
+++ b/src/network_recorder.rs
@@ -122,7 +122,7 @@ fn protocol_str(protocol: u32) -> &'static str {
 
 /// Convert TCP state code to human-readable string.
 /// Based on enum tcp_state from include/uapi/linux/tcp.h.
-fn tcp_state_name(state: u8) -> &'static str {
+pub(crate) fn tcp_state_name(state: u8) -> &'static str {
     match state {
         1 => "ESTABLISHED",
         2 => "SYN_SENT",
@@ -142,7 +142,7 @@ fn tcp_state_name(state: u8) -> &'static str {
 
 /// Convert SKB_DROP_REASON_* code to human-readable string
 /// Based on enum skb_drop_reason from include/net/dropreason-core.h
-fn drop_reason_str(reason: u32) -> &'static str {
+pub(crate) fn drop_reason_str(reason: u32) -> &'static str {
     match reason {
         0 => "NOT_DROPPED_YET",
         1 => "CONSUMED",
@@ -261,6 +261,36 @@ fn drop_reason_str(reason: u32) -> &'static str {
         114 => "BRIDGE_INGRESS_STP_STATE",
         _ => "UNKNOWN",
     }
+}
+
+pub(crate) fn format_tcp_flags(flags: u8) -> String {
+    if flags == 0 {
+        return "NONE".to_string();
+    }
+
+    let mut result = String::with_capacity(32);
+    let mut first = true;
+
+    for (mask, name) in [
+        (0x01, "FIN"),
+        (0x02, "SYN"),
+        (0x04, "RST"),
+        (0x08, "PSH"),
+        (0x10, "ACK"),
+        (0x20, "URG"),
+        (0x40, "ECE"),
+        (0x80, "CWR"),
+    ] {
+        if flags & mask != 0 {
+            if !first {
+                result.push('|');
+            }
+            result.push_str(name);
+            first = false;
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -663,14 +693,6 @@ impl NetworkRecorder {
         Ok(true)
     }
 
-    /// Helper to format TCP flags for packet records. Returns None if no flags set.
-    fn format_tcp_flags_str(flags: u8) -> Option<String> {
-        if flags == 0 {
-            return None;
-        }
-        Some(Self::format_tcp_flags(flags))
-    }
-
     /// Helper function to convert kernel jiffies to microseconds for streaming.
     fn jiffies_to_us(jiffies: u64) -> i64 {
         ((jiffies as u128 * 1_000_000) / system_hz() as u128) as i64
@@ -777,7 +799,7 @@ impl NetworkRecorder {
     fn stream_packet_event(
         &mut self,
         event: &crate::systing_core::types::packet_event,
-        event_name: &str,
+        event_name: &'static str,
     ) -> Result<()> {
         let socket_id = event.socket_id;
         let ts = event.ts as i64;
@@ -809,14 +831,18 @@ impl NetworkRecorder {
             id,
             ts,
             socket_id: socket_id as i64,
-            event_type: event_name.to_string(),
+            event_type: event_name,
             seq: if event.seq > 0 {
                 Some(event.seq as i64)
             } else {
                 None
             },
             length: event.length as i32,
-            tcp_flags: Self::format_tcp_flags_str(event.tcp_flags),
+            tcp_flags: if event.tcp_flags != 0 {
+                Some(event.tcp_flags)
+            } else {
+                None
+            },
             sndbuf_used: None,
             sndbuf_limit: None,
             sndbuf_fill_pct: None,
@@ -900,11 +926,6 @@ impl NetworkRecorder {
             } else {
                 None
             },
-            drop_reason_str: if event.drop_reason > 0 {
-                Some(drop_reason_str(event.drop_reason).to_string())
-            } else {
-                None
-            },
             drop_location: if event.drop_location > 0 {
                 Some(event.drop_location as i64)
             } else {
@@ -961,18 +982,8 @@ impl NetworkRecorder {
             } else {
                 None
             },
-            old_state_str: if event.old_state > 0 {
-                Some(tcp_state_name(event.old_state).to_string())
-            } else {
-                None
-            },
             new_state: if event.new_state > 0 {
                 Some(event.new_state as i16)
-            } else {
-                None
-            },
-            new_state_str: if event.new_state > 0 {
-                Some(tcp_state_name(event.new_state).to_string())
             } else {
                 None
             },
@@ -1078,36 +1089,6 @@ impl NetworkRecorder {
         if count > 0 {
             tracing::info!("Loaded {} socket metadata entries from BPF map", count);
         }
-    }
-
-    fn format_tcp_flags(flags: u8) -> String {
-        if flags == 0 {
-            return "NONE".to_string();
-        }
-
-        let mut result = String::with_capacity(32);
-        let mut first = true;
-
-        for (mask, name) in [
-            (0x01, "FIN"),
-            (0x02, "SYN"),
-            (0x04, "RST"),
-            (0x08, "PSH"),
-            (0x10, "ACK"),
-            (0x20, "URG"),
-            (0x40, "ECE"),
-            (0x80, "CWR"),
-        ] {
-            if flags & mask != 0 {
-                if !first {
-                    result.push('|');
-                }
-                result.push_str(name);
-                first = false;
-            }
-        }
-
-        result
     }
 
     fn poll_events_to_str(events: u32) -> String {
@@ -1366,7 +1347,7 @@ impl NetworkRecorder {
         event.add_uint_nonzero("seq", pkt.seq as u64);
         event.add_uint("length", pkt.length as u64);
         if pkt.tcp_flags != 0 {
-            event.add_string("flags", Self::format_tcp_flags(pkt.tcp_flags));
+            event.add_string("flags", format_tcp_flags(pkt.tcp_flags));
         }
     }
 
@@ -1514,7 +1495,7 @@ impl NetworkRecorder {
                 instant_id,
                 key: "flags".to_string(),
                 int_value: None,
-                string_value: Some(Self::format_tcp_flags(pkt.tcp_flags)),
+                string_value: Some(format_tcp_flags(pkt.tcp_flags)),
                 real_value: None,
             })?;
         }

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -22,6 +22,7 @@ use parquet::arrow::ArrowWriter;
 use parquet::basic::Compression;
 use parquet::file::properties::WriterProperties;
 
+use crate::network_recorder::{drop_reason_str, format_tcp_flags, tcp_state_name};
 use crate::parquet::ParquetPaths;
 use crate::record::RecordCollector;
 use crate::trace::{
@@ -1961,10 +1962,13 @@ fn build_network_packet_batch(
         id_builder.append_value(record.id);
         ts_builder.append_value(record.ts);
         socket_id_builder.append_value(record.socket_id);
-        event_type_builder.append_value(&record.event_type);
+        event_type_builder.append_value(record.event_type);
         seq_builder.append_option(record.seq);
         length_builder.append_value(record.length);
-        tcp_flags_builder.append_option(record.tcp_flags.as_deref());
+        match record.tcp_flags {
+            Some(flags) => tcp_flags_builder.append_value(format_tcp_flags(flags)),
+            None => tcp_flags_builder.append_null(),
+        }
         sndbuf_used_builder.append_option(record.sndbuf_used);
         sndbuf_limit_builder.append_option(record.sndbuf_limit);
         sndbuf_fill_pct_builder.append_option(record.sndbuf_fill_pct);
@@ -1986,7 +1990,8 @@ fn build_network_packet_batch(
         icsk_pending_builder.append_option(record.icsk_pending);
         icsk_timeout_builder.append_option(record.icsk_timeout);
         drop_reason_builder.append_option(record.drop_reason);
-        drop_reason_str_builder.append_option(record.drop_reason_str.as_deref());
+        drop_reason_str_builder
+            .append_option(record.drop_reason.map(|r| drop_reason_str(r as u32)));
         drop_location_builder.append_option(record.drop_location);
         qlen_builder.append_option(record.qlen);
         qlen_limit_builder.append_option(record.qlen_limit);
@@ -1998,9 +2003,9 @@ fn build_network_packet_batch(
         skb_addr_builder.append_option(record.skb_addr);
         qdisc_latency_us_builder.append_option(record.qdisc_latency_us);
         old_state_builder.append_option(record.old_state);
-        old_state_str_builder.append_option(record.old_state_str.as_deref());
+        old_state_str_builder.append_option(record.old_state.map(|s| tcp_state_name(s as u8)));
         new_state_builder.append_option(record.new_state);
-        new_state_str_builder.append_option(record.new_state_str.as_deref());
+        new_state_str_builder.append_option(record.new_state.map(|s| tcp_state_name(s as u8)));
     }
 
     Ok(RecordBatch::try_new(

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -1,10 +1,9 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::ffi::CStr;
 use std::sync::Arc;
 
 use anyhow::Result;
 
-use crate::perfetto::TraceWriter;
 use crate::record::RecordCollector;
 use crate::ringbuf::RingBuffer;
 use crate::systing_core::types::event_type;
@@ -15,16 +14,6 @@ use crate::trace::{
     WakeupNewRecord,
 };
 use crate::utid::UtidGenerator;
-
-use perfetto_protos::ftrace_event::FtraceEvent;
-use perfetto_protos::ftrace_event_bundle::ftrace_event_bundle::CompactSched;
-use perfetto_protos::ftrace_event_bundle::FtraceEventBundle;
-use perfetto_protos::irq::{
-    IrqHandlerEntryFtraceEvent, IrqHandlerExitFtraceEvent, SoftirqEntryFtraceEvent,
-    SoftirqExitFtraceEvent,
-};
-use perfetto_protos::sched::{SchedProcessExitFtraceEvent, SchedWakeupNewFtraceEvent};
-use perfetto_protos::trace_packet::TracePacket;
 
 /// Threshold for flushing streaming sched slices to the collector.
 /// Lower than Parquet batch size (200K) to reduce peak memory while maintaining I/O efficiency.
@@ -48,14 +37,6 @@ struct CpuRunningState {
     start_ts: i64,
     tid: i32,
     prio: i32,
-}
-
-#[derive(Default)]
-struct LocalCompactSched {
-    compact_sched: CompactSched,
-    comm_mapping: HashMap<String, u32>,
-    last_waking_ts: u64,
-    last_switch_ts: u64,
 }
 
 /// Pending IRQ entry waiting for matching exit.
@@ -115,8 +96,6 @@ struct ProcessExitEvent {
 
 pub struct SchedEventRecorder {
     pub ringbuf: RingBuffer<task_event>,
-    events: HashMap<u32, BTreeMap<u64, FtraceEvent>>,
-    compact_sched: HashMap<u32, LocalCompactSched>,
     // Pending IRQ/softirq events keyed by (cpu, irq/vec).
     // IRQs and softirqs cannot nest on the same CPU with the same IRQ number or
     // softirq vector, so (cpu, irq/vec) uniquely identifies a pending entry.
@@ -231,15 +210,6 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                         }
                     }
                 }
-
-                // Only accumulate in compact_sched for the non-streaming path.
-                // In streaming mode, sched slices are emitted directly above and
-                // Perfetto output is generated from Parquet files, so retaining
-                // every event here is pure memory overhead on busy systems.
-                if self.streaming_collector.is_none() {
-                    let compact_sched = self.compact_sched.entry(event.cpu).or_default();
-                    compact_sched.add_task_event(&event);
-                }
             }
 
             // IRQ handler entry - track for pairing with exit
@@ -256,7 +226,6 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                         name,
                     },
                 );
-                self.add_ftrace_event(&event);
             }
 
             // IRQ handler exit - pair with entry to create slice
@@ -290,7 +259,6 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                         });
                     }
                 }
-                self.add_ftrace_event(&event);
             }
 
             // Softirq entry - track for pairing with exit
@@ -298,7 +266,6 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                 let vec = event.target_cpu as i32;
                 self.pending_softirqs
                     .insert((event.cpu, vec), PendingSoftirq { ts: event.ts, vec });
-                self.add_ftrace_event(&event);
             }
 
             // Softirq exit - pair with entry to create slice
@@ -327,7 +294,6 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                         });
                     }
                 }
-                self.add_ftrace_event(&event);
             }
 
             // New process wakeup - the `next` field contains the newly woken process info
@@ -356,7 +322,6 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                         target_cpu: event.target_cpu as i32,
                     });
                 }
-                self.add_ftrace_event(&event);
             }
 
             // Process exit - the `prev` field contains the exiting process info
@@ -383,16 +348,12 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                         pid: tid,
                     });
                 }
-                self.add_ftrace_event(&event);
             }
 
             // Skip SCHED_WAKEUP (redundant with SCHED_WAKING)
             event_type::SCHED_WAKEUP => {}
 
-            // Other events go directly to ftrace
-            _ => {
-                self.add_ftrace_event(&event);
-            }
+            _ => {}
         }
     }
 }
@@ -402,8 +363,6 @@ impl SchedEventRecorder {
     pub fn new(utid_generator: Arc<UtidGenerator>) -> Self {
         Self {
             ringbuf: RingBuffer::default(),
-            events: HashMap::new(),
-            compact_sched: HashMap::new(),
             pending_irqs: HashMap::new(),
             pending_softirqs: HashMap::new(),
             completed_irqs: Vec::new(),
@@ -422,71 +381,10 @@ impl SchedEventRecorder {
         self.streaming_collector = Some(collector);
     }
 
-    /// Add an event to the ftrace events map for Perfetto output.
-    ///
-    /// Skipped entirely in streaming mode: the ftrace event map is only read by
-    /// write_trace()/write_records() on the non-streaming path, and accumulating
-    /// every IRQ/softirq/wakeup event for the whole trace is a major memory cost.
-    fn add_ftrace_event(&mut self, event: &task_event) {
-        if self.streaming_collector.is_some() {
-            return;
-        }
-        let ftrace_event = FtraceEvent::from(event);
-        let cpu_event = self.events.entry(event.cpu).or_default();
-        cpu_event.insert(event.ts, ftrace_event);
-    }
-
     /// Write trace data directly to a RecordCollector (Parquet-first path).
     ///
     /// This method outputs records directly without going through Perfetto format.
-    /// It converts the delta-encoded CompactSched data back to absolute timestamps.
     pub fn write_records(&self, collector: &mut dyn RecordCollector) -> Result<()> {
-        // Process compact sched events (SCHED_SWITCH, SCHED_WAKING)
-        for (cpu, local_compact) in self.compact_sched.iter() {
-            let compact = &local_compact.compact_sched;
-
-            // Decode switch events to SchedSliceRecord
-            let mut switch_ts: i64 = 0;
-            for i in 0..compact.switch_timestamp.len() {
-                switch_ts += compact.switch_timestamp[i] as i64;
-                let next_pid = compact.switch_next_pid[i];
-                let next_prio = compact.switch_next_prio.get(i).copied().unwrap_or(0);
-                let prev_state = compact.switch_prev_state.get(i).copied().unwrap_or(0);
-
-                // Get or create utid for this thread
-                let utid = self.utid_generator.get_or_create_utid(next_pid);
-
-                let end_state = prev_state_to_end_state(prev_state);
-
-                collector.add_sched_slice(SchedSliceRecord {
-                    ts: switch_ts,
-                    dur: 0, // Duration computed later or left as 0 for streaming
-                    cpu: *cpu as i32,
-                    utid,
-                    end_state,
-                    priority: next_prio,
-                })?;
-            }
-
-            // Decode waking events to ThreadStateRecord
-            let mut waking_ts: i64 = 0;
-            for i in 0..compact.waking_timestamp.len() {
-                waking_ts += compact.waking_timestamp[i] as i64;
-                let pid = compact.waking_pid[i];
-                let target_cpu = compact.waking_target_cpu.get(i).copied().unwrap_or(0);
-
-                let utid = self.utid_generator.get_or_create_utid(pid);
-
-                collector.add_thread_state(ThreadStateRecord {
-                    ts: waking_ts,
-                    dur: 0,
-                    utid,
-                    state: 0, // TASK_RUNNING (runnable)
-                    cpu: Some(target_cpu),
-                })?;
-            }
-        }
-
         // Emit completed IRQ slices
         for irq in &self.completed_irqs {
             collector.add_irq_slice(IrqSliceRecord {
@@ -626,194 +524,14 @@ impl SchedEventRecorder {
         // Take ownership of the collector and return it
         Ok(self.streaming_collector.take())
     }
-
-    /// Write trace data to Perfetto format (used by parquet-to-perfetto conversion).
-    pub fn write_trace(&self, writer: &mut dyn TraceWriter) -> Result<()> {
-        // Pull all the compact scheduling events
-        for (cpu, compact_sched) in self.compact_sched.iter() {
-            let mut event_bundle = FtraceEventBundle::default();
-            event_bundle.set_cpu(*cpu);
-            event_bundle.compact_sched = Some(compact_sched.compact_sched.clone()).into();
-            let mut packet = TracePacket::default();
-            packet.set_ftrace_events(event_bundle);
-            writer.write_packet(&packet)?;
-        }
-
-        // Pull all the scheduling events.
-        for (cpu, events) in self.events.iter() {
-            let mut event_bundle = FtraceEventBundle::default();
-            event_bundle.set_cpu(*cpu);
-            event_bundle.event = events.values().cloned().collect();
-            let mut packet = TracePacket::default();
-            packet.set_ftrace_events(event_bundle);
-            writer.write_packet(&packet)?;
-        }
-
-        Ok(())
-    }
-
-    /// Returns the minimum timestamp from all events, or None if no events recorded.
-    pub fn min_timestamp(&self) -> Option<u64> {
-        let compact_min = self
-            .compact_sched
-            .values()
-            .filter_map(|cs| cs.compact_sched.switch_timestamp.first().copied())
-            .min();
-
-        // BTreeMap is sorted by key, so first key is min
-        let events_min = self
-            .events
-            .values()
-            .filter_map(|e| e.keys().next().copied())
-            .min();
-
-        [compact_min, events_min].into_iter().flatten().min()
-    }
-}
-
-impl From<&task_event> for FtraceEvent {
-    fn from(event: &task_event) -> Self {
-        let mut ftrace_event = FtraceEvent::default();
-        ftrace_event.set_pid(event.prev.tgidpid as u32);
-        ftrace_event.set_timestamp(event.ts);
-        match event.r#type {
-            event_type::SCHED_WAKEUP_NEW => {
-                ftrace_event.set_sched_wakeup_new(SchedWakeupNewFtraceEvent::from(event));
-            }
-            event_type::SCHED_IRQ_EXIT => {
-                ftrace_event.set_irq_handler_exit(IrqHandlerExitFtraceEvent::from(event));
-            }
-            event_type::SCHED_IRQ_ENTER => {
-                ftrace_event.set_irq_handler_entry(IrqHandlerEntryFtraceEvent::from(event));
-            }
-            event_type::SCHED_SOFTIRQ_EXIT => {
-                ftrace_event.set_softirq_exit(SoftirqExitFtraceEvent::from(event));
-            }
-            event_type::SCHED_SOFTIRQ_ENTER => {
-                ftrace_event.set_softirq_entry(SoftirqEntryFtraceEvent::from(event));
-            }
-            event_type::SCHED_PROCESS_EXIT => {
-                ftrace_event.set_sched_process_exit(SchedProcessExitFtraceEvent::from(event));
-            }
-            _ => {}
-        }
-        ftrace_event
-    }
-}
-
-impl From<&task_event> for SchedWakeupNewFtraceEvent {
-    fn from(event: &task_event) -> Self {
-        let comm_cstr = CStr::from_bytes_until_nul(&event.next.comm).unwrap();
-        let mut sched_wakeup_new = SchedWakeupNewFtraceEvent::default();
-        sched_wakeup_new.set_pid(event.next.tgidpid as i32);
-        sched_wakeup_new.set_comm(comm_cstr.to_str().unwrap().to_string());
-        sched_wakeup_new.set_prio(event.next_prio as i32);
-        sched_wakeup_new.set_target_cpu(event.target_cpu as i32);
-        sched_wakeup_new
-    }
-}
-
-impl From<&task_event> for IrqHandlerExitFtraceEvent {
-    fn from(event: &task_event) -> Self {
-        let mut irq_handler_exit = IrqHandlerExitFtraceEvent::default();
-        irq_handler_exit.set_irq(event.target_cpu as i32);
-        irq_handler_exit.set_ret(event.next_prio as i32);
-        irq_handler_exit
-    }
-}
-
-impl From<&task_event> for IrqHandlerEntryFtraceEvent {
-    fn from(event: &task_event) -> Self {
-        let mut irq_handler_entry = IrqHandlerEntryFtraceEvent::default();
-        let name_cstr = CStr::from_bytes_until_nul(&event.next.comm).unwrap();
-        irq_handler_entry.set_name(name_cstr.to_str().unwrap().to_string());
-        irq_handler_entry.set_irq(event.target_cpu as i32);
-        irq_handler_entry
-    }
-}
-
-impl From<&task_event> for SoftirqExitFtraceEvent {
-    fn from(event: &task_event) -> Self {
-        let mut softirq_exit = SoftirqExitFtraceEvent::default();
-        softirq_exit.set_vec(event.target_cpu);
-        softirq_exit
-    }
-}
-
-impl From<&task_event> for SoftirqEntryFtraceEvent {
-    fn from(event: &task_event) -> Self {
-        let mut softirq_entry = SoftirqEntryFtraceEvent::default();
-        softirq_entry.set_vec(event.target_cpu);
-        softirq_entry
-    }
-}
-
-impl From<&task_event> for SchedProcessExitFtraceEvent {
-    fn from(event: &task_event) -> Self {
-        let pid = event.prev.tgidpid as i32;
-        let tgid = (event.prev.tgidpid >> 32) as i32;
-        let name_cstr = CStr::from_bytes_until_nul(&event.prev.comm).unwrap();
-        let mut sched_process_exit = SchedProcessExitFtraceEvent::default();
-        sched_process_exit.set_pid(pid);
-        sched_process_exit.set_tgid(tgid);
-        sched_process_exit.set_prio(event.prev_prio as i32);
-        sched_process_exit.set_comm(name_cstr.to_str().unwrap().to_string());
-        sched_process_exit
-    }
-}
-
-impl LocalCompactSched {
-    fn add_task_event(&mut self, event: &task_event) {
-        let comm = CStr::from_bytes_until_nul(&event.next.comm)
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string();
-        let index = self.comm_mapping.entry(comm.clone()).or_insert_with(|| {
-            self.compact_sched.intern_table.push(comm);
-            (self.compact_sched.intern_table.len() as u32) - 1
-        });
-        if event.r#type == event_type::SCHED_WAKING {
-            self.compact_sched
-                .waking_timestamp
-                .push(event.ts - self.last_waking_ts);
-            self.last_waking_ts = event.ts;
-            self.compact_sched
-                .waking_pid
-                .push(event.next.tgidpid as i32);
-            self.compact_sched
-                .waking_target_cpu
-                .push(event.target_cpu as i32);
-            self.compact_sched.waking_prio.push(event.next_prio as i32);
-            self.compact_sched.waking_comm_index.push(*index);
-            self.compact_sched.waking_common_flags.push(1);
-        } else {
-            self.compact_sched
-                .switch_timestamp
-                .push(event.ts - self.last_switch_ts);
-            self.last_switch_ts = event.ts;
-            self.compact_sched
-                .switch_prev_state
-                .push(event.prev_state as i64);
-            self.compact_sched
-                .switch_next_pid
-                .push(event.next.tgidpid as i32);
-            self.compact_sched
-                .switch_next_prio
-                .push(event.next_prio as i32);
-            self.compact_sched.switch_next_comm_index.push(*index);
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::perfetto::VecTraceWriter;
     use crate::systing_core::types::event_type;
     use crate::systing_core::types::task_info;
     use crate::utid::UtidGenerator;
-    use perfetto_protos::trace_packet::TracePacket;
 
     fn copy_to_comm(comm: &mut [u8], value: &CStr) {
         let bytes = value.to_bytes_with_nul();
@@ -822,251 +540,6 @@ mod tests {
 
     fn create_test_recorder() -> SchedEventRecorder {
         SchedEventRecorder::new(Arc::new(UtidGenerator::new()))
-    }
-
-    /// Helper to collect packets from SchedEventRecorder for tests
-    fn generate_trace(recorder: &SchedEventRecorder) -> Vec<TracePacket> {
-        let mut writer = VecTraceWriter::new();
-        recorder.write_trace(&mut writer).unwrap();
-        writer.packets
-    }
-
-    #[test]
-    fn test_handle_event() {
-        let mut recorder = create_test_recorder();
-        let prev_comm = c"prev";
-        let next_comm = c"next";
-
-        let mut event = task_event {
-            r#type: event_type::SCHED_SWITCH,
-            ts: 1000,
-            next: task_info {
-                tgidpid: 1234,
-                ..Default::default()
-            },
-            prev: task_info {
-                tgidpid: 5678,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        copy_to_comm(&mut event.next.comm, next_comm);
-        copy_to_comm(&mut event.prev.comm, prev_comm);
-        recorder.handle_event(event);
-        assert_eq!(recorder.compact_sched.len(), 1);
-        assert!(recorder.compact_sched.contains_key(&0));
-
-        event.ts = 2000;
-        event.next.tgidpid = 5678;
-        event.prev.tgidpid = 1234;
-        copy_to_comm(&mut event.next.comm, prev_comm);
-        copy_to_comm(&mut event.prev.comm, next_comm);
-        recorder.handle_event(event);
-
-        assert_eq!(recorder.compact_sched.len(), 1);
-
-        let packets = generate_trace(&recorder);
-        assert_eq!(packets.len(), 1);
-
-        let packet = &packets[0];
-        assert!(packet.has_ftrace_events());
-        let compact = packet.ftrace_events().compact_sched.as_ref().unwrap();
-        assert_eq!(compact.switch_timestamp.len(), 2);
-        assert_eq!(compact.switch_timestamp[0], 1000);
-        assert_eq!(compact.switch_timestamp[1], 1000);
-        assert_eq!(compact.intern_table.len(), 2);
-        assert_eq!(compact.intern_table[0], "next");
-        assert_eq!(compact.intern_table[1], "prev");
-        assert_eq!(compact.switch_next_comm_index[0], 0);
-        assert_eq!(compact.switch_next_comm_index[1], 1);
-    }
-
-    #[test]
-    fn test_wakeup_new() {
-        let mut recorder = create_test_recorder();
-        let next_comm = c"next";
-
-        let mut event = task_event {
-            r#type: event_type::SCHED_WAKEUP_NEW,
-            ts: 1000,
-            next: task_info {
-                tgidpid: 1234,
-                ..Default::default()
-            },
-            target_cpu: 0,
-            next_prio: 10,
-            ..Default::default()
-        };
-        copy_to_comm(&mut event.next.comm, next_comm);
-        recorder.handle_event(event);
-
-        assert_eq!(recorder.compact_sched.len(), 0);
-        assert_eq!(recorder.events.len(), 1);
-        assert!(recorder.events.contains_key(&0));
-
-        let packets = generate_trace(&recorder);
-        assert_eq!(packets.len(), 1);
-
-        let packet = &packets[0];
-        assert!(packet.has_ftrace_events());
-        let events = &packet.ftrace_events().event;
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].sched_wakeup_new().comm(), "next");
-        assert_eq!(events[0].sched_wakeup_new().pid(), 1234);
-    }
-
-    #[test]
-    fn test_irq_handler_events() {
-        let mut recorder = create_test_recorder();
-        let next_comm = c"irq_handler";
-
-        let mut event = task_event {
-            r#type: event_type::SCHED_IRQ_ENTER,
-            ts: 1000,
-            target_cpu: 0,
-            next_prio: 5,
-            next: task_info {
-                tgidpid: 1234,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        copy_to_comm(&mut event.next.comm, next_comm);
-        recorder.handle_event(event);
-
-        assert_eq!(recorder.compact_sched.len(), 0);
-        assert_eq!(recorder.events.len(), 1);
-        assert!(recorder.events.contains_key(&0));
-
-        let packets = generate_trace(&recorder);
-        assert_eq!(packets.len(), 1);
-
-        let packet = &packets[0];
-        assert!(packet.has_ftrace_events());
-        let events = &packet.ftrace_events().event;
-        assert_eq!(events.len(), 1);
-        assert!(events[0].has_irq_handler_entry());
-        assert_eq!(events[0].irq_handler_entry().name(), "irq_handler");
-    }
-
-    #[test]
-    fn test_irq_exit_handler_events() {
-        let mut recorder = create_test_recorder();
-        let next_comm = c"irq_handler";
-
-        let mut event = task_event {
-            r#type: event_type::SCHED_IRQ_EXIT,
-            ts: 1000,
-            target_cpu: 0,
-            next_prio: 5,
-            next: task_info {
-                tgidpid: 1234,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        copy_to_comm(&mut event.next.comm, next_comm);
-        recorder.handle_event(event);
-
-        assert_eq!(recorder.compact_sched.len(), 0);
-        assert_eq!(recorder.events.len(), 1);
-        assert!(recorder.events.contains_key(&0));
-
-        let packets = generate_trace(&recorder);
-        assert_eq!(packets.len(), 1);
-
-        let packet = &packets[0];
-        assert!(packet.has_ftrace_events());
-        let events = &packet.ftrace_events().event;
-        assert_eq!(events.len(), 1);
-        assert!(events[0].has_irq_handler_exit());
-    }
-
-    #[test]
-    fn test_softirq_events() {
-        let mut recorder = create_test_recorder();
-
-        let event = task_event {
-            r#type: event_type::SCHED_SOFTIRQ_ENTER,
-            ts: 1000,
-            target_cpu: 0,
-            next_prio: 5,
-            ..Default::default()
-        };
-        recorder.handle_event(event);
-
-        assert_eq!(recorder.compact_sched.len(), 0);
-        assert_eq!(recorder.events.len(), 1);
-        assert!(recorder.events.contains_key(&0));
-
-        let packets = generate_trace(&recorder);
-        assert_eq!(packets.len(), 1);
-
-        let packet = &packets[0];
-        assert!(packet.has_ftrace_events());
-        let events = &packet.ftrace_events().event;
-        assert_eq!(events.len(), 1);
-        assert!(events[0].has_softirq_entry());
-    }
-
-    #[test]
-    fn test_softirq_exit_events() {
-        let mut recorder = create_test_recorder();
-
-        let event = task_event {
-            r#type: event_type::SCHED_SOFTIRQ_EXIT,
-            ts: 1000,
-            target_cpu: 0,
-            next_prio: 5,
-            ..Default::default()
-        };
-        recorder.handle_event(event);
-
-        assert_eq!(recorder.compact_sched.len(), 0);
-        assert_eq!(recorder.events.len(), 1);
-        assert!(recorder.events.contains_key(&0));
-
-        let packets = generate_trace(&recorder);
-        assert_eq!(packets.len(), 1);
-
-        let packet = &packets[0];
-        assert!(packet.has_ftrace_events());
-        let events = &packet.ftrace_events().event;
-        assert_eq!(events.len(), 1);
-        assert!(events[0].has_softirq_exit());
-    }
-
-    #[test]
-    fn test_process_exit_event() {
-        let mut recorder = create_test_recorder();
-        let prev_comm = c"prev";
-
-        let mut event = task_event {
-            r#type: event_type::SCHED_PROCESS_EXIT,
-            ts: 1000,
-            prev: task_info {
-                tgidpid: 1234,
-                ..Default::default()
-            },
-            prev_prio: 10,
-            ..Default::default()
-        };
-        copy_to_comm(&mut event.prev.comm, prev_comm);
-        recorder.handle_event(event);
-
-        assert_eq!(recorder.compact_sched.len(), 0);
-        assert_eq!(recorder.events.len(), 1);
-        assert!(recorder.events.contains_key(&0));
-
-        let packets = generate_trace(&recorder);
-        assert_eq!(packets.len(), 1);
-
-        let packet = &packets[0];
-        assert!(packet.has_ftrace_events());
-        let events = &packet.ftrace_events().event;
-        assert_eq!(events.len(), 1);
-        assert!(events[0].has_sched_process_exit());
-        assert_eq!(events[0].sched_process_exit().comm(), "prev");
     }
 
     #[test]

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -232,12 +232,14 @@ impl SystingRecordEvent<task_event> for SchedEventRecorder {
                     }
                 }
 
-                // Always add to compact_sched for both SCHED_SWITCH and SCHED_WAKING.
-                // This is intentional even in streaming mode: compact_sched is used by
-                // write_trace() for Perfetto output, allowing both Parquet and Perfetto
-                // formats from a single recording session.
-                let compact_sched = self.compact_sched.entry(event.cpu).or_default();
-                compact_sched.add_task_event(&event);
+                // Only accumulate in compact_sched for the non-streaming path.
+                // In streaming mode, sched slices are emitted directly above and
+                // Perfetto output is generated from Parquet files, so retaining
+                // every event here is pure memory overhead on busy systems.
+                if self.streaming_collector.is_none() {
+                    let compact_sched = self.compact_sched.entry(event.cpu).or_default();
+                    compact_sched.add_task_event(&event);
+                }
             }
 
             // IRQ handler entry - track for pairing with exit
@@ -421,7 +423,14 @@ impl SchedEventRecorder {
     }
 
     /// Add an event to the ftrace events map for Perfetto output.
+    ///
+    /// Skipped entirely in streaming mode: the ftrace event map is only read by
+    /// write_trace()/write_records() on the non-streaming path, and accumulating
+    /// every IRQ/softirq/wakeup event for the whole trace is a major memory cost.
     fn add_ftrace_event(&mut self, event: &task_event) {
+        if self.streaming_collector.is_some() {
+            return;
+        }
         let ftrace_event = FtraceEvent::from(event);
         let cpu_event = self.events.entry(event.cpu).or_default();
         cpu_event.insert(event.ts, ftrace_event);

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -1243,7 +1243,6 @@ mod tests {
     /// Gets the minimum timestamp from all recorded events across all recorders.
     fn get_min_event_timestamp(recorder: &SessionRecorder) -> u64 {
         [
-            recorder.event_recorder.lock().unwrap().min_timestamp(),
             recorder.stack_recorder.lock().unwrap().min_timestamp(),
             recorder
                 .perf_counter_recorder
@@ -1982,40 +1981,5 @@ mod tests {
             ts > 0,
             "Should return current BOOTTIME when no events recorded"
         );
-    }
-
-    #[test]
-    fn test_get_min_event_timestamp_with_sched_events() {
-        let recorder = create_test_session_recorder();
-
-        // Add a sched event with a known timestamp
-        {
-            let mut event_recorder = recorder.event_recorder.lock().unwrap();
-
-            let mut task = task_info {
-                tgidpid: ((1234u64) << 32) | 5678u64,
-                comm: [0; 16],
-            };
-            task.comm[0..4].copy_from_slice(b"test");
-
-            // Create a switch event which is stored in compact_sched
-            let event = crate::systing_core::types::task_event {
-                ts: 1_000_000_000, // 1 second
-                r#type: crate::systing_core::types::event_type::SCHED_SWITCH,
-                cpu: 0,
-                target_cpu: 0,
-                prev_prio: 0,
-                next_prio: 0,
-                prev: task,
-                next: task,
-                ..Default::default()
-            };
-            event_recorder.handle_event(event);
-        }
-
-        let ts = get_min_event_timestamp(&recorder);
-
-        // Should return the timestamp of the recorded event
-        assert_eq!(ts, 1_000_000_000, "Should return min event timestamp");
     }
 }

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -880,8 +880,13 @@ impl SessionRecorder {
             .unwrap()
             .set_streaming_collector(Box::new(writer));
 
-        // Enable streaming mode for stack recorder (samples buffered, written at end)
-        self.stack_recorder.lock().unwrap().enable_streaming();
+        // Set up streaming collector for stack recorder so samples are written
+        // incrementally instead of buffered for the entire trace.
+        let stack_writer = StreamingParquetWriter::new(output_dir)?;
+        self.stack_recorder
+            .lock()
+            .unwrap()
+            .set_streaming_collector(Box::new(stack_writer));
 
         // Set up streaming collector for network recorder (events emitted immediately)
         let network_writer = StreamingParquetWriter::new(output_dir)?;

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -171,12 +171,9 @@ pub struct StackRecorder {
     pub process_dispatcher: Option<Arc<ProcessDispatcher>>,
     pub global_func_manager: Arc<GlobalFunctionManager>,
     // Streaming support
-    /// Whether streaming mode is enabled. When true, stacks are deduplicated during
-    /// recording and samples are buffered for later writing via finish().
-    streaming_enabled: bool,
     /// Collector for emitting StackSampleRecords as they arrive. When set, samples
-    /// are written immediately in handle_event() instead of accumulating in
-    /// pending_samples for the whole trace.
+    /// are written immediately in handle_event() and stacks are deduplicated during
+    /// recording for end-of-trace symbolization via finish().
     streaming_collector: Option<Box<dyn RecordCollector + Send>>,
     /// Maps (Stack, tgid) to stack_id for deduplication during streaming.
     /// The tgid is included in the key because the same addresses in different processes
@@ -184,8 +181,6 @@ pub struct StackRecorder {
     unique_stacks: HashMap<(Stack, i32), i64>,
     /// Next stack_id to assign for new unique stacks.
     next_stack_id: i64,
-    /// Pending samples buffer for streaming.
-    pending_samples: Vec<StackSampleRecord>,
     /// Shared utid generator for consistent thread IDs across all recorders.
     utid_generator: Arc<UtidGenerator>,
 }
@@ -205,27 +200,17 @@ impl StackRecorder {
             psr: Arc::new(StackWalkerRun::default()),
             process_dispatcher,
             global_func_manager: Arc::new(GlobalFunctionManager::new(id_counter)),
-            streaming_enabled: false,
             streaming_collector: None,
             unique_stacks: HashMap::new(),
             next_stack_id: 1,
-            pending_samples: Vec::new(),
             utid_generator,
         }
-    }
-
-    /// Enable streaming mode for stack recording.
-    /// When enabled, stacks are deduplicated during recording and samples are
-    /// buffered for later writing via finish().
-    pub fn enable_streaming(&mut self) {
-        self.streaming_enabled = true;
     }
 
     /// Enable streaming mode and attach a collector so that StackSampleRecords
     /// are emitted immediately in handle_event() rather than accumulated for the
     /// entire trace. unique_stacks is still retained for end-of-trace symbolization.
     pub fn set_streaming_collector(&mut self, collector: Box<dyn RecordCollector + Send>) {
-        self.streaming_enabled = true;
         self.streaming_collector = Some(collector);
     }
 
@@ -263,9 +248,9 @@ impl StackRecorder {
         collector: Box<dyn RecordCollector + Send>,
     ) -> Result<Box<dyn RecordCollector + Send>> {
         // If we were given our own streaming collector at startup, stack samples
-        // have already been written to it incrementally. Route the remaining
-        // pending samples and symbolized stacks through it as well, finish it,
-        // and hand the caller's collector back untouched.
+        // have already been written to it incrementally. Route the symbolized
+        // stacks through it as well, finish it, and hand the caller's collector
+        // back untouched.
         if let Some(mut own) = self.streaming_collector.take() {
             self.finish_inner(own.as_mut())?;
             own.flush()?;
@@ -280,18 +265,8 @@ impl StackRecorder {
     }
 
     fn finish_inner(&mut self, collector: &mut dyn RecordCollector) -> Result<()> {
-        // Check if streaming was enabled (we have pending samples/unique stacks)
         if self.unique_stacks.is_empty() {
             return Ok(());
-        }
-
-        // Flush pending samples to the collector
-        eprintln!(
-            "Flushing {} pending stack samples...",
-            self.pending_samples.len()
-        );
-        for sample in self.pending_samples.drain(..) {
-            collector.add_stack_sample(sample)?;
         }
 
         // Now symbolize all unique stacks and stream StackRecords
@@ -385,7 +360,7 @@ impl StackRecorder {
 
     /// Check if streaming mode is enabled.
     pub fn is_streaming(&self) -> bool {
-        self.streaming_enabled
+        self.streaming_collector.is_some()
     }
 
     /// Symbolize a single stack and return frame names.
@@ -1280,8 +1255,8 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
             let tid = event.task.tgidpid as i32;
             let tgid = stack_key; // tgid for process-specific symbolization
 
-            // Streaming mode: dedupe stacks and buffer samples for streaming
-            if self.streaming_enabled {
+            // Streaming mode: dedupe stacks and emit samples directly to the collector
+            if let Some(collector) = &mut self.streaming_collector {
                 // Get or assign stack_id for this (stack, tgid) pair
                 // Include tgid in key since same addresses may resolve differently per-process
                 let key = (stack, tgid);
@@ -1302,13 +1277,8 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
                     stack_event_type: convert_stack_event_type(event.stack_event_type.0),
                 };
 
-                // Emit immediately if we have a collector; otherwise buffer for finish().
-                if let Some(collector) = &mut self.streaming_collector {
-                    if let Err(e) = collector.add_stack_sample(sample) {
-                        eprintln!("Warning: Failed to stream stack sample: {e}");
-                    }
-                } else {
-                    self.pending_samples.push(sample);
+                if let Err(e) = collector.add_stack_sample(sample) {
+                    eprintln!("Warning: Failed to stream stack sample: {e}");
                 }
             } else {
                 // Non-streaming mode: store all events for later processing

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -174,6 +174,10 @@ pub struct StackRecorder {
     /// Whether streaming mode is enabled. When true, stacks are deduplicated during
     /// recording and samples are buffered for later writing via finish().
     streaming_enabled: bool,
+    /// Collector for emitting StackSampleRecords as they arrive. When set, samples
+    /// are written immediately in handle_event() instead of accumulating in
+    /// pending_samples for the whole trace.
+    streaming_collector: Option<Box<dyn RecordCollector + Send>>,
     /// Maps (Stack, tgid) to stack_id for deduplication during streaming.
     /// The tgid is included in the key because the same addresses in different processes
     /// may resolve to different symbols (e.g., shared libraries at fixed addresses).
@@ -202,6 +206,7 @@ impl StackRecorder {
             process_dispatcher,
             global_func_manager: Arc::new(GlobalFunctionManager::new(id_counter)),
             streaming_enabled: false,
+            streaming_collector: None,
             unique_stacks: HashMap::new(),
             next_stack_id: 1,
             pending_samples: Vec::new(),
@@ -214,6 +219,14 @@ impl StackRecorder {
     /// buffered for later writing via finish().
     pub fn enable_streaming(&mut self) {
         self.streaming_enabled = true;
+    }
+
+    /// Enable streaming mode and attach a collector so that StackSampleRecords
+    /// are emitted immediately in handle_event() rather than accumulated for the
+    /// entire trace. unique_stacks is still retained for end-of-trace symbolization.
+    pub fn set_streaming_collector(&mut self, collector: Box<dyn RecordCollector + Send>) {
+        self.streaming_enabled = true;
+        self.streaming_collector = Some(collector);
     }
 
     /// Create a symbolizer with the configured process dispatcher.
@@ -247,11 +260,29 @@ impl StackRecorder {
     /// Returns the collector so it can be passed to other recorders or finished.
     pub fn finish(
         &mut self,
-        mut collector: Box<dyn RecordCollector + Send>,
+        collector: Box<dyn RecordCollector + Send>,
     ) -> Result<Box<dyn RecordCollector + Send>> {
+        // If we were given our own streaming collector at startup, stack samples
+        // have already been written to it incrementally. Route the remaining
+        // pending samples and symbolized stacks through it as well, finish it,
+        // and hand the caller's collector back untouched.
+        if let Some(mut own) = self.streaming_collector.take() {
+            self.finish_inner(own.as_mut())?;
+            own.flush()?;
+            own.finish_boxed()?;
+            return Ok(collector);
+        }
+
+        let mut collector = collector;
+        self.finish_inner(collector.as_mut())?;
+        collector.flush()?;
+        Ok(collector)
+    }
+
+    fn finish_inner(&mut self, collector: &mut dyn RecordCollector) -> Result<()> {
         // Check if streaming was enabled (we have pending samples/unique stacks)
         if self.unique_stacks.is_empty() {
-            return Ok(collector);
+            return Ok(());
         }
 
         // Flush pending samples to the collector
@@ -349,9 +380,7 @@ impl StackRecorder {
             pb.finish_with_message("Stack symbolization complete");
         }
 
-        // Flush and return the collector
-        collector.flush()?;
-        Ok(collector)
+        Ok(())
     }
 
     /// Check if streaming mode is enabled.
@@ -1265,14 +1294,22 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
                     id
                 };
 
-                // Buffer the sample for streaming (will be flushed in finish())
-                self.pending_samples.push(StackSampleRecord {
+                let sample = StackSampleRecord {
                     ts: event.ts as i64,
                     utid: self.utid_generator.get_or_create_utid(tid),
                     cpu: Some(event.cpu as i32),
                     stack_id,
                     stack_event_type: convert_stack_event_type(event.stack_event_type.0),
-                });
+                };
+
+                // Emit immediately if we have a collector; otherwise buffer for finish().
+                if let Some(collector) = &mut self.streaming_collector {
+                    if let Err(e) = collector.add_stack_sample(sample) {
+                        eprintln!("Warning: Failed to stream stack sample: {e}");
+                    }
+                } else {
+                    self.pending_samples.push(sample);
+                }
             } else {
                 // Non-streaming mode: store all events for later processing
                 let stack_event = StackEvent {

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -1637,7 +1637,7 @@ fn configure_bpf_skeleton(
         let object = open_skel.open_object_mut();
         for mut map in object.maps_mut() {
             let name = map.name().to_str().unwrap().to_string();
-            if name.starts_with("node") {
+            if name.starts_with("ringbuf_") && name.contains("_node") {
                 map.set_max_entries(size).with_context(|| {
                     format!(
                         "Failed to set ringbuf size to {} MiB for map '{}'",

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -14,7 +14,7 @@ use std::os::unix::net::UnixDatagram;
 use std::path::PathBuf;
 use std::process;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{channel, sync_channel, Receiver, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
@@ -591,7 +591,7 @@ impl SystingEvent for marker_event {
 
 fn create_ring<'a, T>(
     map: &dyn libbpf_rs::MapCore,
-    tx: Sender<T>,
+    tx: SyncSender<T>,
 ) -> Result<libbpf_rs::RingBuffer<'a>, libbpf_rs::Error>
 where
     T: Default + Plain + 'a,
@@ -600,6 +600,10 @@ where
     builder.add(map, move |data: &[u8]| {
         let mut event = T::default();
         plain::copy_from_bytes(&mut event, data).expect("Data buffer was too short");
+        // SyncSender::send blocks when the channel is full, applying backpressure
+        // to ringbuf consumption. If the recorder thread can't keep up, events
+        // back up in the kernel ringbuf (which is bounded) rather than in an
+        // unbounded userspace queue.
         if tx.send(event).is_err() {
             // Receiver has been dropped, we can silently ignore this
             return -1;
@@ -1370,16 +1374,23 @@ fn setup_ringbuffers<'a>(
     perf_counter_names: &[String],
     collect_pystacks: bool,
 ) -> Result<(Vec<(String, libbpf_rs::RingBuffer<'a>)>, RecorderChannels)> {
+    // Per-event-type channel capacity. Bounded so that a slow recorder thread
+    // applies backpressure to the ringbuf reader instead of letting an unbounded
+    // queue grow until OOM. If the kernel ringbuf fills as a result, BPF drops
+    // events and increments the missed-events counter, which is the intended
+    // behaviour under sustained overload.
+    const CHANNEL_CAPACITY: usize = 100_000;
+
     let mut rings = Vec::new();
-    let (event_tx, event_rx) = channel();
-    let (stack_tx, stack_rx) = channel();
-    let (cache_tx, cache_rx) = channel();
-    let (probe_tx, probe_rx) = channel();
-    let (network_tx, network_rx) = channel();
-    let (packet_tx, packet_rx) = channel();
-    let (epoll_tx, epoll_rx) = channel();
-    let (marker_tx, marker_rx) = channel();
-    let (exec_tx, exec_rx) = channel();
+    let (event_tx, event_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (stack_tx, stack_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (cache_tx, cache_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (probe_tx, probe_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (network_tx, network_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (packet_tx, packet_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (epoll_tx, epoll_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (marker_tx, marker_rx) = sync_channel(CHANNEL_CAPACITY);
+    let (exec_tx, exec_rx) = sync_channel(CHANNEL_CAPACITY);
     let mut has_exec_ringbuf = false;
 
     let object = skel.object();

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -1648,6 +1648,27 @@ fn configure_bpf_skeleton(
         }
     }
 
+    // BPF selects a per-CPU ringbuf via `cpu_id % NR_RINGBUFS` (NR_RINGBUFS = 8).
+    // On hosts with fewer than 8 possible CPUs, ringbufs whose index is >= num_cpus
+    // can never be selected, so shrink them to the minimum to avoid wasting up to
+    // hundreds of MiB of mlocked kernel memory per unused slot.
+    const NR_RINGBUFS: u32 = 8;
+    if num_cpus < NR_RINGBUFS {
+        let object = open_skel.open_object_mut();
+        for mut map in object.maps_mut() {
+            let name = map.name().to_str().unwrap().to_string();
+            if let Some(idx) = name
+                .rfind("_node")
+                .and_then(|pos| name[pos + 5..].parse::<u32>().ok())
+            {
+                if idx >= num_cpus {
+                    map.set_max_entries(1)
+                        .with_context(|| format!("Failed to shrink unused ringbuf map '{name}'"))?;
+                }
+            }
+        }
+    }
+
     // Set network ringbuffer maps to zero capacity if network recording is disabled
     if !opts.network {
         let object = open_skel.open_object_mut();

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -336,15 +336,15 @@ pub struct NetworkSyscallRecord {
 /// buffer_queue, zero_window_probe, zero_window_ack, rto_timeout, udp_send, udp_receive,
 /// udp_enqueue, packet_drop, cpu_backlog_drop, mem_pressure, tsq_throttle, qdisc_enqueue,
 /// qdisc_dequeue, tx_queue_stop, tx_queue_wake
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NetworkPacketRecord {
     pub id: i64,
     pub ts: i64,
     pub socket_id: i64,
-    pub event_type: String,
+    pub event_type: &'static str,
     pub seq: Option<i64>,
     pub length: i32,
-    pub tcp_flags: Option<String>,
+    pub tcp_flags: Option<u8>,
     // Send buffer fields
     pub sndbuf_used: Option<i64>,
     pub sndbuf_limit: Option<i64>,
@@ -372,7 +372,6 @@ pub struct NetworkPacketRecord {
     pub icsk_timeout: Option<i64>,
     // Drop fields
     pub drop_reason: Option<i32>,
-    pub drop_reason_str: Option<String>,
     pub drop_location: Option<i64>,
     // Queue fields
     pub qlen: Option<i32>,
@@ -389,9 +388,7 @@ pub struct NetworkPacketRecord {
     pub qdisc_latency_us: Option<i32>,
     // TCP state change fields
     pub old_state: Option<i16>,
-    pub old_state_str: Option<String>,
     pub new_state: Option<i16>,
-    pub new_state_str: Option<String>,
 }
 
 /// Network socket record - represents socket metadata.


### PR DESCRIPTION
## Summary

This branch tackles the primary OOM causes when tracing busy hosts or running long traces:

- **Skip dead compact_sched/ftrace accumulation in streaming mode** — sched events were buffered in memory even though streaming mode writes them directly to Parquet
- **Stream stack samples incrementally** instead of buffering all samples until trace end
- **Bound BPF-to-recorder event channels** (sync_channel with 100k cap) so excess events back-pressure into the kernel ringbuf instead of growing unbounded userspace heap
- **Shrink unused per-CPU ringbuf slots** on hosts with fewer than 8 CPUs, saving hundreds of MiB of mlocked kernel memory
- **Store ints instead of Strings in NetworkPacketRecord** — eliminates ~24-30MB heap overhead per 200k-record batch
- **Fix `--ringbuf-size-mib` never being applied** — map name prefix check was wrong
- **Remove dead code**: in-memory compact_sched/ftrace Perfetto path and pending_samples buffer, which are unreachable after streaming was made unconditional

Net: -714 lines, +159 lines across 11 files.

## Test plan
- [ ] `cargo test` passes
- [ ] Integration tests pass via `./scripts/run-integration-tests.sh`
- [ ] Run a trace on a busy multi-CPU host and verify memory stays bounded
- [ ] Verify `--ringbuf-size-mib` now actually takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)