### PR TITLE
Skip unused ringbuf ARRAY_OF_MAPS for disabled recorders

### DIFF
--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -311,6 +311,10 @@ pub fn get_available_recorders() -> Vec<RecorderInfo> {
             description: "Userspace marker events (faccessat2 with mode=-975)",
             default_enabled: false,
             bpf_programs: MARKER_BPF_PROGRAMS,
+            // Markers write to the standalone ringbuf_marker map, not a family.
+            // MARKER_BPF_PROGRAMS (== SYSCALL_BPF_PROGRAMS) do reference
+            // probe_ringbufs in sys_enter/exit, but behind a
+            // tool_config.collect_syscalls rodata gate the verifier prunes.
             ringbuf_families: &[],
         },
         RecorderInfo {
@@ -1769,7 +1773,7 @@ fn setup_ringbuffers<'a>(
         let name = map.name().to_str().unwrap();
         if name.starts_with("ringbuf_events") && required.contains("ringbufs") {
             let ring = create_ring::<task_event>(&map, event_tx.clone())?;
-            rings.push((format!("events_{i}").to_string(), ring));
+            rings.push((format!("events_{i}"), ring));
         } else if name.starts_with("ringbuf_stack") {
             let ring = create_ring::<stack_event>(&map, stack_tx.clone())?;
             rings.push((name.to_string(), ring));

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -137,6 +137,10 @@ pub struct RecorderInfo {
     /// BPF programs required by this recorder. Empty for recorders that don't
     /// need BPF programs (e.g., tpu, tpu-metrics).
     pub bpf_programs: &'static [&'static str],
+    /// Ringbuf ARRAY_OF_MAPS families this recorder's programs write to.
+    /// Drives autocreate in `configure_bpf_skeleton` and consumption in
+    /// `setup_ringbuffers`.
+    pub ringbuf_families: &'static [&'static str],
 }
 
 // BPF program lists for each recorder.
@@ -237,78 +241,91 @@ pub fn get_available_recorders() -> Vec<RecorderInfo> {
             description: "Scheduler event tracing",
             default_enabled: true,
             bpf_programs: SCHED_BPF_PROGRAMS,
+            ringbuf_families: &["ringbufs"],
         },
         RecorderInfo {
             name: "syscalls",
             description: "Syscall tracing",
             default_enabled: false,
             bpf_programs: SYSCALL_BPF_PROGRAMS,
+            ringbuf_families: &["probe_ringbufs"],
         },
         RecorderInfo {
             name: "sleep-stacks",
             description: "Sleep stack traces",
             default_enabled: true,
             bpf_programs: &[],
+            ringbuf_families: &[],
         },
         RecorderInfo {
             name: "interruptible-stacks",
             description: "Interruptible sleep stack traces",
             default_enabled: true,
             bpf_programs: &[],
+            ringbuf_families: &[],
         },
         RecorderInfo {
             name: "cpu-stacks",
             description: "CPU perf stack traces",
             default_enabled: true,
             bpf_programs: &[],
+            ringbuf_families: &[],
         },
         RecorderInfo {
             name: "network",
             description: "Network connection state tracking",
             default_enabled: false,
             bpf_programs: NETWORK_BPF_PROGRAMS,
+            ringbuf_families: &["packet_ringbufs"],
         },
         RecorderInfo {
             name: "network-packets",
             description: "Network packet-level tracing (sendmsg, recvmsg, qdisc, drops)",
             default_enabled: false,
             bpf_programs: NETWORK_PACKETS_BPF_PROGRAMS,
+            ringbuf_families: &["network_ringbufs", "packet_ringbufs", "epoll_ringbufs"],
         },
         RecorderInfo {
             name: "memory",
             description: "Memory usage tracking (RSS, mmap/munmap/brk, page faults)",
             default_enabled: false,
             bpf_programs: MEMORY_BPF_PROGRAMS,
+            ringbuf_families: &["memory_ringbufs"],
         },
         RecorderInfo {
             name: "memory-alloc",
             description: "Heap allocator uprobes (malloc/calloc/realloc/free) with stacks",
             default_enabled: false,
             bpf_programs: MEMORY_ALLOC_BPF_PROGRAMS,
+            ringbuf_families: &["memory_ringbufs"],
         },
         RecorderInfo {
             name: "pystacks",
             description: "Python stack tracing",
             default_enabled: false,
             bpf_programs: &[],
+            ringbuf_families: &[],
         },
         RecorderInfo {
             name: "markers",
             description: "Userspace marker events (faccessat2 with mode=-975)",
             default_enabled: false,
             bpf_programs: MARKER_BPF_PROGRAMS,
+            ringbuf_families: &[],
         },
         RecorderInfo {
             name: "tpu",
             description: "TPU profiling (gRPC to XLA runtime profiler service)",
             default_enabled: false,
             bpf_programs: &[],
+            ringbuf_families: &[],
         },
         RecorderInfo {
             name: "tpu-metrics",
             description: "TPU runtime metrics polling (port 8431, always available)",
             default_enabled: false,
             bpf_programs: &[],
+            ringbuf_families: &[],
         },
     ]
 }
@@ -373,21 +390,24 @@ const RINGBUF_FAMILIES: &[(&str, &str)] = &[
     ("memory_ringbufs", "ringbuf_memory_events_node"),
 ];
 
