### PR TITLE
Stop packet BPF probes at teardown and batch recorder consumption

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -2830,6 +2830,8 @@ int BPF_KRETPROBE(udp_recvmsg_exit, int ret)
 SEC("kprobe/udp_send_skb")
 int BPF_KPROBE(udp_send_skb_entry, struct sk_buff *skb, struct flowi4 *fl4, struct inet_cork *cork)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!skb || !fl4)
 		return 0;
 
@@ -2901,6 +2903,8 @@ int BPF_KPROBE(udp_send_skb_entry, struct sk_buff *skb, struct flowi4 *fl4, stru
 SEC("kprobe/udp_queue_rcv_one_skb")
 int BPF_KPROBE(udp_queue_rcv_one_skb_entry, struct sock *sk, struct sk_buff *skb)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk || !skb)
 		return 0;
 
@@ -2969,6 +2973,8 @@ int BPF_KPROBE(udp_queue_rcv_one_skb_entry, struct sock *sk, struct sk_buff *skb
 SEC("kprobe/__udp_enqueue_schedule_skb")
 int BPF_KPROBE(udp_enqueue_schedule_skb_entry, struct sock *sk, struct sk_buff *skb)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk || !skb)
 		return 0;
 
@@ -3037,6 +3043,8 @@ int BPF_KPROBE(udp_enqueue_schedule_skb_entry, struct sock *sk, struct sk_buff *
 SEC("kprobe/__tcp_transmit_skb")
 int BPF_KPROBE(tcp_transmit_skb_entry, struct sock *sk, struct sk_buff *skb, int clone_it, gfp_t gfp_mask, u32 rcv_nxt)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk || !skb)
 		return 0;
 
@@ -3209,6 +3217,8 @@ static __always_inline int emit_udp_packet_event(struct sock *sk, struct sk_buff
 SEC("tp_btf/net_dev_start_xmit")
 int BPF_PROG(net_dev_start_xmit, struct sk_buff *skb, struct net_device *dev)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!skb)
 		return 0;
 
@@ -3290,6 +3300,8 @@ static __always_inline int read_src_addr_from_skb(struct sk_buff *skb,
 SEC("kprobe/tcp_rcv_established")
 int BPF_KPROBE(tcp_rcv_established_entry, struct sock *sk, struct sk_buff *skb)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk || !skb)
 		return 0;
 
@@ -3348,6 +3360,8 @@ int BPF_KPROBE(tcp_rcv_established_entry, struct sock *sk, struct sk_buff *skb)
 SEC("kprobe/tcp_queue_rcv")
 int BPF_KPROBE(tcp_queue_rcv_entry, struct sock *sk, struct sk_buff *skb, bool *fragstolen)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk || !skb)
 		return 0;
 
@@ -3408,6 +3422,8 @@ int BPF_KPROBE(tcp_queue_rcv_entry, struct sock *sk, struct sk_buff *skb, bool *
 SEC("kprobe/tcp_data_queue")
 int BPF_KPROBE(tcp_data_queue_entry, struct sock *sk, struct sk_buff *skb)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk || !skb)
 		return 0;
 
@@ -3530,6 +3546,8 @@ int BPF_PROG(skb_copy_datagram_iovec, const struct sk_buff *skb, int len)
 SEC("kprobe/tcp_send_probe0")
 int BPF_KPROBE(tcp_send_probe0_entry, struct sock *sk)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk)
 		return 0;
 
@@ -3601,6 +3619,8 @@ int BPF_KPROBE(tcp_send_probe0_entry, struct sock *sk)
 SEC("kprobe/tcp_send_ack")
 int BPF_KPROBE(tcp_send_ack_entry, struct sock *sk)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk)
 		return 0;
 
@@ -3718,6 +3738,8 @@ int BPF_KPROBE(tcp_send_ack_entry, struct sock *sk)
 SEC("kprobe/tcp_retransmit_timer")
 int BPF_KPROBE(tcp_retransmit_timer_entry, struct sock *sk)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk)
 		return 0;
 
