### PR TITLE
Attribute marker slices to the emitting thread

### DIFF
--- a/src/bin/systing_util.rs
+++ b/src/bin/systing_util.rs
@@ -1015,6 +1015,12 @@ impl TraceExtractor {
                     if let Some(&upid) = self.pid_to_upid.get(&pid) {
                         self.track_uuid_to_id.insert(desc.uuid(), upid);
                     }
+                    // Map the process track UUID to the main thread's utid so
+                    // child custom tracks (e.g. marker tracks) can inherit it
+                    // via parent_uuid propagation.
+                    if let Some(&utid) = self.tid_to_utid.get(&pid) {
+                        self.track_uuid_to_utid.insert(desc.uuid(), utid);
+                    }
                 }
             }
 

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -509,7 +509,7 @@ fn test_range_packet() {
     assert!(recorder
         .outstanding_ranges
         .get(&1234)
-        .map_or(true, |r| r.is_empty()));
+        .is_none_or(|r| r.is_empty()));
     let data = recorder.finish_in_memory();
     assert_eq!(data.tracks.len(), 1);
     assert_eq!(data.tracks[0].name, "track_name");
@@ -675,7 +675,7 @@ fn test_range_packet_multiple_ranges() {
     assert!(recorder
         .outstanding_ranges
         .get(&1234)
-        .map_or(true, |r| r.is_empty()));
+        .is_none_or(|r| r.is_empty()));
     let collector = recorder.finish().unwrap().unwrap();
     collector.finish_boxed().unwrap();
 }
@@ -749,7 +749,7 @@ fn test_range_packet_multiple_ranges_multi_packet() {
     assert!(recorder
         .outstanding_ranges
         .get(&1234)
-        .map_or(true, |r| r.is_empty()));
+        .is_none_or(|r| r.is_empty()));
     let collector = recorder.finish().unwrap().unwrap();
     collector.finish_boxed().unwrap();
 }
@@ -2042,7 +2042,7 @@ fn test_thread_scope_no_cross_thread_match() {
     assert!(recorder
         .outstanding_ranges
         .get(&tgidpid_thread1)
-        .map_or(false, |r| !r.is_empty()));
+        .is_some_and(|r| !r.is_empty()));
 }
 
 #[test]
@@ -2098,7 +2098,7 @@ fn test_process_scope_cross_thread_match() {
     assert!(recorder
         .outstanding_ranges
         .get(&tgid)
-        .map_or(true, |r| r.is_empty()));
+        .is_none_or(|r| r.is_empty()));
     let data = recorder.finish_in_memory();
     assert_eq!(data.slices.len(), 1);
     assert_eq!(data.slices[0].name, "my_span");

--- a/src/marker_recorder.rs
+++ b/src/marker_recorder.rs
@@ -215,36 +215,50 @@ impl MarkerRecorder {
         // thread-attributed via slice.utid / instant.utid. Resolve each row's
         // track id in a single pass so the emission loops below do zero
         // hashmap lookups.
-        let mut track_ids: HashMap<(i32, String), i64> = HashMap::new();
+        // Two-level map: tid -> (track_name -> track_id). The inner map
+        // keys on &str borrowed from the recorded ranges/instants, avoiding
+        // a String clone on every lookup hit.
+        let mut track_ids: HashMap<i32, HashMap<&str, i64>> = HashMap::new();
         let mut range_track_ids: Vec<i64> = Vec::with_capacity(self.recorded_ranges.len());
         let mut instant_track_ids: Vec<i64> = Vec::with_capacity(self.instants.len());
         for r in &self.recorded_ranges {
             let tid = r.tgidpid as i32;
-            let id = *track_ids.entry((tid, r.track.clone())).or_insert_with(|| {
-                let id = *track_id_counter;
-                *track_id_counter += 1;
-                id
-            });
+            let id = *track_ids
+                .entry(tid)
+                .or_default()
+                .entry(&r.track)
+                .or_insert_with(|| {
+                    let id = *track_id_counter;
+                    *track_id_counter += 1;
+                    id
+                });
             range_track_ids.push(id);
         }
         for i in &self.instants {
             let tid = i.tgidpid as i32;
-            let id = *track_ids.entry((tid, i.track.clone())).or_insert_with(|| {
-                let id = *track_id_counter;
-                *track_id_counter += 1;
-                id
-            });
+            let id = *track_ids
+                .entry(tid)
+                .or_default()
+                .entry(&i.track)
+                .or_insert_with(|| {
+                    let id = *track_id_counter;
+                    *track_id_counter += 1;
+                    id
+                });
             instant_track_ids.push(id);
         }
 
         // Emit track descriptors in stable id order (HashMap iteration is
         // non-deterministic; ids are monotonic from track_id_counter).
-        let mut ordered_tracks: Vec<(&(i32, String), &i64)> = track_ids.iter().collect();
-        ordered_tracks.sort_by_key(|(_, &id)| id);
-        for ((_tid, name), &id) in ordered_tracks {
+        let mut ordered_tracks: Vec<(&str, i64)> = track_ids
+            .values()
+            .flat_map(|inner| inner.iter().map(|(&name, &id)| (name, id)))
+            .collect();
+        ordered_tracks.sort_by_key(|&(_, id)| id);
+        for (name, id) in ordered_tracks {
             collector.add_track(TrackRecord {
                 id,
-                name: name.clone(),
+                name: name.to_string(),
                 parent_id: None,
             })?;
         }
@@ -680,5 +694,30 @@ mod tests {
         assert_eq!(data.instants[0].track_id, data.tracks[0].id);
         assert_eq!(data.slices[0].utid, Some(expected_utid));
         assert_eq!(data.instants[0].utid, Some(expected_utid));
+    }
+
+    #[test]
+    fn test_non_main_thread_uses_tid_not_tgid() {
+        // When tgid != tid (non-main thread), the track and utid must be keyed
+        // on the tid (lower 32 bits), not the tgid (upper 32 bits).
+        let gen = Arc::new(UtidGenerator::new());
+        let tgid: i32 = 99;
+        let tid: i32 = 42;
+        let tgidpid = ((tgid as u64) << 32) | (tid as u32 as u64);
+        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        recorder.handle_event(make_event(0, "T:evt", tgidpid, 100));
+        recorder.handle_event(make_event(1, "T:evt", tgidpid, 200));
+        recorder.handle_event(make_event(2, "T:inst", tgidpid, 150));
+
+        let mut collector = crate::record::collector::InMemoryCollector::new();
+        recorder
+            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
+            .unwrap();
+        let data = collector.into_data();
+
+        let utid = gen.get_utid(tid).expect("utid should exist for tid");
+        assert!(gen.get_utid(tgid).is_none(), "tgid should not have a utid");
+        assert_eq!(data.slices[0].utid, Some(utid));
+        assert_eq!(data.instants[0].utid, Some(utid));
     }
 }

--- a/src/marker_recorder.rs
+++ b/src/marker_recorder.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::sync::Arc;
 
 use anyhow::Result;
 
@@ -7,6 +8,7 @@ use crate::record::RecordCollector;
 use crate::ringbuf::RingBuffer;
 use crate::systing_core::{marker_event, SystingRecordEvent};
 use crate::trace::{ArgRecord, InstantArgRecord, InstantRecord, SliceRecord, TrackRecord};
+use crate::utid::UtidGenerator;
 
 struct MarkerRange {
     track: String,
@@ -14,6 +16,7 @@ struct MarkerRange {
     start: u64,
     end: u64,
     info: u64,
+    tgidpid: u64,
 }
 
 struct MarkerInstant {
@@ -21,9 +24,9 @@ struct MarkerInstant {
     name: String,
     ts: u64,
     info: u64,
+    tgidpid: u64,
 }
 
-#[derive(Default)]
 pub struct MarkerRecorder {
     pub ringbuf: RingBuffer<marker_event>,
     // Key: (tgidpid, track, name) -> (start_ts, info)
@@ -39,6 +42,7 @@ pub struct MarkerRecorder {
     // ingestion path (before events enter the ring buffer), while `handle_event`
     // runs on the drain path. They observe events at different times.
     outstanding_triggers: HashMap<(u64, String, String), u64>,
+    utid_generator: Arc<UtidGenerator>,
 }
 
 /// Marker type values passed in the `dirfd` argument of the `faccessat2` syscall.
@@ -140,6 +144,7 @@ impl SystingRecordEvent<marker_event> for MarkerRecorder {
                         start,
                         end: ts,
                         info: start_info,
+                        tgidpid,
                     });
                 }
             }
@@ -149,6 +154,7 @@ impl SystingRecordEvent<marker_event> for MarkerRecorder {
                     name,
                     ts,
                     info,
+                    tgidpid,
                 });
             }
             _ => {}