-/// Whether any enabled recorder's BPF program writes to the given outer map.
-/// Single source of truth for both `configure_bpf_skeleton` (autocreate) and
-/// `setup_ringbuffers` (mmap/consume); keeping these in sync by hand is what
-/// broke `--syscalls` when this optimization first landed.
-fn want_ringbuf_family(opts: &Config, outer: &str) -> bool {
-    match outer {
-        "ringbufs" => !opts.no_sched,
-        "perf_counter_ringbufs" => !opts.perf_counter.is_empty(),
-        "probe_ringbufs" => {
-            !opts.trace_event.is_empty() || !opts.trace_event_config.is_empty() || opts.syscalls
+/// Collect ringbuf ARRAY_OF_MAPS families written by any enabled recorder or
+/// probe. Drives both autocreate in `configure_bpf_skeleton` and mmap/consume
+/// in `setup_ringbuffers`; derived from `RecorderInfo::ringbuf_families` so it
+/// cannot drift from `get_required_bpf_programs`.
+fn get_required_ringbuf_families(opts: &Config) -> HashSet<&'static str> {
+    let mut required = HashSet::new();
+    for recorder in get_available_recorders() {
+        if is_recorder_enabled(recorder.name, opts) {
+            required.extend(recorder.ringbuf_families);
         }
-        "network_ringbufs" | "packet_ringbufs" | "epoll_ringbufs" => opts.network,
-        "memory_ringbufs" => opts.memory || opts.memory_alloc,
-        _ => true,
     }
+    if !opts.trace_event.is_empty() || !opts.trace_event_config.is_empty() {
+        required.insert("probe_ringbufs");
+    }
+    if !opts.perf_counter.is_empty() {
+        required.insert("perf_counter_ringbufs");
+    }
+    required
 }
 
 /// Collect the set of BPF programs required by all enabled recorders.
@@ -1742,38 +1762,35 @@ fn setup_ringbuffers<'a>(
     let object = skel.object();
 
     // Ringbuf families for disabled recorders are autocreate=false and have no
-    // fd to mmap; gate each create_ring on want_ringbuf_family so the two
-    // sites cannot drift.
+    // fd to mmap; gate each create_ring on the same required-set that governed
+    // autocreate (see configure_bpf_skeleton).
+    let required = get_required_ringbuf_families(opts);
     for (i, map) in object.maps().enumerate() {
         let name = map.name().to_str().unwrap();
-        if name.starts_with("ringbuf_events") && want_ringbuf_family(opts, "ringbufs") {
+        if name.starts_with("ringbuf_events") && required.contains("ringbufs") {
             let ring = create_ring::<task_event>(&map, event_tx.clone())?;
             rings.push((format!("events_{i}").to_string(), ring));
         } else if name.starts_with("ringbuf_stack") {
             let ring = create_ring::<stack_event>(&map, stack_tx.clone())?;
             rings.push((name.to_string(), ring));
         } else if name.starts_with("ringbuf_perf_counter")
-            && want_ringbuf_family(opts, "perf_counter_ringbufs")
+            && required.contains("perf_counter_ringbufs")
         {
             let ring = create_ring::<perf_counter_event>(&map, cache_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_probe") && want_ringbuf_family(opts, "probe_ringbufs") {
+        } else if name.starts_with("ringbuf_probe") && required.contains("probe_ringbufs") {
             let ring = create_ring::<probe_event>(&map, probe_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_network")
-            && want_ringbuf_family(opts, "network_ringbufs")
-        {
+        } else if name.starts_with("ringbuf_network") && required.contains("network_ringbufs") {
             let ring = create_ring::<network_event>(&map, network_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_packet") && want_ringbuf_family(opts, "packet_ringbufs")
-        {
+        } else if name.starts_with("ringbuf_packet") && required.contains("packet_ringbufs") {
             let ring = create_ring::<packet_event>(&map, packet_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_epoll") && want_ringbuf_family(opts, "epoll_ringbufs") {
+        } else if name.starts_with("ringbuf_epoll") && required.contains("epoll_ringbufs") {
             let ring = create_ring::<epoll_event_bpf>(&map, epoll_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_memory") && want_ringbuf_family(opts, "memory_ringbufs")
-        {
+        } else if name.starts_with("ringbuf_memory") && required.contains("memory_ringbufs") {
             let ring = create_memory_ring(&map, memory_tx.clone())?;
             rings.push((name.to_string(), ring));
         }
@@ -2034,10 +2051,11 @@ fn configure_bpf_skeleton(
     const NR_RINGBUFS: u32 = 8;
     // SAFETY: sysconf is always safe to call; _SC_PAGESIZE cannot fail.
     let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
+    let required = get_required_ringbuf_families(opts);
     let unused: Vec<(&str, &str)> = RINGBUF_FAMILIES
         .iter()
         .copied()
-        .filter(|(outer, _)| !want_ringbuf_family(opts, outer))
+        .filter(|(outer, _)| !required.contains(outer))
         .collect();
     for mut map in open_skel.open_object_mut().maps_mut() {
         let name = map.name().to_str().unwrap().to_owned();

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -362,6 +362,34 @@ const CORE_BPF_PROGRAMS: &[&str] = &["systing_perf_event_clock"];
 /// `probe_ringbufs` can be `autocreate=false` otherwise.
 const PROBE_BPF_PROGRAMS: &[&str] = &["systing_usdt", "systing_uprobe", "systing_kprobe"];
 
+/// Per-CPU ringbuf ARRAY_OF_MAPS families: (outer map name, inner-map name prefix).
+const RINGBUF_FAMILIES: &[(&str, &str)] = &[
+    ("ringbufs", "ringbuf_events_node"),
+    ("perf_counter_ringbufs", "ringbuf_perf_counter_events_node"),
+    ("probe_ringbufs", "ringbuf_probe_events_node"),
+    ("network_ringbufs", "ringbuf_network_events_node"),
+    ("packet_ringbufs", "ringbuf_packet_events_node"),
+    ("epoll_ringbufs", "ringbuf_epoll_events_node"),
+    ("memory_ringbufs", "ringbuf_memory_events_node"),
+];
+
+/// Whether any enabled recorder's BPF program writes to the given outer map.
+/// Single source of truth for both `configure_bpf_skeleton` (autocreate) and
+/// `setup_ringbuffers` (mmap/consume); keeping these in sync by hand is what
+/// broke `--syscalls` when this optimization first landed.
+fn want_ringbuf_family(opts: &Config, outer: &str) -> bool {
+    match outer {
+        "ringbufs" => !opts.no_sched,
+        "perf_counter_ringbufs" => !opts.perf_counter.is_empty(),
+        "probe_ringbufs" => {
+            !opts.trace_event.is_empty() || !opts.trace_event_config.is_empty() || opts.syscalls
+        }
+        "network_ringbufs" | "packet_ringbufs" | "epoll_ringbufs" => opts.network,
+        "memory_ringbufs" => opts.memory || opts.memory_alloc,
+        _ => true,
+    }
+}
+
 /// Collect the set of BPF programs required by all enabled recorders.
 ///
 /// This coalesces programs from each enabled recorder's `bpf_programs` list,
@@ -1689,7 +1717,6 @@ fn discover_processes_with_mapping(
 fn setup_ringbuffers<'a>(
     skel: &SystingSystemSkel,
     opts: &Config,
-    perf_counter_names: &[String],
     collect_pystacks: bool,
 ) -> Result<(Vec<(String, libbpf_rs::RingBuffer<'a>)>, RecorderChannels)> {
     // Per-event-type channel capacity. Bounded so that a slow recorder thread
@@ -1714,37 +1741,39 @@ fn setup_ringbuffers<'a>(
 
     let object = skel.object();
 
-    // Ringbuf families for disabled recorders are autocreate=false
-    // (see configure_bpf_skeleton) and have no fd to mmap; gate each
-    // create_ring on the same condition that governed autocreate.
-    let want_events = !opts.no_sched || opts.syscalls;
-    let want_probe = !opts.trace_event.is_empty() || !opts.trace_event_config.is_empty();
+    // Ringbuf families for disabled recorders are autocreate=false and have no
+    // fd to mmap; gate each create_ring on want_ringbuf_family so the two
+    // sites cannot drift.
     for (i, map) in object.maps().enumerate() {
         let name = map.name().to_str().unwrap();
-        if name.starts_with("ringbuf_events") && want_events {
+        if name.starts_with("ringbuf_events") && want_ringbuf_family(opts, "ringbufs") {
             let ring = create_ring::<task_event>(&map, event_tx.clone())?;
             rings.push((format!("events_{i}").to_string(), ring));
         } else if name.starts_with("ringbuf_stack") {
             let ring = create_ring::<stack_event>(&map, stack_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_perf_counter") {
-            if !perf_counter_names.is_empty() {
-                let ring = create_ring::<perf_counter_event>(&map, cache_tx.clone())?;
-                rings.push((name.to_string(), ring));
-            }
-        } else if name.starts_with("ringbuf_probe") && want_probe {
+        } else if name.starts_with("ringbuf_perf_counter")
+            && want_ringbuf_family(opts, "perf_counter_ringbufs")
+        {
+            let ring = create_ring::<perf_counter_event>(&map, cache_tx.clone())?;
+            rings.push((name.to_string(), ring));
+        } else if name.starts_with("ringbuf_probe") && want_ringbuf_family(opts, "probe_ringbufs") {
             let ring = create_ring::<probe_event>(&map, probe_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_network") && opts.network {
+        } else if name.starts_with("ringbuf_network")
+            && want_ringbuf_family(opts, "network_ringbufs")
+        {
             let ring = create_ring::<network_event>(&map, network_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_packet") && opts.network {
+        } else if name.starts_with("ringbuf_packet") && want_ringbuf_family(opts, "packet_ringbufs")
+        {
             let ring = create_ring::<packet_event>(&map, packet_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_epoll") && opts.network {
+        } else if name.starts_with("ringbuf_epoll") && want_ringbuf_family(opts, "epoll_ringbufs") {
             let ring = create_ring::<epoll_event_bpf>(&map, epoll_tx.clone())?;
             rings.push((name.to_string(), ring));
-        } else if name.starts_with("ringbuf_memory") && opts.memory {
+        } else if name.starts_with("ringbuf_memory") && want_ringbuf_family(opts, "memory_ringbufs")
+        {
             let ring = create_memory_ring(&map, memory_tx.clone())?;
             rings.push((name.to_string(), ring));
         }
@@ -2005,25 +2034,11 @@ fn configure_bpf_skeleton(
     const NR_RINGBUFS: u32 = 8;
     // SAFETY: sysconf is always safe to call; _SC_PAGESIZE cannot fail.
     let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
-    // (outer map name, inner-map prefix)
-    let mut unused: Vec<(&str, &str)> = Vec::new();
-    if opts.no_sched && !opts.syscalls {
-        unused.push(("ringbufs", "ringbuf_events_node"));
-    }
-    if opts.perf_counter.is_empty() && !opts.cpu_frequency {
-        unused.push(("perf_counter_ringbufs", "ringbuf_perf_counter_events_node"));
-    }
-    if opts.trace_event.is_empty() && opts.trace_event_config.is_empty() {
-        unused.push(("probe_ringbufs", "ringbuf_probe_events_node"));
-    }
-    if !opts.network {
-        unused.push(("network_ringbufs", "ringbuf_network_events_node"));
-        unused.push(("packet_ringbufs", "ringbuf_packet_events_node"));
-        unused.push(("epoll_ringbufs", "ringbuf_epoll_events_node"));
-    }
-    if !opts.memory && !opts.memory_alloc {
-        unused.push(("memory_ringbufs", "ringbuf_memory_events_node"));
-    }
+    let unused: Vec<(&str, &str)> = RINGBUF_FAMILIES
+        .iter()
+        .copied()
+        .filter(|(outer, _)| !want_ringbuf_family(opts, outer))
+        .collect();
     for mut map in open_skel.open_object_mut().maps_mut() {
         let name = map.name().to_str().unwrap().to_owned();
         if unused
@@ -3023,8 +3038,7 @@ pub fn systing(
             );
         }
 
-        let (rings, mut channels) =
-            setup_ringbuffers(&skel, &opts, &perf_counter_names, collect_pystacks)?;
+        let (rings, mut channels) = setup_ringbuffers(&skel, &opts, collect_pystacks)?;
         // Take exec_event_rx out before channels is moved into spawn_recorder_threads
         let exec_event_rx = channels.exec_event_rx.take();
 

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -351,14 +351,16 @@ fn is_recorder_enabled(name: &str, opts: &Config) -> bool {
 }
 
 /// BPF programs that are always loaded regardless of recorder selection.
-/// These provide core infrastructure (clock sampling) and generic probe handlers
-/// that are needed for user-specified trace events.
-const CORE_BPF_PROGRAMS: &[&str] = &[
-    "systing_perf_event_clock",
-    "systing_usdt",
-    "systing_uprobe",
-    "systing_kprobe",
-];
+/// `systing_perf_event_clock` is the periodic sampler that drives cpu-stacks,
+/// perf-counters, and memory RSS; its perf-counter and memory paths are
+/// rodata-gated (`tool_config.num_perf_counters`, `tool_config.collect_memory`)
+/// so the verifier prunes them when those recorders are disabled.
+const CORE_BPF_PROGRAMS: &[&str] = &["systing_perf_event_clock"];
+
+/// Generic probe handlers for user-specified `--trace-event` / USDT / uprobe /
+/// kprobe. Loaded only when at least one trace event is configured so that
+/// `probe_ringbufs` can be `autocreate=false` otherwise.
+const PROBE_BPF_PROGRAMS: &[&str] = &["systing_usdt", "systing_uprobe", "systing_kprobe"];
 
 /// Collect the set of BPF programs required by all enabled recorders.
 ///
@@ -375,11 +377,16 @@ pub fn get_required_bpf_programs(
     // Core programs always loaded
     required.extend(CORE_BPF_PROGRAMS);
 
-    // Kernel version determines which generic tracepoint handler to use
-    if old_kernel {
-        required.insert("systing_tracepoint");
-    } else {
-        required.insert("systing_raw_tracepoint");
+    // Generic probe handlers are loaded-but-unattached until a trace event is
+    // configured; skip the load entirely when none are so probe_ringbufs can
+    // be autocreate=false (see configure_bpf_skeleton).
+    if !opts.trace_event.is_empty() || !opts.trace_event_config.is_empty() {
+        required.extend(PROBE_BPF_PROGRAMS);
+        if old_kernel {
+            required.insert("systing_tracepoint");
+        } else {
+            required.insert("systing_raw_tracepoint");
+        }
     }
 
     // PID filtering needs fork tracking to follow child processes
@@ -1707,9 +1714,14 @@ fn setup_ringbuffers<'a>(
 
     let object = skel.object();
 
+    // Ringbuf families for disabled recorders are autocreate=false
+    // (see configure_bpf_skeleton) and have no fd to mmap; gate each
+    // create_ring on the same condition that governed autocreate.
+    let want_events = !opts.no_sched || opts.syscalls;
+    let want_probe = !opts.trace_event.is_empty() || !opts.trace_event_config.is_empty();
     for (i, map) in object.maps().enumerate() {
         let name = map.name().to_str().unwrap();
-        if name.starts_with("ringbuf_events") {
+        if name.starts_with("ringbuf_events") && want_events {
             let ring = create_ring::<task_event>(&map, event_tx.clone())?;
             rings.push((format!("events_{i}").to_string(), ring));
         } else if name.starts_with("ringbuf_stack") {
@@ -1720,7 +1732,7 @@ fn setup_ringbuffers<'a>(
                 let ring = create_ring::<perf_counter_event>(&map, cache_tx.clone())?;
                 rings.push((name.to_string(), ring));
             }
-        } else if name.starts_with("ringbuf_probe") {
+        } else if name.starts_with("ringbuf_probe") && want_probe {
             let ring = create_ring::<probe_event>(&map, probe_tx.clone())?;
             rings.push((name.to_string(), ring));
         } else if name.starts_with("ringbuf_network") && opts.network {
@@ -1972,50 +1984,76 @@ fn configure_bpf_skeleton(
         }
     }
 
-    // BPF selects a per-CPU ringbuf via `cpu_id % NR_RINGBUFS` (NR_RINGBUFS = 8).
-    // On hosts with fewer than 8 possible CPUs, ringbufs whose index is >= num_cpus
-    // can never be selected, so shrink them to the minimum to avoid wasting up to
-    // hundreds of MiB of mlocked kernel memory per unused slot.
+    // Skip creating ringbuf ARRAY_OF_MAPS for disabled recorders. The cost
+    // isn't the inner-map vmalloc (shrinking those to PAGE_SIZE makes creates
+    // ~25 µs each) — it's `synchronize_rcu()` in the kernel's
+    // `maybe_wait_bpf_programs()` after every `BPF_MAP_UPDATE_ELEM` on a
+    // map-of-maps, which libbpf calls once per `.values` slot. On a busy
+    // many-core host a grace period is ~100 ms, so 8 families × 8 slots ≈
+    // 6.4 s of startup even with every inner shrunk. Setting
+    // `autocreate(false)` on the outer skips the whole family (template,
+    // inners, and the slot updates that trigger the RCU waits). All programs
+    // that reference a skipped outer are already `autoload=false` via
+    // `required_programs` below, so the verifier never sees the dangling
+    // reference.
+    //
+    // Inners for families that ARE enabled still get shrunk to PAGE_SIZE when
+    // their slot index >= num_cpus, to save mlocked memory on small hosts
+    // (the slot update still happens, so no time saving there).
+    //
+    // Must match NR_RINGBUFS in src/bpf/systing_system.bpf.c.
     const NR_RINGBUFS: u32 = 8;
-    if num_cpus < NR_RINGBUFS {
-        let object = open_skel.open_object_mut();
-        for mut map in object.maps_mut() {
-            let name = map.name().to_str().unwrap().to_string();
-            if let Some(idx) = name
-                .rfind("_node")
-                .and_then(|pos| name[pos + 5..].parse::<u32>().ok())
-            {
-                if idx >= num_cpus {
-                    map.set_max_entries(1)
-                        .with_context(|| format!("Failed to shrink unused ringbuf map '{name}'"))?;
-                }
-            }
-        }
+    // SAFETY: sysconf is always safe to call; _SC_PAGESIZE cannot fail.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
+    // (outer map name, inner-map prefix)
+    let mut unused: Vec<(&str, &str)> = Vec::new();
+    if opts.no_sched && !opts.syscalls {
+        unused.push(("ringbufs", "ringbuf_events_node"));
     }
-
-    // Set network ringbuffer maps to zero capacity if network recording is disabled
+    if opts.perf_counter.is_empty() && !opts.cpu_frequency {
+        unused.push(("perf_counter_ringbufs", "ringbuf_perf_counter_events_node"));
+    }
+    if opts.trace_event.is_empty() && opts.trace_event_config.is_empty() {
+        unused.push(("probe_ringbufs", "ringbuf_probe_events_node"));
+    }
     if !opts.network {
-        let object = open_skel.open_object_mut();
-        for mut map in object.maps_mut() {
-            let name = map.name().to_str().unwrap().to_string();
-            if name.starts_with("ringbuf_network_events_")
-                || name.starts_with("ringbuf_packet_events_")
-                || name.starts_with("ringbuf_epoll_events_")
-            {
-                map.set_max_entries(1).with_context(|| {
-                    format!("Failed to shrink unused ringbuf map '{name}' to 1 entry")
-                })?;
-            }
+        unused.push(("network_ringbufs", "ringbuf_network_events_node"));
+        unused.push(("packet_ringbufs", "ringbuf_packet_events_node"));
+        unused.push(("epoll_ringbufs", "ringbuf_epoll_events_node"));
+    }
+    if !opts.memory && !opts.memory_alloc {
+        unused.push(("memory_ringbufs", "ringbuf_memory_events_node"));
+    }
+    for mut map in open_skel.open_object_mut().maps_mut() {
+        let name = map.name().to_str().unwrap().to_owned();
+        if unused
+            .iter()
+            .any(|(outer, inner)| name == *outer || name.starts_with(inner))
+        {
+            map.set_autocreate(false)
+                .with_context(|| format!("Failed to disable autocreate for '{name}'"))?;
+            continue;
+        }
+        let unreachable_slot = name
+            .rfind("_node")
+            .and_then(|pos| name[pos + 5..].parse::<u32>().ok())
+            .is_some_and(|idx| idx >= num_cpus && num_cpus < NR_RINGBUFS);
+        if unreachable_slot {
+            map.set_max_entries(page_size)
+                .with_context(|| format!("Failed to shrink unreachable ringbuf slot '{name}'"))?;
         }
     }
 
-    if !opts.memory {
-        for mut map in open_skel.open_object_mut().maps_mut() {
-            let name = map.name().to_str().unwrap().to_owned();
-            if name.starts_with("ringbuf_memory_events_") {
-                map.set_max_entries(1).with_context(|| {
-                    format!("Failed to set network ringbuf map '{name}' to zero capacity")
-                })?;
+    if std::env::var_os("SYSTING_DIAG_RINGBUFS").is_some() {
+        for map in open_skel.open_object_mut().maps_mut() {
+            let name = map.name().to_str().unwrap();
+            if name.starts_with("ringbuf_") || name.ends_with("ringbufs") {
+                eprintln!(
+                    "[diag] map={} type={:?} max_entries={}",
+                    name,
+                    map.map_type(),
+                    map.max_entries()
+                );
             }
         }
     }
@@ -2893,9 +2931,14 @@ pub fn systing(
                 format!("Failed to set missed_events map size to {num_cpus} entries")
             })?;
 
+        let diag = std::env::var_os("SYSTING_DIAG_RINGBUFS").is_some();
+        let t_load = std::time::Instant::now();
         let mut skel = open_skel.load().with_context(|| {
             "Failed to load BPF skeleton into kernel. Check dmesg for BPF verifier errors."
         })?;
+        if diag {
+            eprintln!("[diag] open_skel.load() took {:?}", t_load.elapsed());
+        }
         for cgroup in opts.cgroup.iter() {
             let metadata = std::fs::metadata(cgroup)
                 .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -134,13 +134,13 @@ fn spawn_python_workload(
     );
     let script_path = dir.join(script_name);
     std::fs::write(&script_path, &script).expect("write python script");
-    let ready_marker = dir.join("ready");
+    let ready_marker = dir.join(format!("{script_name}.ready"));
     let _ = std::fs::remove_file(&ready_marker);
 
     let mut child = std::process::Command::new(python_bin)
         .arg(&script_path)
         .arg(&ready_marker)
-        .stdout(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn()
         .expect("spawn python");

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -1844,7 +1844,7 @@ fn run_pystacks_version_test(full_ver: &str) {
     setup_bpf_environment();
 
     let script_content = r#"
-import time
+import sys
 
 def pystacks_version_test_function():
     """Function that does busy work to show up in profiling."""
@@ -1854,8 +1854,11 @@ def pystacks_version_test_function():
     return total
 
 def main():
-    start_time = time.time()
-    while time.time() - start_time < 10:
+    # Signal the harness that the interpreter is fully initialized and in the
+    # hot loop, so pystacks discovery can find _PyRuntime.
+    with open(sys.argv[1], "w") as f:
+        f.write("ready")
+    while True:
         pystacks_version_test_function()
 
 if __name__ == "__main__":
@@ -1864,6 +1867,7 @@ if __name__ == "__main__":
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
+    let ready_marker = dir.path().join("ready");
 
     let python_script = dir.path().join("test_version.py");
     {
@@ -1874,6 +1878,7 @@ if __name__ == "__main__":
 
     let mut python_proc = Command::new(&python_bin)
         .arg(&python_script)
+        .arg(&ready_marker)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -1882,8 +1887,23 @@ if __name__ == "__main__":
     let python_pid = python_proc.id();
     eprintln!("Started Python {} with PID: {}", full_ver, python_pid);
 
-    // Give Python time to start and begin executing
-    thread::sleep(Duration::from_millis(1000));
+    // Wait for Python to reach its hot loop before attaching. A fixed sleep
+    // races pyenv shim exec + Py_Initialize under parallel-suite load.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while !ready_marker.exists() {
+        if let Ok(Some(status)) = python_proc.try_wait() {
+            panic!(
+                "[Python {}] exited before signalling ready: {:?}",
+                full_ver, status
+            );
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "[Python {}] timed out waiting for ready marker",
+            full_ver
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
 
     let config = Config {
         duration: 3,
@@ -1897,6 +1917,7 @@ if __name__ == "__main__":
 
     systing(config, None).expect("systing recording failed");
 
+    let _ = python_proc.kill();
     let _ = python_proc.wait();
 
     let stack_parquet = dir.path().join("stack.parquet");

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -25,18 +25,8 @@ use systing::{
 };
 use tempfile::TempDir;
 
-// Timing constants for network namespace tests.
-// BPF initialization (skeleton build, probe attachment) can take 5+ seconds on some systems.
-// These values provide buffer for initialization before traffic generation begins.
-//
-// TODO: Consider adding a proper synchronization mechanism to systing (e.g., a callback
-// or channel that signals when BPF probes are attached) rather than relying on fixed delays.
-
-/// Time to wait for BPF probe initialization before generating test traffic (seconds).
-const NETNS_BPF_INIT_WAIT_SECS: u64 = 7;
-
-/// Total recording duration for netns tests (seconds). Must be longer than
-/// NETNS_BPF_INIT_WAIT_SECS plus time for traffic generation.
+/// Total recording duration for netns tests (seconds). Workloads loop until
+/// teardown, so this only needs to exceed BPF attach latency.
 const NETNS_RECORDING_DURATION_SECS: u64 = 10;
 
 /// Recording duration for the basic validation suite (seconds).
@@ -92,6 +82,86 @@ fn pyenv_python(version: &str) -> PathBuf {
     try_pyenv_python(version).unwrap_or_else(|| {
         panic!("Python {version} not found. Install it with: ./scripts/setup-pystacks.sh")
     })
+}
+
+/// A Python process running `loop_body` forever. Killed on drop.
+struct PythonWorkload {
+    child: std::process::Child,
+    pid: u32,
+}
+
+impl Drop for PythonWorkload {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn a Python process that runs `loop_body` in an infinite loop, blocking
+/// until the interpreter has fully initialized and executed one warm-up
+/// iteration. Replaces the flaky "spawn, sleep 1s, hope pyenv shim +
+/// Py_Initialize finished" pattern. The returned handle kills the child on
+/// drop.
+fn spawn_python_workload(
+    python_bin: impl AsRef<std::ffi::OsStr>,
+    dir: &std::path::Path,
+    script_name: &str,
+    defs: &str,
+    loop_body: &str,
+) -> PythonWorkload {
+    let indent = |s: &str, n| {
+        let pad = " ".repeat(n);
+        s.lines()
+            .map(|l| format!("{pad}{l}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    // One warm-up iteration before writing the ready marker: proves the
+    // workload is actually executing, not just that the interpreter finished
+    // init. Pystacks discovery and the recorder both start only once this
+    // fires, so every sample is known-good.
+    let script = format!(
+        "import sys, time\n\
+         {defs}\n\
+         if __name__ == \"__main__\":\n\
+         {warmup}\n    \
+             with open(sys.argv[1], \"w\") as f:\n        \
+                 f.write(\"ready\")\n    \
+             while True:\n\
+         {body}\n",
+        warmup = indent(loop_body, 4),
+        body = indent(loop_body, 8),
+    );
+    let script_path = dir.join(script_name);
+    std::fs::write(&script_path, &script).expect("write python script");
+    let ready_marker = dir.join("ready");
+    let _ = std::fs::remove_file(&ready_marker);
+
+    let mut child = std::process::Command::new(python_bin)
+        .arg(&script_path)
+        .arg(&ready_marker)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn python");
+    let pid = child.id();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    while !ready_marker.exists() {
+        if let Ok(Some(status)) = child.try_wait() {
+            let mut stderr = String::new();
+            if let Some(mut e) = child.stderr.take() {
+                let _ = std::io::Read::read_to_string(&mut e, &mut stderr);
+            }
+            panic!("python exited before ready: {status:?}\nstderr:\n{stderr}");
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for python ready marker"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    PythonWorkload { child, pid }
 }
 
 /// Scan a stack.parquet file for Python symbols and a specific target function name.
@@ -289,27 +359,26 @@ fn test_e2e_validation_suite() {
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
-    // Spawn exit workload to generate EXIT_DEAD/EXIT_ZOMBIE states
-    // We run many short-lived processes to ensure we reliably capture exit states
-    // during the trace window. The 500ms initial delay gives BPF programs time to
-    // fully initialize before we start generating exit events.
-    let workload_handle = thread::spawn(move || {
-        thread::sleep(Duration::from_millis(500));
-        // Run multiple rounds of short-lived processes. Each round spawns 50 subshells
-        // that immediately exit, which should generate EXIT_DEAD/EXIT_ZOMBIE states.
-        // We run continuously throughout the trace window.
-        for _ in 0..20 {
-            let mut child = Command::new("bash")
-                .arg("-c")
-                .arg("for i in $(seq 1 50); do (exit 0) & done; wait")
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .spawn()
-                .expect("Failed to spawn workload");
-            child.wait().expect("Failed to wait for workload");
-            thread::sleep(Duration::from_millis(50));
-        }
-    });
+    // Spawn exit workload to generate EXIT_DEAD/EXIT_ZOMBIE states. Loop until
+    // told to stop so the workload is guaranteed to overlap the full record
+    // window regardless of BPF attach latency.
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let workload_handle = {
+        let stop = stop.clone();
+        thread::spawn(move || {
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                let mut child = Command::new("bash")
+                    .arg("-c")
+                    .arg("for i in $(seq 1 50); do (exit 0) & done; wait")
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("Failed to spawn workload");
+                child.wait().expect("Failed to wait for workload");
+                thread::sleep(Duration::from_millis(50));
+            }
+        })
+    };
 
     // Record a trace with both parquet and perfetto output
     eprintln!(
@@ -324,6 +393,7 @@ fn test_e2e_validation_suite() {
     };
 
     systing(config, None).expect("systing recording failed");
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
     workload_handle.join().expect("Workload thread panicked");
     eprintln!("Recording complete.\n");
 
@@ -1037,12 +1107,13 @@ fn test_network_recording_with_netns() {
     let dest_ip = netns_env.config.ns_ip.to_string();
     let dest_port = netns_env.server_port;
 
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let traffic_handle = {
         let server_addr = netns_env.server_addr();
+        let stop = stop.clone();
         thread::spawn(move || {
-            thread::sleep(Duration::from_secs(NETNS_BPF_INIT_WAIT_SECS));
-
-            for i in 0..5 {
+            let mut i = 0u64;
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
                 let message = format!("Hello from netns test round {i}");
                 if let Ok(mut stream) = std::net::TcpStream::connect(&server_addr) {
                     let _ = stream.write_all(message.as_bytes());
@@ -1051,11 +1122,13 @@ fn test_network_recording_with_netns() {
                     let _ = stream.read_to_end(&mut response);
                 }
                 thread::sleep(Duration::from_millis(200));
+                i += 1;
             }
         })
     };
 
     systing(config, None).expect("systing recording failed");
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
     traffic_handle.join().expect("Traffic thread panicked");
     drop(netns_env);
 
@@ -1167,21 +1240,13 @@ fn test_network_recording_with_netns() {
 fn test_pystacks_symbol_resolution() {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::fs::File;
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-    use std::thread;
-    use std::time::Duration;
 
     setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
-    let python_script = dir.path().join("test_pystacks.py");
-    let script_content = r#"
-import time
-import sys
-
+    let defs = r#"
 def systing_test_leaf_function():
     """Leaf function that does busy work to show up in profiling."""
     total = 0
@@ -1199,53 +1264,29 @@ def systing_test_middle_function():
 def systing_test_outer_function():
     """Outer function that calls middle."""
     return systing_test_middle_function()
-
-def main():
-    """Main entry point."""
-    print("Python test script starting...", flush=True)
-    start_time = time.time()
-    while time.time() - start_time < 10:
-        systing_test_outer_function()
-    print("Python test script done.", flush=True)
-
-if __name__ == "__main__":
-    main()
 "#;
 
-    {
-        let mut file = File::create(&python_script).expect("Failed to create Python script");
-        file.write_all(script_content.as_bytes())
-            .expect("Failed to write Python script");
-    }
-
-    let mut python_proc = Command::new(pyenv_python(PYTHON_313_VERSION))
-        .arg(&python_script)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn Python process");
-
-    let python_pid = python_proc.id();
-    eprintln!("Started Python process with PID: {}", python_pid);
-
-    thread::sleep(Duration::from_millis(1000));
+    let workload = spawn_python_workload(
+        pyenv_python(PYTHON_313_VERSION),
+        dir.path(),
+        "test_pystacks.py",
+        defs,
+        "systing_test_outer_function()",
+    );
+    eprintln!("Started Python process with PID: {}", workload.pid);
 
     let config = Config {
         duration: 3,
         parquet_only: false,
         collect_pystacks: true,
-        pystacks_pids: vec![python_pid],
+        pystacks_pids: vec![workload.pid],
         output_dir: dir.path().to_path_buf(),
         output: trace_path.clone(),
         ..Config::default()
     };
 
     systing(config, None).expect("systing recording failed");
-
-    let python_status = python_proc
-        .wait()
-        .expect("Failed to wait for Python process");
-    eprintln!("Python process exited with status: {:?}", python_status);
+    drop(workload);
 
     // === VALIDATE PARQUET OUTPUT ===
 
@@ -1429,21 +1470,13 @@ fn test_pystacks_sleep_stacks() {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::collections::HashMap;
     use std::fs::File;
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-    use std::thread;
-    use std::time::Duration;
 
     setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
-    let python_script = dir.path().join("test_sleep_pystacks.py");
-    let script_content = r#"
-import time
-import sys
-
+    let defs = r#"
 def systing_sleep_leaf_function():
     """Leaf function that sleeps - should appear in STACK_SLEEP samples."""
     time.sleep(0.05)
@@ -1466,54 +1499,29 @@ def systing_cpu_middle_function():
     for _ in range(10):
         result += systing_cpu_leaf_function()
     return result
-
-def main():
-    """Main entry point - alternates between CPU work and sleeping."""
-    print("Python sleep/CPU test script starting...", flush=True)
-    start_time = time.time()
-    while time.time() - start_time < 10:
-        systing_cpu_middle_function()
-        systing_sleep_middle_function()
-    print("Python sleep/CPU test script done.", flush=True)
-
-if __name__ == "__main__":
-    main()
 "#;
 
-    {
-        let mut file = File::create(&python_script).expect("Failed to create Python script");
-        file.write_all(script_content.as_bytes())
-            .expect("Failed to write Python script");
-    }
-
-    let mut python_proc = Command::new(pyenv_python(PYTHON_313_VERSION))
-        .arg(&python_script)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn Python process");
-
-    let python_pid = python_proc.id();
-    eprintln!("Started Python process with PID: {}", python_pid);
-
-    thread::sleep(Duration::from_millis(1000));
+    let workload = spawn_python_workload(
+        pyenv_python(PYTHON_313_VERSION),
+        dir.path(),
+        "test_sleep_pystacks.py",
+        defs,
+        "systing_cpu_middle_function()\nsysting_sleep_middle_function()",
+    );
+    eprintln!("Started Python process with PID: {}", workload.pid);
 
     let config = Config {
         duration: 5,
         parquet_only: false,
         collect_pystacks: true,
-        pystacks_pids: vec![python_pid],
+        pystacks_pids: vec![workload.pid],
         output_dir: dir.path().to_path_buf(),
         output: trace_path.clone(),
         ..Config::default()
     };
 
     systing(config, None).expect("systing recording failed");
-
-    let python_status = python_proc
-        .wait()
-        .expect("Failed to wait for Python process");
-    eprintln!("Python process exited with status: {:?}", python_status);
+    drop(workload);
 
     // === LOAD STACK.PARQUET INTO A MAP ===
     let stack_parquet = dir.path().join("stack.parquet");
@@ -1657,10 +1665,6 @@ if __name__ == "__main__":
 fn test_pystacks_frame_error_rate() {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::fs::File;
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-    use std::thread;
-    use std::time::Duration;
 
     let python_bin = match try_pyenv_python(PYTHON_311_VERSION) {
         Some(p) => p,
@@ -1678,10 +1682,7 @@ fn test_pystacks_frame_error_rate() {
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
-    let python_script = dir.path().join("test_frame_error.py");
-    let script_content = r#"
-import time
-
+    let defs = r#"
 def level3():
     total = 0
     for i in range(100000):
@@ -1693,46 +1694,28 @@ def level2():
 
 def level1():
     return level2()
-
-def main():
-    start = time.time()
-    while time.time() - start < 10:
-        level1()
-
-if __name__ == "__main__":
-    main()
 "#;
 
-    {
-        let mut file = File::create(&python_script).expect("Failed to create Python script");
-        file.write_all(script_content.as_bytes())
-            .expect("Failed to write Python script");
-    }
-
-    let mut python_proc = Command::new(&python_bin)
-        .arg(&python_script)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn Python process");
-
-    let python_pid = python_proc.id();
-    thread::sleep(Duration::from_millis(1000));
+    let workload = spawn_python_workload(
+        &python_bin,
+        dir.path(),
+        "test_frame_error.py",
+        defs,
+        "level1()",
+    );
 
     let config = Config {
         duration: 3,
         parquet_only: false,
         collect_pystacks: true,
-        pystacks_pids: vec![python_pid],
+        pystacks_pids: vec![workload.pid],
         output_dir: dir.path().to_path_buf(),
         output: trace_path.clone(),
         ..Config::default()
     };
 
     systing(config, None).expect("systing recording failed");
-    python_proc
-        .wait()
-        .expect("Failed to wait for Python process");
+    drop(workload);
 
     let stack_parquet = dir.path().join("stack.parquet");
     assert!(stack_parquet.exists(), "stack.parquet not found");
@@ -1744,6 +1727,8 @@ if __name__ == "__main__":
     let mut total_python_stacks = 0;
     let mut frame_error_not_at_bottom = 0;
     let mut expected_functions_found = 0;
+    let mut total_rows = 0;
+    let mut sample_other: Option<Vec<String>> = None;
 
     for batch_result in reader {
         let batch = batch_result.expect("Failed to read batch");
@@ -1759,6 +1744,7 @@ if __name__ == "__main__":
             if frame_names_col.is_null(i) {
                 continue;
             }
+            total_rows += 1;
 
             let inner = frame_names_col.value(i);
             let string_array = inner
@@ -1778,6 +1764,9 @@ if __name__ == "__main__":
 
             let is_our_stack = frames.iter().any(|f| f.contains("test_frame_error.py"));
             if !is_our_stack {
+                if sample_other.is_none() && frames.iter().any(|f| f.contains("(python)")) {
+                    sample_other = Some(frames.clone());
+                }
                 continue;
             }
 
@@ -1808,7 +1797,11 @@ if __name__ == "__main__":
         }
     }
 
-    assert!(total_python_stacks > 0, "No Python stacks captured");
+    assert!(
+        total_python_stacks > 0,
+        "No Python stacks captured: {total_rows} total stack rows, sample (python) stack that \
+         didn't match test_frame_error.py: {sample_other:?}"
+    );
 
     assert!(
         expected_functions_found > 0,
@@ -1833,92 +1826,43 @@ if __name__ == "__main__":
 
 /// Helper: trace a Python script with pystacks and verify symbols appear.
 fn run_pystacks_version_test(full_ver: &str) {
-    use std::fs::File;
-    use std::io::Write;
-    use std::process::{Command, Stdio};
-    use std::thread;
-    use std::time::Duration;
-
     let python_bin = pyenv_python(full_ver);
 
     setup_bpf_environment();
 
-    let script_content = r#"
-import sys
-
+    let defs = r#"
 def pystacks_version_test_function():
     """Function that does busy work to show up in profiling."""
     total = 0
     for i in range(1000000):
         total += i * i
     return total
-
-def main():
-    # Signal the harness that the interpreter is fully initialized and in the
-    # hot loop, so pystacks discovery can find _PyRuntime.
-    with open(sys.argv[1], "w") as f:
-        f.write("ready")
-    while True:
-        pystacks_version_test_function()
-
-if __name__ == "__main__":
-    main()
 "#;
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
-    let ready_marker = dir.path().join("ready");
 
-    let python_script = dir.path().join("test_version.py");
-    {
-        let mut file = File::create(&python_script).expect("Failed to create Python script");
-        file.write_all(script_content.as_bytes())
-            .expect("Failed to write Python script");
-    }
-
-    let mut python_proc = Command::new(&python_bin)
-        .arg(&python_script)
-        .arg(&ready_marker)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .unwrap_or_else(|e| panic!("Failed to spawn Python {}: {}", full_ver, e));
-
-    let python_pid = python_proc.id();
-    eprintln!("Started Python {} with PID: {}", full_ver, python_pid);
-
-    // Wait for Python to reach its hot loop before attaching. A fixed sleep
-    // races pyenv shim exec + Py_Initialize under parallel-suite load.
-    let deadline = std::time::Instant::now() + Duration::from_secs(30);
-    while !ready_marker.exists() {
-        if let Ok(Some(status)) = python_proc.try_wait() {
-            panic!(
-                "[Python {}] exited before signalling ready: {:?}",
-                full_ver, status
-            );
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "[Python {}] timed out waiting for ready marker",
-            full_ver
-        );
-        thread::sleep(Duration::from_millis(50));
-    }
+    let workload = spawn_python_workload(
+        &python_bin,
+        dir.path(),
+        "test_version.py",
+        defs,
+        "pystacks_version_test_function()",
+    );
+    eprintln!("Started Python {} with PID: {}", full_ver, workload.pid);
 
     let config = Config {
         duration: 3,
         parquet_only: true,
         collect_pystacks: true,
-        pystacks_pids: vec![python_pid],
+        pystacks_pids: vec![workload.pid],
         output_dir: dir.path().to_path_buf(),
         output: trace_path,
         ..Config::default()
     };
 
     systing(config, None).expect("systing recording failed");
-
-    let _ = python_proc.kill();
-    let _ = python_proc.wait();
+    drop(workload);
 
     let stack_parquet = dir.path().join("stack.parquet");
     assert!(


### PR DESCRIPTION
## Summary
- Set `autocreate=false` on ringbuf ARRAY_OF_MAPS families (and their per-node inner maps) that no enabled recorder writes to, so targeted traces like `--only-recorder syscalls` don't allocate the sched/network/memory/perf_counter ringbufs. Shrinks unreachable inner-map slots to one page instead of the full size.
- Derive the required-family set from a new `RecorderInfo::ringbuf_families` field via `get_required_ringbuf_families()`, parallel to `get_required_bpf_programs()`, so autocreate (`configure_bpf_skeleton`) and consume (`setup_ringbuffers`) can't drift. This fixes the initial cut's `--syscalls` regression (syscall tracepoints write to `probe_ringbufs`, not `ringbufs`) and narrows `--network` alone to `packet_ringbufs` only.
- Integration-test sweep: replace the recurring "spawn, sleep, hope it overlaps" race with a `spawn_python_workload()` helper (ready-marker after one warm-up iteration, loop-forever, kill-on-drop) for all pystacks tests, and convert the remaining bounded-workload tests to stop-flag loops. Also fixes `analyze_commands::record_trace` which needed `network_packets: true` to populate `network_syscall`.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test`
- [x] `./scripts/run-integration-tests.sh trace_validation` — 25/25, run twice back-to-back
- [x] `./scripts/run-integration-tests.sh analyze_commands` — 1/1
- [x] `./scripts/run-integration-tests.sh memory_recorder` — 2/2
- [x] `bpftool map list` under `--only-recorder syscalls` confirms only `probe_ringbufs` + `stack_ringbufs` created
- [x] `bpftool map list` under `--only-recorder network-packets` confirms all three network families created
- [x] `--only-recorder markers` loads cleanly with `probe_ringbufs` disabled (rodata-gated `collect_syscalls` branch pruned by verifier)