@@ -3974,6 +3996,8 @@ static __always_inline u64 get_socket_id_from_skb(struct sk_buff *skb)
 SEC("tracepoint/skb/kfree_skb")
 int tracepoint__skb__kfree_skb(struct trace_event_raw_kfree_skb *ctx)
 {
+	if (!tracing_enabled)
+		return 0;
 	// Get the SKB and check if it's associated with a tracked socket
 	struct sk_buff *skb = (struct sk_buff *)ctx->skbaddr;
 	u64 socket_id = get_socket_id_from_skb(skb);
@@ -4050,6 +4074,8 @@ struct {
 SEC("kprobe/enqueue_to_backlog")
 int BPF_KPROBE(enqueue_to_backlog_entry, struct sk_buff *skb, int cpu, unsigned int *qtail)
 {
+	if (!tracing_enabled)
+		return 0;
 	u64 socket_id = get_socket_id_from_skb(skb);
 	if (socket_id == 0)
 		return 0;
@@ -4068,6 +4094,8 @@ int BPF_KPROBE(enqueue_to_backlog_entry, struct sk_buff *skb, int cpu, unsigned 
 SEC("kretprobe/enqueue_to_backlog")
 int BPF_KRETPROBE(enqueue_to_backlog_exit, int ret)
 {
+	if (!tracing_enabled)
+		return 0;
 	u64 pid_tgid = bpf_get_current_pid_tgid();
 	struct backlog_entry *entry = bpf_map_lookup_elem(&pending_backlog, &pid_tgid);
 	if (!entry) {
@@ -4132,6 +4160,8 @@ int BPF_KRETPROBE(enqueue_to_backlog_exit, int ret)
 SEC("kprobe/sk_stream_wait_memory")
 int BPF_KPROBE(sk_stream_wait_memory_entry, struct sock *sk, long *timeo)
 {
+	if (!tracing_enabled)
+		return 0;
 	if (!sk)
 		return 0;
 
@@ -4231,6 +4261,8 @@ struct {
 SEC("tracepoint/qdisc/qdisc_enqueue")
 int tracepoint__qdisc__qdisc_enqueue(struct trace_event_raw_qdisc_enqueue *ctx)
 {
+	if (!tracing_enabled)
+		return 0;
 	struct sk_buff *skb = (struct sk_buff *)ctx->skbaddr;
 	if (!skb)
 		return 0;
@@ -4306,6 +4338,8 @@ int tracepoint__qdisc__qdisc_enqueue(struct trace_event_raw_qdisc_enqueue *ctx)
 SEC("tracepoint/qdisc/qdisc_dequeue")
 int tracepoint__qdisc__qdisc_dequeue(struct trace_event_raw_qdisc_dequeue *ctx)
 {
+	if (!tracing_enabled)
+		return 0;
 	// skb can be NULL if dequeue was attempted but queue was empty
 	struct sk_buff *skb = (struct sk_buff *)ctx->skbaddr;
 	if (!skb)

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -925,6 +925,8 @@ fn create_memory_ring<'a>(
     builder.build()
 }
 
+const CONSUME_BATCH: usize = 4096;
+
 fn consume_loop<T, N>(
     recorder: &Mutex<T>,
     rx: Receiver<N>,
@@ -938,34 +940,44 @@ fn consume_loop<T, N>(
     // Use a HashSet for deduplication - bloom filters have false positives which
     // can cause threads to not be recorded if the filter incorrectly says "seen"
     let mut seen_tasks: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut batch: Vec<N> = Vec::with_capacity(CONSUME_BATCH);
 
-    while let Ok(event) = rx.recv() {
-        // Send task_info to process discovery thread only if not already seen
-        if let Some(task_info) = event.next_task_info() {
-            if seen_tasks.insert(task_info.tgidpid) {
-                let _ = task_info_tx.send(*task_info);
+    // Block for the first event so an idle recorder doesn't spin, then drain
+    // whatever else is immediately available so we take the recorder lock once
+    // per batch instead of once per event.
+    'outer: while let Ok(first) = rx.recv() {
+        batch.push(first);
+        batch.extend(rx.try_iter().take(CONSUME_BATCH - 1));
+
+        for event in &batch {
+            // Send task_info to process discovery thread only if not already seen
+            if let Some(task_info) = event.next_task_info() {
+                if seen_tasks.insert(task_info.tgidpid) {
+                    let _ = task_info_tx.send(*task_info);
+                }
+            }
+            if let Some(task_info) = event.prev_task_info() {
+                if seen_tasks.insert(task_info.tgidpid) {
+                    let _ = task_info_tx.send(*task_info);
+                }
+            }
+
+            // Send event to pystack symbol loading thread only if it has Python stack data
+            // This avoids waking up the symbol loader thread for events without Python stacks
+            if let Some(ref tx) = pystack_symbol_tx {
+                if event.has_pystack() {
+                    tx.send(*event)
+                        .expect("Failed to send event to pystack symbol loader thread");
+                }
             }
         }
-        if let Some(task_info) = event.prev_task_info() {
-            if seen_tasks.insert(task_info.tgidpid) {
-                let _ = task_info_tx.send(*task_info);
+
+        let mut rec = recorder.lock().unwrap();
+        for event in batch.drain(..) {
+            if rec.record_event(event) {
+                let _ = stop_tx.send(());
+                break 'outer;
             }
-        }
-
-        // Send event to pystack symbol loading thread only if it has Python stack data
-        // This avoids waking up the symbol loader thread for events without Python stacks
-        if let Some(ref tx) = pystack_symbol_tx {
-            if event.has_pystack() {
-                tx.send(event)
-                    .expect("Failed to send event to pystack symbol loader thread");
-            }
-        }
-
-        let ret = recorder.lock().unwrap().record_event(event);
-
-        if ret {
-            let _ = stop_tx.send(());
-            break;
         }
     }
 }
@@ -1100,17 +1112,21 @@ fn spawn_recorder_threads(
                     // Use HashSet for deduplication - bloom filters have false positives
                     let mut seen_tasks: std::collections::HashSet<u64> =
                         std::collections::HashSet::new();
-                    while let Ok(event) = packet_rx.recv() {
-                        if let Some(task_info) = event.next_task_info() {
-                            if seen_tasks.insert(task_info.tgidpid) {
-                                session_recorder.maybe_record_task(task_info);
+                    let mut batch: Vec<packet_event> = Vec::with_capacity(CONSUME_BATCH);
+                    while let Ok(first) = packet_rx.recv() {
+                        batch.push(first);
+                        batch.extend(packet_rx.try_iter().take(CONSUME_BATCH - 1));
+                        for event in &batch {
+                            if let Some(task_info) = event.next_task_info() {
+                                if seen_tasks.insert(task_info.tgidpid) {
+                                    session_recorder.maybe_record_task(task_info);
+                                }
                             }
                         }
-                        session_recorder
-                            .network_recorder
-                            .lock()
-                            .unwrap()
-                            .handle_packet_event(event);
+                        let mut rec = session_recorder.network_recorder.lock().unwrap();
+                        for event in batch.drain(..) {
+                            rec.handle_packet_event(event);
+                        }
                     }
                     0
                 })?,
@@ -1125,17 +1141,21 @@ fn spawn_recorder_threads(
                     // Use HashSet for deduplication
                     let mut seen_tasks: std::collections::HashSet<u64> =
                         std::collections::HashSet::new();
-                    while let Ok(event) = epoll_rx.recv() {
-                        if let Some(task_info) = event.next_task_info() {
-                            if seen_tasks.insert(task_info.tgidpid) {
-                                session_recorder.maybe_record_task(task_info);
+                    let mut batch: Vec<epoll_event_bpf> = Vec::with_capacity(CONSUME_BATCH);
+                    while let Ok(first) = epoll_rx.recv() {
+                        batch.push(first);
+                        batch.extend(epoll_rx.try_iter().take(CONSUME_BATCH - 1));
+                        for event in &batch {
+                            if let Some(task_info) = event.next_task_info() {
+                                if seen_tasks.insert(task_info.tgidpid) {
+                                    session_recorder.maybe_record_task(task_info);
+                                }
                             }
                         }
-                        session_recorder
-                            .network_recorder
-                            .lock()
-                            .unwrap()
-                            .handle_epoll_event(event);
+                        let mut rec = session_recorder.network_recorder.lock().unwrap();
+                        for event in batch.drain(..) {
+                            rec.handle_epoll_event(event);
+                        }
                     }
                     0
                 })?,

--- a/tests/network_throughput.rs
+++ b/tests/network_throughput.rs
@@ -1,0 +1,121 @@
+//! Throughput benchmark for the network recorder hot path under lock contention.
+//!
+//! Reproduces the scenario where the network/packet/epoll consumer threads all
+//! contend on the single `Mutex<NetworkRecorder>`: compares locking once per
+//! event against locking once per batch of events. Run with:
+//!
+//!     cargo test --release --test network_throughput -- --ignored --nocapture
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Instant;
+
+use systing::network_recorder::NetworkRecorder;
+use systing::record::InMemoryCollector;
+use systing::systing_core::types::{
+    network_address_family, network_protocol, packet_event, packet_event_type,
+};
+use systing::utid::UtidGenerator;
+
+#[allow(clippy::field_reassign_with_default)]
+fn make_event(i: u64) -> packet_event {
+    let mut ev = packet_event::default();
+    ev.ts = 1_000_000_000 + i;
+    ev.protocol = network_protocol::NETWORK_TCP;
+    ev.af = network_address_family::NETWORK_AF_INET;
+    ev.src_addr[0] = 10;
+    ev.src_port = 12345;
+    ev.dest_addr[0] = 10;
+    ev.dest_addr[3] = 1;
+    ev.dest_port = 443;
+    ev.seq = i as u32;
+    ev.length = 1448;
+    ev.event_type = packet_event_type::PACKET_ENQUEUE;
+    // Cycle through a small set of socket ids so the seen_sockets set stays tiny.
+    ev.socket_id = 1 + (i % 16);
+    ev.sndbuf_used = 4096;
+    ev.sndbuf_limit = 65536;
+    ev
+}
+
+fn new_recorder() -> Arc<Mutex<NetworkRecorder>> {
+    let utid = Arc::new(UtidGenerator::new());
+    let mut rec = NetworkRecorder::new(utid, false);
+    rec.set_streaming_collector(Box::new(InMemoryCollector::new()));
+    Arc::new(Mutex::new(rec))
+}
+
+const THREADS: usize = 3;
+const EVENTS_PER_THREAD: u64 = 500_000;
+
+fn run_per_event() -> f64 {
+    let rec = new_recorder();
+    let start = Instant::now();
+    let handles: Vec<_> = (0..THREADS)
+        .map(|t| {
+            let rec = rec.clone();
+            thread::spawn(move || {
+                for i in 0..EVENTS_PER_THREAD {
+                    let ev = make_event(t as u64 * EVENTS_PER_THREAD + i);
+                    rec.lock().unwrap().handle_packet_event(ev);
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    (THREADS as u64 * EVENTS_PER_THREAD) as f64 / elapsed
+}
+
+fn run_batched(batch: usize) -> f64 {
+    let rec = new_recorder();
+    let start = Instant::now();
+    let handles: Vec<_> = (0..THREADS)
+        .map(|t| {
+            let rec = rec.clone();
+            thread::spawn(move || {
+                let mut buf = Vec::with_capacity(batch);
+                for i in 0..EVENTS_PER_THREAD {
+                    buf.push(make_event(t as u64 * EVENTS_PER_THREAD + i));
+                    if buf.len() == batch {
+                        let mut r = rec.lock().unwrap();
+                        for ev in buf.drain(..) {
+                            r.handle_packet_event(ev);
+                        }
+                    }
+                }
+                if !buf.is_empty() {
+                    let mut r = rec.lock().unwrap();
+                    for ev in buf.drain(..) {
+                        r.handle_packet_event(ev);
+                    }
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    (THREADS as u64 * EVENTS_PER_THREAD) as f64 / elapsed
+}
+
+#[test]
+#[ignore = "throughput benchmark, run manually with --release --nocapture"]
+fn network_recorder_lock_contention_throughput() {
+    let per_event = run_per_event();
+    let batched = run_batched(4096);
+    println!(
+        "handle_packet_event throughput under {}-way contention:",
+        THREADS
+    );
+    println!("  per-event lock: {:>10.0} events/s", per_event);
+    println!("  batched (4096): {:>10.0} events/s", batched);
+    println!("  speedup:        {:>10.1}x", batched / per_event);
+    assert!(
+        batched > per_event * 1.5,
+        "batched locking should be meaningfully faster than per-event"
+    );
+}


### PR DESCRIPTION
## Summary
Under heavy network load (e.g. 30 s at 90 Gbps) the drain after "Stopping..." could take many minutes.

- **Gate packet-path BPF probes on `tracing_enabled`.** The per-packet probes (`__tcp_transmit_skb`, `tcp_rcv_established`, `net_dev_start_xmit`, `qdisc_enqueue`/`dequeue`, `kfree_skb`, `enqueue_to_backlog`, `sk_stream_wait_memory`, UDP send/recv skb, etc.) never checked `tracing_enabled`, so they kept emitting after userspace flipped it. libbpf's `ring_buffer__consume` re-reads `producer_pos` in a loop, so the ringbuf reader stayed inside `consume()` blocked on `tx.send()` and never returned to see the shutdown eventfd until external traffic subsided. Added the guard at the top of the 17 probes that don't already go through `trace_task()`.
- **Batch recorder consumption.** `consume_loop` and the packet/epoll consumer threads took the `Mutex<NetworkRecorder>` once per event under 3-way contention. They now `recv()` one event, `try_iter().take()` up to `CONSUME_BATCH-1` more into a reused `Vec`, then lock once for the whole batch (`CONSUME_BATCH = 4096`).
- `tests/network_throughput.rs` — ignored microbench of the contended `handle_packet_event` path (per-event vs batched lock).

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --all-targets`
- [x] `cargo test --lib` (321 tests)
- [x] `./scripts/run-integration-tests.sh` — trace_validation 25/25
- [x] memory_recorder integration tests 2/2, analyze_commands 1/1
- [x] `cargo test --release --test network_throughput -- --ignored` — per-event 2.96M ev/s → batched 6.54M ev/s
- [ ] Validate on a high-throughput host that drain after 30 s at line rate is now seconds, not minutes