@@ -157,6 +163,20 @@ impl SystingRecordEvent<marker_event> for MarkerRecorder {
 }
 
 impl MarkerRecorder {
+    pub fn new(utid_generator: Arc<UtidGenerator>) -> Self {
+        Self {
+            ringbuf: RingBuffer::default(),
+            outstanding_ranges: HashMap::new(),
+            recorded_ranges: Vec::new(),
+            instants: Vec::new(),
+            instant_count: 0,
+            threshold: None,
+            duration_threshold_ns: None,
+            outstanding_triggers: HashMap::new(),
+            utid_generator,
+        }
+    }
+
     pub fn with_threshold(mut self, threshold: Option<u64>) -> Self {
         self.threshold = threshold;
         self
@@ -191,35 +211,48 @@ impl MarkerRecorder {
             );
         }
 
-        // Assign a single track ID per unique track name, shared by ranges and instants.
-        let mut track_ids: HashMap<&str, i64> = HashMap::new();
+        // Per-thread track id keyed by (tid, track_name) — rows are
+        // thread-attributed via slice.utid / instant.utid. Resolve each row's
+        // track id in a single pass so the emission loops below do zero
+        // hashmap lookups.
+        let mut track_ids: HashMap<(i32, String), i64> = HashMap::new();
+        let mut range_track_ids: Vec<i64> = Vec::with_capacity(self.recorded_ranges.len());
+        let mut instant_track_ids: Vec<i64> = Vec::with_capacity(self.instants.len());
         for r in &self.recorded_ranges {
-            track_ids.entry(&r.track).or_insert_with(|| {
+            let tid = r.tgidpid as i32;
+            let id = *track_ids.entry((tid, r.track.clone())).or_insert_with(|| {
                 let id = *track_id_counter;
                 *track_id_counter += 1;
                 id
             });
+            range_track_ids.push(id);
         }
         for i in &self.instants {
-            track_ids.entry(&i.track).or_insert_with(|| {
+            let tid = i.tgidpid as i32;
+            let id = *track_ids.entry((tid, i.track.clone())).or_insert_with(|| {
                 let id = *track_id_counter;
                 *track_id_counter += 1;
                 id
             });
+            instant_track_ids.push(id);
         }
 
-        // Emit track descriptors
-        for (name, &id) in &track_ids {
+        // Emit track descriptors in stable id order (HashMap iteration is
+        // non-deterministic; ids are monotonic from track_id_counter).
+        let mut ordered_tracks: Vec<(&(i32, String), &i64)> = track_ids.iter().collect();
+        ordered_tracks.sort_by_key(|(_, &id)| id);
+        for ((_tid, name), &id) in ordered_tracks {
             collector.add_track(TrackRecord {
                 id,
-                name: name.to_string(),
+                name: name.clone(),
                 parent_id: None,
             })?;
         }
 
         // Emit slices
-        for r in &self.recorded_ranges {
-            let track_id = track_ids[r.track.as_str()];
+        for (r, &track_id) in self.recorded_ranges.iter().zip(range_track_ids.iter()) {
+            let tid = r.tgidpid as i32;
+            let utid = Some(self.utid_generator.get_or_create_utid(tid));
             let slice_id = *slice_id_counter;
             *slice_id_counter += 1;
 
@@ -228,7 +261,7 @@ impl MarkerRecorder {
                 ts: r.start as i64,
                 dur: (r.end - r.start) as i64,
                 track_id,
-                utid: None,
+                utid,
                 name: r.name.clone(),
                 category: None,
                 depth: 0,
@@ -244,8 +277,9 @@ impl MarkerRecorder {
         }
 
         // Emit instants
-        for i in &self.instants {
-            let track_id = track_ids[i.track.as_str()];
+        for (i, &track_id) in self.instants.iter().zip(instant_track_ids.iter()) {
+            let tid = i.tgidpid as i32;
+            let utid = Some(self.utid_generator.get_or_create_utid(tid));
             let instant_id = *instant_id_counter;
             *instant_id_counter += 1;
 
@@ -253,7 +287,7 @@ impl MarkerRecorder {
                 id: instant_id,
                 ts: i.ts as i64,
                 track_id,
-                utid: None,
+                utid,
                 name: i.name.clone(),
                 category: None,
             })?;
@@ -275,6 +309,10 @@ impl MarkerRecorder {
 mod tests {
     use super::*;
     use crate::systing_core::task_info;
+
+    fn new_recorder() -> MarkerRecorder {
+        MarkerRecorder::new(Arc::new(UtidGenerator::new()))
+    }
 
     fn make_event(marker_type: u32, name: &str, tgidpid: u64, ts: u64) -> marker_event {
         make_event_with_info(marker_type, name, tgidpid, ts, 0)
@@ -326,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_range_start_end() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event(0, "T:evt", 1234, 1000));
         recorder.handle_event(make_event(1, "T:evt", 1234, 2000));
 
@@ -339,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_instant() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event(2, "Markers:check", 1234, 5000));
 
         assert_eq!(recorder.instants.len(), 1);
@@ -349,14 +387,14 @@ mod tests {
 
     #[test]
     fn test_orphan_end_dropped() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event(1, "T:evt", 1234, 2000));
         assert!(recorder.recorded_ranges.is_empty());
     }
 
     #[test]
     fn test_orphan_start_not_emitted() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event(0, "T:evt", 1234, 1000));
         assert!(recorder.recorded_ranges.is_empty());
         assert_eq!(recorder.outstanding_ranges.len(), 1);
@@ -364,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_cross_thread_not_matched() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event(0, "T:evt", 1001, 1000));
         recorder.handle_event(make_event(1, "T:evt", 1002, 2000));
         // Different tgidpid -> no match
@@ -374,7 +412,7 @@ mod tests {
     #[test]
     fn test_shared_track_for_ranges_and_instants() {
         // Ranges and instants on the same track name must share one TrackRecord.
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event(0, "T:range", 1, 100));
         recorder.handle_event(make_event(1, "T:range", 1, 200));
         recorder.handle_event(make_event(2, "T:instant", 1, 150));
@@ -395,7 +433,7 @@ mod tests {
 
     #[test]
     fn test_threshold_none_never_triggers() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         // No threshold set, instants should never trigger
         for i in 0..100 {
             assert!(!recorder.maybe_trigger(&make_event(2, "T:check", 1, i * 100)));
@@ -404,7 +442,7 @@ mod tests {
 
     #[test]
     fn test_threshold_triggers_at_count() {
-        let mut recorder = MarkerRecorder::default().with_threshold(Some(3));
+        let mut recorder = new_recorder().with_threshold(Some(3));
         // First two instants should not trigger
         assert!(!recorder.maybe_trigger(&make_event(2, "T:check", 1, 100)));
         assert!(!recorder.maybe_trigger(&make_event(2, "T:check", 1, 200)));
@@ -414,13 +452,13 @@ mod tests {
 
     #[test]
     fn test_threshold_one_triggers_immediately() {
-        let mut recorder = MarkerRecorder::default().with_threshold(Some(1));
+        let mut recorder = new_recorder().with_threshold(Some(1));
         assert!(recorder.maybe_trigger(&make_event(2, "T:check", 1, 100)));
     }
 
     #[test]
     fn test_threshold_ignores_ranges() {
-        let mut recorder = MarkerRecorder::default().with_threshold(Some(1));
+        let mut recorder = new_recorder().with_threshold(Some(1));
         // Start/end range events should not count toward instant threshold
         assert!(!recorder.maybe_trigger(&make_event(0, "T:evt", 1, 100)));
         assert!(!recorder.maybe_trigger(&make_event(1, "T:evt", 1, 200)));
@@ -431,7 +469,7 @@ mod tests {
     #[test]
     fn test_duration_threshold_triggers_on_long_range() {
         // 100ms threshold in milliseconds -> 100_000_000 ns internally
-        let mut recorder = MarkerRecorder::default().with_duration_threshold(Some(100));
+        let mut recorder = new_recorder().with_duration_threshold(Some(100));
         // Range lasting 50ms (50_000_000 ns) - should NOT trigger
         assert!(!recorder.maybe_trigger(&make_event(0, "T:evt", 1, 0)));
         assert!(!recorder.maybe_trigger(&make_event(1, "T:evt", 1, 50_000_000)));
@@ -443,14 +481,14 @@ mod tests {
     #[test]
     fn test_duration_threshold_exact_boundary() {
         // Exactly at threshold should trigger
-        let mut recorder = MarkerRecorder::default().with_duration_threshold(Some(100));
+        let mut recorder = new_recorder().with_duration_threshold(Some(100));
         assert!(!recorder.maybe_trigger(&make_event(0, "T:evt", 1, 0)));
         assert!(recorder.maybe_trigger(&make_event(1, "T:evt", 1, 100_000_000)));
     }
 
     #[test]
     fn test_duration_threshold_none_never_triggers() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         // No thresholds set, even very long ranges should not trigger
         assert!(!recorder.maybe_trigger(&make_event(0, "T:evt", 1, 0)));
         assert!(!recorder.maybe_trigger(&make_event(1, "T:evt", 1, 999_000_000_000)));
@@ -458,14 +496,14 @@ mod tests {
 
     #[test]
     fn test_duration_threshold_ignores_instants() {
-        let mut recorder = MarkerRecorder::default().with_duration_threshold(Some(100));
+        let mut recorder = new_recorder().with_duration_threshold(Some(100));
         assert!(!recorder.maybe_trigger(&make_event(2, "T:check", 1, 0)));
         assert!(!recorder.maybe_trigger(&make_event(2, "T:check", 1, 999_000_000_000)));
     }
 
     #[test]
     fn test_duration_threshold_ignores_orphan_end() {
-        let mut recorder = MarkerRecorder::default().with_duration_threshold(Some(1));
+        let mut recorder = new_recorder().with_duration_threshold(Some(1));
         assert!(!recorder.maybe_trigger(&make_event(1, "T:evt", 1, 999_000_000_000)));
     }
 
@@ -473,7 +511,7 @@ mod tests {
     fn test_both_thresholds_duration_fires_first() {
         // Both instant count (10) and duration (100ms) thresholds set
         // A long range should fire duration before enough instants are seen
-        let mut recorder = MarkerRecorder::default()
+        let mut recorder = new_recorder()
             .with_threshold(Some(10))
             .with_duration_threshold(Some(100));
         // Instants don't fire yet (only 2 of 10)
@@ -488,7 +526,7 @@ mod tests {
     fn test_both_thresholds_count_fires_first() {
         // Both instant count (2) and duration (1s) thresholds set
         // Instants trigger count before any range is long enough for duration
-        let mut recorder = MarkerRecorder::default()
+        let mut recorder = new_recorder()
             .with_threshold(Some(2))
             .with_duration_threshold(Some(1000));
         // Short range - no duration trigger
@@ -502,7 +540,7 @@ mod tests {
 
     #[test]
     fn test_range_captures_info() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event_with_info(0, "T:evt", 1, 1000, 42));
         recorder.handle_event(make_event_with_info(1, "T:evt", 1, 2000, 99));
 
@@ -513,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_instant_captures_info() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event_with_info(2, "T:check", 1, 5000, 123));
 
         assert_eq!(recorder.instants.len(), 1);
@@ -522,7 +560,7 @@ mod tests {
 
     #[test]
     fn test_info_emitted_as_arg_records() {
-        let mut recorder = MarkerRecorder::default();
+        let mut recorder = new_recorder();
         recorder.handle_event(make_event_with_info(0, "T:range", 1, 100, 42));
         recorder.handle_event(make_event_with_info(1, "T:range", 1, 200, 0));
         recorder.handle_event(make_event_with_info(2, "T:instant", 1, 150, 77));
@@ -544,5 +582,103 @@ mod tests {
         assert_eq!(data.instant_args[0].key, "info");
         assert_eq!(data.instant_args[0].int_value, Some(77));
         assert_eq!(data.instant_args[0].instant_id, data.instants[0].id);
+    }
+
+    #[test]
+    fn test_slice_and_instant_utid_populated() {
+        // Markers must carry per-thread utid so downstream queries can join
+        // slice.utid = thread.utid for correct per-thread attribution.
+        let gen = Arc::new(UtidGenerator::new());
+        let tid: i32 = 4242;
+        let tgidpid = ((tid as u64) << 32) | (tid as u64);
+        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        recorder.handle_event(make_event(0, "T:evt", tgidpid, 1000));
+        recorder.handle_event(make_event(1, "T:evt", tgidpid, 2000));
+        recorder.handle_event(make_event(2, "T:inst", tgidpid, 1500));
+
+        let mut collector = crate::record::collector::InMemoryCollector::new();
+        recorder
+            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
+            .unwrap();
+        let data = collector.into_data();
+
+        let expected_utid = gen.get_utid(tid).expect("utid should exist after write");
+        assert_eq!(data.slices.len(), 1);
+        assert_eq!(data.slices[0].utid, Some(expected_utid));
+        assert_eq!(data.instants.len(), 1);
+        assert_eq!(data.instants[0].utid, Some(expected_utid));
+    }
+
+    #[test]
+    fn test_distinct_threads_get_distinct_track_ids_and_utids() {
+        // Same track name from two different threads must produce two distinct
+        // TrackRecords, and each slice must carry its own thread's utid so
+        // narrowest-enclosing queries do not cross-attribute.
+        let gen = Arc::new(UtidGenerator::new());
+        let tid_a: i32 = 1001;
+        let tid_b: i32 = 1002;
+        let tgidpid_a = ((tid_a as u64) << 32) | (tid_a as u64);
+        let tgidpid_b = ((tid_b as u64) << 32) | (tid_b as u64);
+        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        recorder.handle_event(make_event(0, "T:evt", tgidpid_a, 100));
+        recorder.handle_event(make_event(1, "T:evt", tgidpid_a, 200));
+        recorder.handle_event(make_event(0, "T:evt", tgidpid_b, 150));
+        recorder.handle_event(make_event(1, "T:evt", tgidpid_b, 250));
+
+        let mut collector = crate::record::collector::InMemoryCollector::new();
+        recorder
+            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
+            .unwrap();
+        let data = collector.into_data();
+
+        assert_eq!(data.tracks.len(), 2, "expected one track per thread");
+        assert_eq!(data.slices.len(), 2);
+
+        let utid_a = gen.get_utid(tid_a).unwrap();
+        let utid_b = gen.get_utid(tid_b).unwrap();
+        assert_ne!(utid_a, utid_b);
+
+        let slice_a = data
+            .slices
+            .iter()
+            .find(|s| s.ts == 100)
+            .expect("slice A missing");
+        let slice_b = data
+            .slices
+            .iter()
+            .find(|s| s.ts == 150)
+            .expect("slice B missing");
+        assert_eq!(slice_a.utid, Some(utid_a));
+        assert_eq!(slice_b.utid, Some(utid_b));
+        assert_ne!(
+            slice_a.track_id, slice_b.track_id,
+            "cross-thread same-name tracks must be distinct"
+        );
+    }
+
+    #[test]
+    fn test_same_thread_same_name_collapses_to_one_track() {
+        // Sanity: a single thread emitting both range and instant with the same
+        // track prefix should still share a single TrackRecord (no regression).
+        let gen = Arc::new(UtidGenerator::new());
+        let tid: i32 = 77;
+        let tgidpid = ((tid as u64) << 32) | (tid as u64);
+        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        recorder.handle_event(make_event(0, "T:range", tgidpid, 100));
+        recorder.handle_event(make_event(1, "T:range", tgidpid, 200));
+        recorder.handle_event(make_event(2, "T:inst", tgidpid, 150));
+
+        let mut collector = crate::record::collector::InMemoryCollector::new();
+        recorder
+            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
+            .unwrap();
+        let data = collector.into_data();
+
+        let expected_utid = gen.get_utid(tid).unwrap();
+        assert_eq!(data.tracks.len(), 1);
+        assert_eq!(data.slices[0].track_id, data.tracks[0].id);
+        assert_eq!(data.instants[0].track_id, data.tracks[0].id);
+        assert_eq!(data.slices[0].utid, Some(expected_utid));
+        assert_eq!(data.instants[0].utid, Some(expected_utid));
     }
 }

--- a/src/parquet_to_perfetto.rs
+++ b/src/parquet_to_perfetto.rs
@@ -416,8 +416,13 @@ impl ParquetToPerfettoConverter {
                     // Look up the TGID from the parent process
                     let tgid = self.resolve_tgid(upid, tid);
 
-                    // Skip main threads (TID == TGID) - they're handled by ProcessDescriptor
+                    // Main threads (TID == TGID) already have a ProcessDescriptor
+                    // track, but we still need to record their utid so marker
+                    // tracks emitted by the main thread can parent to it.
                     if tid == tgid {
+                        if let Some(&uuid) = self.tid_to_uuid.get(&tid) {
+                            self.utid_to_uuid.insert(utid, uuid);
+                        }
                         continue;
                     }
 

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -449,7 +449,7 @@ impl SessionRecorder {
             probe_recorder: Mutex::new(SystingProbeRecorder::new(Arc::clone(&utid_generator))),
             network_recorder: Mutex::new(NetworkRecorder::new(resolve_network_addresses)),
             marker_recorder: Mutex::new(
-                MarkerRecorder::default()
+                MarkerRecorder::new(Arc::clone(&utid_generator))
                     .with_threshold(marker_threshold)
                     .with_duration_threshold(marker_duration_threshold),
             ),
@@ -1249,7 +1249,7 @@ mod tests {
             sysinfo_recorder: Mutex::new(SysinfoRecorder::default()),
             probe_recorder: Mutex::new(SystingProbeRecorder::new(Arc::clone(&utid_generator))),
             network_recorder: Mutex::new(NetworkRecorder::default()),
-            marker_recorder: Mutex::new(MarkerRecorder::default()),
+            marker_recorder: Mutex::new(MarkerRecorder::new(Arc::clone(&utid_generator))),
             process_descriptors: RwLock::new(HashMap::new()),
             processes: RwLock::new(HashMap::new()),
             threads: RwLock::new(HashMap::new()),

--- a/src/validation/duckdb_queries.rs
+++ b/src/validation/duckdb_queries.rs
@@ -50,6 +50,78 @@ impl DuckDbQueries {
             .unwrap_or(false)
     }
 
+    /// Find rows in `table` whose `utid` column is NULL on a non-CPU custom track.
+    ///
+    /// Joins the table against `track` and excludes tracks whose name matches
+    /// the ` CPU <digits>` suffix produced by `events::mod` for per-CPU tracks.
+    /// All other custom tracks (markers + thread-scoped event tracks) must
+    /// carry a non-NULL `utid`.
+    ///
+    /// The ` CPU [0-9]+$` regex must stay in sync with the Rust classifier
+    /// `is_cpu_track_name` in `parquet_queries.rs`.
+    ///
+    /// Returns `FieldCheck::ok(0)` if the table, `track` table, or required
+    /// columns are missing (e.g. a trace that did not collect any markers or
+    /// custom events).
+    fn find_utid_violations_table(&self, table: &str) -> Result<FieldCheck> {
+        if !self.table_exists(table)
+            || !self.column_exists(table, "utid")
+            || !self.column_exists(table, "track_id")
+            || !self.column_exists(table, "id")
+            || !self.table_exists("track")
+            || !self.column_exists("track", "id")
+            || !self.column_exists("track", "name")
+        {
+            return Ok(FieldCheck::ok(0));
+        }
+
+        let denom_sql = format!(
+            "SELECT COUNT(*) \
+             FROM {table} s \
+             JOIN track t ON s.track_id = t.id \
+             WHERE NOT regexp_matches(t.name, ' CPU [0-9]+$')"
+        );
+        let total_count: i64 = self
+            .conn
+            .query_row(&denom_sql, [], |row| row.get(0))
+            .with_context(|| format!("Failed to count non-CPU {table} rows"))?;
+
+        let viol_sql = format!(
+            "SELECT COUNT(*) \
+             FROM {table} s \
+             JOIN track t ON s.track_id = t.id \
+             WHERE s.utid IS NULL \
+               AND NOT regexp_matches(t.name, ' CPU [0-9]+$')"
+        );
+        let empty_count: i64 = self
+            .conn
+            .query_row(&viol_sql, [], |row| row.get(0))
+            .with_context(|| format!("Failed to count utid violations in {table}"))?;
+
+        let mut sample_ids = Vec::new();
+        if empty_count > 0 {
+            let sample_sql = format!(
+                "SELECT s.id \
+                 FROM {table} s \
+                 JOIN track t ON s.track_id = t.id \
+                 WHERE s.utid IS NULL \
+                   AND NOT regexp_matches(t.name, ' CPU [0-9]+$') \
+                 LIMIT 10"
+            );
+            let mut stmt = self.conn.prepare(&sample_sql)?;
+            let rows = stmt.query_map([], |row| row.get::<_, i64>(0))?;
+            for row in rows {
+                sample_ids.push(row?);
+            }
+        }
+
+        Ok(FieldCheck {
+            empty_count,
+            total_count,
+            sample_ids,
+        })
+    }
+
     /// Get the data type of a column.
     fn get_column_type(&self, table: &str, column: &str) -> Option<String> {
         self.conn
@@ -220,6 +292,14 @@ impl ValidationQueries for DuckDbQueries {
             total_count,
             sample_ids,
         })
+    }
+
+    fn find_slice_utid_violations(&mut self) -> Result<FieldCheck> {
+        self.find_utid_violations_table("slice")
+    }
+
+    fn find_instant_utid_violations(&mut self) -> Result<FieldCheck> {
+        self.find_utid_violations_table("instant")
     }
 
     fn get_cmdline_stats(&mut self) -> Result<CmdlineStats> {

--- a/src/validation/duckdb_queries.rs
+++ b/src/validation/duckdb_queries.rs
@@ -50,15 +50,15 @@ impl DuckDbQueries {
             .unwrap_or(false)
     }
 
-    /// Find rows in `table` whose `utid` column is NULL on a non-CPU custom track.
+    /// Find rows in `table` whose `utid` column is NULL on a thread-attributed
+    /// custom track.
     ///
-    /// Joins the table against `track` and excludes tracks whose name matches
-    /// the ` CPU <digits>` suffix produced by `events::mod` for per-CPU tracks.
-    /// All other custom tracks (markers + thread-scoped event tracks) must
-    /// carry a non-NULL `utid`.
+    /// Joins the table against `track` and excludes tracks that are not expected
+    /// to carry per-thread utid:
+    /// - Per-CPU tracks (`" CPU <digits>"` suffix from `events::mod`)
+    /// - Network tracks (`"Network Packets"`, `"Network Interfaces"`, `"Socket ..."`)
     ///
-    /// The ` CPU [0-9]+$` regex must stay in sync with the Rust classifier
-    /// `is_cpu_track_name` in `parquet_queries.rs`.
+    /// Must stay in sync with `is_non_thread_track` in `parquet_queries.rs`.
     ///
     /// Returns `FieldCheck::ok(0)` if the table, `track` table, or required
     /// columns are missing (e.g. a trace that did not collect any markers or
@@ -75,23 +75,47 @@ impl DuckDbQueries {
             return Ok(FieldCheck::ok(0));
         }
 
+        // Exclude tracks that legitimately have no thread attribution:
+        // - CPU tracks (per-CPU event tracks from events::mod)
+        // - Network hierarchy tracks (Network Packets, Network Interfaces,
+        //   and all their descendants: socket tracks, namespace tracks,
+        //   interface tracks)
+        //
+        // We use a recursive CTE to walk the parent_id chain and exclude
+        // the entire network track subtree.
+        let non_thread_tracks_cte = "\
+            WITH RECURSIVE network_roots AS ( \
+                SELECT id FROM track \
+                WHERE name IN ('Network Packets', 'Network Interfaces') \
+            ), network_tree AS ( \
+                SELECT id FROM network_roots \
+                UNION ALL \
+                SELECT t.id FROM track t \
+                JOIN network_tree nt ON t.parent_id = nt.id \
+            ) ";
+
+        let track_filter = "NOT regexp_matches(t.name, ' CPU [0-9]+$') \
+               AND t.id NOT IN (SELECT id FROM network_tree)";
+
         let denom_sql = format!(
-            "SELECT COUNT(*) \
+            "{non_thread_tracks_cte} \
+             SELECT COUNT(*) \
              FROM {table} s \
              JOIN track t ON s.track_id = t.id \
-             WHERE NOT regexp_matches(t.name, ' CPU [0-9]+$')"
+             WHERE {track_filter}"
         );
         let total_count: i64 = self
             .conn
             .query_row(&denom_sql, [], |row| row.get(0))
-            .with_context(|| format!("Failed to count non-CPU {table} rows"))?;
+            .with_context(|| format!("Failed to count thread-attributed {table} rows"))?;
 
         let viol_sql = format!(
-            "SELECT COUNT(*) \
+            "{non_thread_tracks_cte} \
+             SELECT COUNT(*) \
              FROM {table} s \
              JOIN track t ON s.track_id = t.id \
              WHERE s.utid IS NULL \
-               AND NOT regexp_matches(t.name, ' CPU [0-9]+$')"
+               AND {track_filter}"
         );
         let empty_count: i64 = self
             .conn
@@ -101,11 +125,12 @@ impl DuckDbQueries {
         let mut sample_ids = Vec::new();
         if empty_count > 0 {
             let sample_sql = format!(
-                "SELECT s.id \
+                "{non_thread_tracks_cte} \
+                 SELECT s.id \
                  FROM {table} s \
                  JOIN track t ON s.track_id = t.id \
                  WHERE s.utid IS NULL \
-                   AND NOT regexp_matches(t.name, ' CPU [0-9]+$') \
+                   AND {track_filter} \
                  LIMIT 10"
             );
             let mut stmt = self.conn.prepare(&sample_sql)?;

--- a/src/validation/parquet_queries.rs
+++ b/src/validation/parquet_queries.rs
@@ -190,6 +190,16 @@ impl ValidationQueries for ParquetQueries {
         count_empty_names(&self.paths.thread, "utid", "tid", 0)
     }
 
+    fn find_slice_utid_violations(&mut self) -> Result<FieldCheck> {
+        let non_cpu_track_ids = load_non_cpu_track_ids(&self.paths.track)?;
+        find_utid_violations(&self.paths.slice, &non_cpu_track_ids)
+    }
+
+    fn find_instant_utid_violations(&mut self) -> Result<FieldCheck> {
+        let non_cpu_track_ids = load_non_cpu_track_ids(&self.paths.track)?;
+        find_utid_violations(&self.paths.instant, &non_cpu_track_ids)
+    }
+
     fn get_cmdline_stats(&mut self) -> Result<CmdlineStats> {
         let path = &self.paths.process;
         if !path.exists() {
@@ -626,6 +636,127 @@ fn count_empty_names(
     })
 }
 
+/// Returns true if a track name matches the per-CPU track naming pattern
+/// (`"{track_name} CPU {cpu}"`, where `{cpu}` is a decimal integer).
+///
+/// Per-CPU tracks are emitted by `events::mod` for events that are not bound
+/// to a specific thread; rows on those tracks legitimately have NULL `utid`.
+///
+/// Known ambiguity: a user-defined marker track literally named e.g.
+/// `"Request CPU 0"` would be misclassified as a CPU track and excluded
+/// from utid validation. In practice marker track names don't collide with
+/// this pattern.
+///
+/// Must stay in sync with the DuckDB regex ` CPU [0-9]+$` used in
+/// `duckdb_queries::find_utid_violations_table`.
+fn is_cpu_track_name(name: &str) -> bool {
+    match name.rsplit_once(" CPU ") {
+        Some((_, tail)) => !tail.is_empty() && tail.bytes().all(|b| b.is_ascii_digit()),
+        None => false,
+    }
+}
+
+/// Load the set of track ids from `track.parquet` whose name does NOT match
+/// the per-CPU track pattern. Returns an empty set if the file is missing.
+fn load_non_cpu_track_ids(path: &Path) -> Result<HashSet<i64>> {
+    let mut ids = HashSet::new();
+    if !path.exists() {
+        return Ok(ids);
+    }
+
+    let file = File::open(path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let reader = builder.build()?;
+
+    for batch_result in reader {
+        let batch = batch_result?;
+        let id_col = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
+        let name_col = batch
+            .column_by_name("name")
+            .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+        if let (Some(id_col), Some(name_col)) = (id_col, name_col) {
+            for i in 0..batch.num_rows() {
+                if id_col.is_null(i) || name_col.is_null(i) {
+                    continue;
+                }
+                if !is_cpu_track_name(name_col.value(i)) {
+                    ids.insert(id_col.value(i));
+                }
+            }
+        }
+    }
+
+    Ok(ids)
+}
+
+/// Find rows in a slice or instant parquet file whose `utid` is NULL and
+/// whose `track_id` belongs to a non-CPU custom track (as determined by
+/// `non_cpu_track_ids`). Returns the violating count, the denominator of rows
+/// on non-CPU tracks, and up to 10 sample violating `id`s.
+fn find_utid_violations(path: &Path, non_cpu_track_ids: &HashSet<i64>) -> Result<FieldCheck> {
+    if !path.exists() || non_cpu_track_ids.is_empty() {
+        return Ok(FieldCheck::ok(0));
+    }
+
+    let file = File::open(path)?;
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
+    let reader = builder.build()?;
+
+    let mut empty_count = 0i64;
+    let mut total_count = 0i64;
+    let mut sample_ids = Vec::new();
+
+    for batch_result in reader {
+        let batch = batch_result?;
+        let track_col = batch
+            .column_by_name("track_id")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
+        let utid_col = batch
+            .column_by_name("utid")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
+        let id_col = batch
+            .column_by_name("id")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
+
+        let (Some(track_col), Some(utid_col)) = (track_col, utid_col) else {
+            eprintln!(
+                "warning: {} batch missing track_id or utid column; skipping utid violation scan",
+                path.display()
+            );
+            continue;
+        };
+
+        for i in 0..batch.num_rows() {
+            if track_col.is_null(i) {
+                continue;
+            }
+            let track_id = track_col.value(i);
+            if !non_cpu_track_ids.contains(&track_id) {
+                continue;
+            }
+            total_count += 1;
+            if utid_col.is_null(i) {
+                empty_count += 1;
+                if sample_ids.len() < 10 {
+                    if let Some(id_col) = id_col {
+                        if !id_col.is_null(i) {
+                            sample_ids.push(id_col.value(i));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(FieldCheck {
+        empty_count,
+        total_count,
+        sample_ids,
+    })
+}
+
 /// Collect all values from an Int64 column into a HashSet.
 fn collect_i64_column(path: &Path, column: &str, set: &mut HashSet<i64>) -> Result<()> {
     let file = File::open(path)?;
@@ -900,6 +1031,22 @@ mod tests {
     use arrow::record_batch::RecordBatch;
 
     use crate::validation::test_utils::create_test_parquet;
+
+    #[test]
+    fn test_is_cpu_track_name() {
+        // Matches per-CPU tracks emitted by events::mod.
+        assert!(is_cpu_track_name("Syscalls CPU 0"));
+        assert!(is_cpu_track_name("Syscalls CPU 15"));
+        assert!(is_cpu_track_name("Some Long Name CPU 127"));
+        // Must not match anything else — user marker names, thread tracks, etc.
+        assert!(!is_cpu_track_name("MyTrack"));
+        assert!(!is_cpu_track_name("Markers"));
+        assert!(!is_cpu_track_name("CPU 0"), "no space before CPU");
+        assert!(!is_cpu_track_name("Syscalls CPU"), "no trailing digits");
+        assert!(!is_cpu_track_name("Syscalls CPU x"), "non-digit tail");
+        assert!(!is_cpu_track_name("Syscalls CPU 0a"), "trailing non-digit");
+        assert!(!is_cpu_track_name(""), "empty");
+    }
 
     /// Helper to create a valid process.parquet with required cmdline field.
     fn create_valid_process_parquet(dir: &Path, upid: i64, pid: i32, name: &str) {

--- a/src/validation/parquet_queries.rs
+++ b/src/validation/parquet_queries.rs
@@ -3,6 +3,8 @@
 //! This module implements `ValidationQueries` for Parquet trace files using
 //! native Arrow columnar scans with HashSet lookups.
 
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use arrow::array::{
     Array, BooleanArray, Int32Array, Int64Array, Int8Array, ListArray, StringArray,
@@ -191,12 +193,12 @@ impl ValidationQueries for ParquetQueries {
     }
 
     fn find_slice_utid_violations(&mut self) -> Result<FieldCheck> {
-        let non_cpu_track_ids = load_non_cpu_track_ids(&self.paths.track)?;
+        let non_cpu_track_ids = load_thread_attributed_track_ids(&self.paths.track)?;
         find_utid_violations(&self.paths.slice, &non_cpu_track_ids)
     }
 
     fn find_instant_utid_violations(&mut self) -> Result<FieldCheck> {
-        let non_cpu_track_ids = load_non_cpu_track_ids(&self.paths.track)?;
+        let non_cpu_track_ids = load_thread_attributed_track_ids(&self.paths.track)?;
         find_utid_violations(&self.paths.instant, &non_cpu_track_ids)
     }
 
@@ -656,17 +658,50 @@ fn is_cpu_track_name(name: &str) -> bool {
     }
 }
 
-/// Load the set of track ids from `track.parquet` whose name does NOT match
-/// the per-CPU track pattern. Returns an empty set if the file is missing.
-fn load_non_cpu_track_ids(path: &Path) -> Result<HashSet<i64>> {
-    let mut ids = HashSet::new();
+/// Returns true if a track name identifies a root-level non-thread track.
+///
+/// This catches tracks that are directly identifiable by name pattern. Child
+/// tracks of excluded roots (e.g. network namespace/interface tracks) are
+/// handled separately by the parent-chain walk in
+/// `load_thread_attributed_track_ids`.
+///
+/// Tracks excluded from utid validation:
+/// - Per-CPU tracks (`"{name} CPU {n}"`) — events are CPU-scoped, not thread-scoped
+/// - Network root tracks (`"Network Packets"`, `"Network Interfaces"`)
+/// - Socket tracks (`"Socket ..."`) — bound to a connection, not a thread
+///
+/// Must stay in sync with the DuckDB filter in
+/// `duckdb_queries::find_utid_violations_table`.
+fn is_non_thread_track(name: &str) -> bool {
+    if is_cpu_track_name(name) {
+        return true;
+    }
+    // Network root tracks
+    if name == "Network Packets" || name == "Network Interfaces" {
+        return true;
+    }
+    // Socket tracks: "Socket {id}:{protocol}:..."
+    if name.starts_with("Socket ") {
+        return true;
+    }
+    false
+}
+
+/// Load the set of track ids from `track.parquet` that are expected to carry
+/// per-thread utid attribution. Excludes CPU tracks and network tracks
+/// (including descendants of network root tracks).
+/// Returns an empty set if the file is missing.
+fn load_thread_attributed_track_ids(path: &Path) -> Result<HashSet<i64>> {
     if !path.exists() {
-        return Ok(ids);
+        return Ok(HashSet::new());
     }
 
+    // First pass: collect all tracks with their names and parent_ids
     let file = File::open(path)?;
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)?;
     let reader = builder.build()?;
+
+    let mut all_tracks: Vec<(i64, String, Option<i64>)> = Vec::new();
 
     for batch_result in reader {
         let batch = batch_result?;
@@ -676,17 +711,53 @@ fn load_non_cpu_track_ids(path: &Path) -> Result<HashSet<i64>> {
         let name_col = batch
             .column_by_name("name")
             .and_then(|c| c.as_any().downcast_ref::<StringArray>());
+        let parent_col = batch
+            .column_by_name("parent_id")
+            .and_then(|c| c.as_any().downcast_ref::<Int64Array>());
         if let (Some(id_col), Some(name_col)) = (id_col, name_col) {
             for i in 0..batch.num_rows() {
                 if id_col.is_null(i) || name_col.is_null(i) {
                     continue;
                 }
-                if !is_cpu_track_name(name_col.value(i)) {
-                    ids.insert(id_col.value(i));
+                let parent_id =
+                    parent_col.and_then(|c| if c.is_null(i) { None } else { Some(c.value(i)) });
+                all_tracks.push((id_col.value(i), name_col.value(i).to_string(), parent_id));
+            }
+        }
+    }
+
+    // Identify non-thread tracks (CPU tracks, network roots, socket tracks)
+    // and propagate exclusion to all descendants via BFS.
+    let mut excluded: HashSet<i64> = HashSet::new();
+    let mut children_map: HashMap<i64, Vec<i64>> = HashMap::new();
+
+    for &(id, ref name, parent_id) in &all_tracks {
+        if is_non_thread_track(name) {
+            excluded.insert(id);
+        }
+        if let Some(pid) = parent_id {
+            children_map.entry(pid).or_default().push(id);
+        }
+    }
+
+    // BFS from excluded roots to propagate exclusion to descendants
+    let mut queue: Vec<i64> = excluded.iter().copied().collect();
+    while let Some(parent) = queue.pop() {
+        if let Some(children) = children_map.get(&parent) {
+            for &child in children {
+                if excluded.insert(child) {
+                    queue.push(child);
                 }
             }
         }
     }
+
+    // Return tracks that are NOT excluded
+    let ids = all_tracks
+        .iter()
+        .filter(|(id, _, _)| !excluded.contains(id))
+        .map(|(id, _, _)| *id)
+        .collect();
 
     Ok(ids)
 }
@@ -1041,7 +1112,7 @@ mod tests {
         // Must not match anything else — user marker names, thread tracks, etc.
         assert!(!is_cpu_track_name("MyTrack"));
         assert!(!is_cpu_track_name("Markers"));
-        assert!(!is_cpu_track_name("CPU 0"), "no space before CPU");
+        assert!(!is_cpu_track_name("CPU 0"), "no prefix before ' CPU '");
         assert!(!is_cpu_track_name("Syscalls CPU"), "no trailing digits");
         assert!(!is_cpu_track_name("Syscalls CPU x"), "non-digit tail");
         assert!(!is_cpu_track_name("Syscalls CPU 0a"), "trailing non-digit");

--- a/src/validation/perfetto_queries.rs
+++ b/src/validation/perfetto_queries.rs
@@ -396,6 +396,17 @@ impl ValidationQueries for PerfettoQueries {
         })
     }
 
+    fn find_slice_utid_violations(&mut self) -> Result<FieldCheck> {
+        // Perfetto TrackEvents are routed via `track_uuid`, not via a
+        // slice.utid column. The equivalent thread-attribution invariant is
+        // enforced by parent_uuid hierarchy validation.
+        Ok(FieldCheck::ok(0))
+    }
+
+    fn find_instant_utid_violations(&mut self) -> Result<FieldCheck> {
+        Ok(FieldCheck::ok(0))
+    }
+
     fn get_cmdline_stats(&mut self) -> Result<CmdlineStats> {
         let total = self.context.empty_cmdline_count + self.context.has_cmdline_count;
         Ok(CmdlineStats {

--- a/src/validation/queries.rs
+++ b/src/validation/queries.rs
@@ -79,6 +79,33 @@ pub trait ValidationQueries {
     /// Validate tpu_metric table data: timestamps > 0, metric_name not empty, values finite.
     /// Returns None if the table doesn't exist, or Some(TpuMetricCheck) with results.
     fn check_tpu_metrics(&mut self) -> Result<Option<TpuMetricCheck>>;
+
+    /// Find slice rows on a non-CPU custom track whose `utid` is NULL.
+    ///
+    /// Two recorders write to `track.parquet`:
+    ///   - `marker_recorder` — user-emitted markers; rows MUST carry `utid` so
+    ///     downstream joins against `thread` work for per-thread attribution.
+    ///   - `events::mod` — emits both `Thread` tracks (rows MUST have `utid`)
+    ///     and `Cpu` tracks (rows legitimately have no `utid`).
+    ///
+    /// CPU tracks are identified by the ` CPU <digits>` suffix produced by
+    /// `events::mod` (`format!("{track_name} CPU {cpu}")`). Rows on all other
+    /// custom tracks must be thread-attributed.
+    ///
+    /// `FieldCheck::empty_count` counts violating rows, `total_count` counts
+    /// rows on non-CPU custom tracks (the denominator), and `sample_ids`
+    /// contains up to 10 violating `slice.id` values for the error message.
+    ///
+    /// Note: For Perfetto traces, this always returns `FieldCheck::ok(0)`
+    /// because Perfetto routes events via `track_uuid`, not a `slice.utid`
+    /// column; the equivalent invariant is covered by parent_uuid hierarchy
+    /// validation.
+    fn find_slice_utid_violations(&mut self) -> Result<FieldCheck>;
+
+    /// Find instant rows on a non-CPU custom track whose `utid` is NULL.
+    ///
+    /// See `find_slice_utid_violations` for the selection rules.
+    fn find_instant_utid_violations(&mut self) -> Result<FieldCheck>;
 }
 
 /// Result of reference integrity check - includes sample IDs for debugging.

--- a/src/validation/runner.rs
+++ b/src/validation/runner.rs
@@ -24,6 +24,59 @@ pub fn run_common_validations<Q: ValidationQueries>(
     validate_schema(queries, result);
     validate_stack_timing(queries, config, result);
     validate_tpu_metrics(queries, result);
+    validate_custom_track_utid_attribution(queries, result);
+}
+
+/// Validate per-thread attribution on custom (non-CPU) tracks.
+///
+/// Slices and instants on marker tracks and `events::mod` Thread tracks must
+/// carry a non-NULL `utid` so downstream joins against `thread` resolve the
+/// emitting thread. Per-CPU tracks — named `"<name> CPU <n>"` by `events::mod`
+/// — are excluded because their events are legitimately not thread-attributed.
+///
+/// Fires a hard `InvalidValue` error for every violating row found (capped by
+/// the sample list). This catches regressions like the pre-fix marker recorder
+/// path where `slice.utid` was left NULL even when sched/event rows in the
+/// same table were correctly attributed.
+fn validate_custom_track_utid_attribution<Q: ValidationQueries>(
+    queries: &mut Q,
+    result: &mut ValidationResult,
+) {
+    for (table, check_result) in [
+        ("slice", queries.find_slice_utid_violations()),
+        ("instant", queries.find_instant_utid_violations()),
+    ] {
+        match check_result {
+            Ok(check) => {
+                if check.empty_count > 0 {
+                    let message = if check.sample_ids.is_empty() {
+                        format!(
+                            "{} row(s) on non-CPU custom tracks have NULL utid \
+                             (of {} such rows)",
+                            check.empty_count, check.total_count,
+                        )
+                    } else {
+                        format!(
+                            "{} row(s) on non-CPU custom tracks have NULL utid \
+                             (of {} such rows); sample {}.id: {:?}",
+                            check.empty_count, check.total_count, table, check.sample_ids,
+                        )
+                    };
+                    result.add_error(ValidationError::InvalidValue {
+                        table: table.into(),
+                        column: "utid".into(),
+                        message,
+                    });
+                }
+            }
+            Err(e) => {
+                result.add_error(ValidationError::ReadError {
+                    table: table.into(),
+                    message: format!("Failed to check utid attribution: {e}"),
+                });
+            }
+        }
+    }
 }
 
 /// Validate reference integrity (foreign key relationships).

--- a/src/validation/runner.rs
+++ b/src/validation/runner.rs
@@ -51,13 +51,13 @@ fn validate_custom_track_utid_attribution<Q: ValidationQueries>(
                 if check.empty_count > 0 {
                     let message = if check.sample_ids.is_empty() {
                         format!(
-                            "{} row(s) on non-CPU custom tracks have NULL utid \
+                            "{} row(s) on thread-attributed custom tracks have NULL utid \
                              (of {} such rows)",
                             check.empty_count, check.total_count,
                         )
                     } else {
                         format!(
-                            "{} row(s) on non-CPU custom tracks have NULL utid \
+                            "{} row(s) on thread-attributed custom tracks have NULL utid \
                              (of {} such rows); sample {}.id: {:?}",
                             check.empty_count, check.total_count, table, check.sample_ids,
                         )


### PR DESCRIPTION
## Summary

- Adds per-thread attribution to marker events by threading `tgidpid` through `MarkerRange`/`MarkerInstant`, keying track IDs by `(tid, track_name)`, and populating `utid` on slice/instant records
- Fixes Perfetto round-trip: populates `utid_to_uuid` for main threads in the exporter and maps process track UUIDs to main thread utids in the importer
- Adds validation that slice/instant rows on thread-attributed custom tracks carry non-NULL `utid`, with proper exclusions for CPU tracks and network track hierarchies (recursive CTE for DuckDB, BFS parent walk for parquet)
- Adds unit tests for utid population, cross-thread track separation, same-thread track collapsing, and non-main thread tid extraction

## Test plan

- [x] All 318 unit tests pass (`cargo test --lib`)
- [x] All 25 integration tests pass (`./scripts/run-integration-tests.sh`)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)