### PR TITLE
Discover override allocators for memory-alloc uprobes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y linux-tools-common libelf-dev linux-libc-dev clang libbpf-dev make pkg-config jq
+          sudo apt-get install -y linux-tools-common libelf-dev linux-libc-dev clang libbpf-dev make pkg-config jq libjemalloc2
       - uses: actions/checkout@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -51,7 +51,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y linux-tools-common libelf-dev linux-libc-dev clang libbpf-dev make pkg-config jq
+          sudo apt-get install -y linux-tools-common libelf-dev linux-libc-dev clang libbpf-dev make pkg-config jq libjemalloc2
       - uses: actions/checkout@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/install_deps.sh
+++ b/.github/workflows/install_deps.sh
@@ -3,7 +3,7 @@
 export DEBIAN_FRONTEND=noninteractive
 
 sudo apt-get install -y rustup linux-tools-common libelf-dev linux-libc-dev \
-    clang libbpf-dev make pkg-config jq \
+    clang libbpf-dev make pkg-config jq libjemalloc2 \
     --no-install-recommends
 
 # make errno/asm.h available.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,12 @@ struct Command {
     /// Sample 1 in N allocator calls (malloc/free/...) when the memory-alloc recorder is enabled (0 or 1 = record all). Note: values > 1 sample alloc and free independently, so addr-based alloc/free pairing for leak detection is unreliable; use for hotspot profiling.
     #[arg(long, default_value = "1")]
     memory_alloc_sample_rate: u32,
+    /// Override allocator library for memory-alloc uprobes. Absolute path is used verbatim (host namespace); bare name is resolved per-pid via /proc/<pid>/maps (container-safe). An absolute path also works around the pre-exec limitation when tracing via `-- <cmd>`.
+    #[arg(long)]
+    memory_alloc_lib: Option<String>,
+    /// Prefix prepended to malloc/free/... symbol names when attaching memory-alloc uprobes (e.g. "je_" for jemalloc built with --with-jemalloc-prefix).
+    #[arg(long)]
+    memory_alloc_symbol_prefix: Option<String>,
     // Network recording enabled state (set by recorder management, not a CLI flag)
     #[arg(skip)]
     network: bool,
@@ -175,6 +181,8 @@ impl From<Command> for Config {
             memory_fault_sample_rate: cmd.memory_fault_sample_rate,
             memory_alloc: cmd.memory_alloc,
             memory_alloc_sample_rate: cmd.memory_alloc_sample_rate,
+            memory_alloc_lib: cmd.memory_alloc_lib,
+            memory_alloc_symbol_prefix: cmd.memory_alloc_symbol_prefix,
             network: cmd.network,
             network_packets: cmd.network_packets,
             resolve_addresses: cmd.resolve_addresses,

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -523,6 +523,10 @@ pub struct Config {
     pub memory_alloc: bool,
     /// Sample 1 in N allocator calls (0 or 1 = record all)
     pub memory_alloc_sample_rate: u32,
+    /// Override allocator library for memory-alloc uprobes (path or bare name)
+    pub memory_alloc_lib: Option<String>,
+    /// Prefix prepended to malloc/free/... symbol names (e.g. "je_")
+    pub memory_alloc_symbol_prefix: Option<String>,
     /// Enable network recording
     pub network: bool,
     /// Enable network packet-level probes (sendmsg, recvmsg, transmit, qdisc, drops).
@@ -582,6 +586,8 @@ impl Default for Config {
             memory_fault_sample_rate: 97,
             memory_alloc: false,
             memory_alloc_sample_rate: 1,
+            memory_alloc_lib: None,
+            memory_alloc_symbol_prefix: None,
             network: false,
             network_packets: false,
             resolve_addresses: false,
@@ -1185,8 +1191,10 @@ fn spawn_recorder_threads(
         );
     }
 
-    // Conditionally spawn memory recorder
-    if opts.memory {
+    // Conditionally spawn memory recorder. The same ringbuf/consumer carries
+    // both `memory` (mmap/brk/fault/rss) and `memory-alloc` (malloc/free)
+    // events, so start it if either recorder is enabled.
+    if opts.memory || opts.memory_alloc {
         let session_recorder = recorder.clone();
         let my_stop_tx = stop_tx.clone();
         let my_task_tx = task_info_tx.clone();
@@ -2313,38 +2321,85 @@ fn collect_memory_alloc_target_pids(opts: &Config) -> Vec<u32> {
     pids.into_iter().collect()
 }
 
-/// Resolve the set of distinct libc binaries mapped by the target processes.
-/// Matches `libc.so`, `libc.so.6`, `libc-2.xx.so`, and musl's `libc.so`/
-/// `ld-musl-*.so` via `resolve_library_path_for_pid`. Paths are deduplicated
-/// by `(st_dev, st_ino)` so containers that share an image get exactly one
-/// set of uprobes. Returns `(unique-inode paths, distinct path-string count)`.
-fn discover_libc_paths(pids: &[u32]) -> (Vec<String>, usize) {
-    let mut raw_paths = HashSet::new();
-    for pid in pids {
-        for name in ["libc.so.6", "libc.so", "ld-musl"] {
-            if let Some(p) = resolve_library_path_for_pid(*pid, name) {
-                raw_paths.insert(p);
-                break;
-            }
-        }
-    }
-    let raw_count = raw_paths.len();
-    let mut seen_inodes: HashSet<(u64, u64)> = HashSet::new();
+/// Override allocator libraries, checked before libc. When one of these is
+/// LD_PRELOAD'd it interposes `malloc`/`free`/... and libc's copies never run,
+/// so uprobes on libc would silently miss. Bare substrings so the `.contains()`
+/// match in `resolve_library_path_for_pid` catches versioned sonames and
+/// variants (`.so.2`, `_minimal`, `_and_profiler`, `-secure`, `shim`).
+const OVERRIDE_ALLOCATORS: &[&str] = &["libjemalloc", "libtcmalloc", "libmimalloc", "libsnmalloc"];
+const LIBC_CANDIDATES: &[&str] = &["libc.so.6", "libc.so", "ld-musl"];
+
+/// Check whether the main executable of `pid` defines `malloc` itself (e.g.
+/// jemalloc/tcmalloc statically linked into the binary). Only a *defined*
+/// global text symbol counts — every glibc-linked binary has an *undefined*
+/// `malloc` import in `.dynsym`, which must not match. For dynamic exes only
+/// `.dynsym` governs interposition; `.symtab` is consulted only when the
+/// binary is fully static (no dynamic symbol table).
+pub fn exe_defines_malloc(pid: u32) -> Option<String> {
+    use object::{Object, ObjectSymbol, SymbolKind};
+    let exe = format!("/proc/{pid}/exe");
+    let data = std::fs::read(&exe).ok()?;
+    let file = object::File::parse(&*data).ok()?;
+    let defines = |s: object::Symbol| {
+        s.kind() == SymbolKind::Text
+            && s.is_global()
+            && !s.is_undefined()
+            && s.name() == Ok("malloc")
+    };
+    let hit = if file.dynamic_symbols().next().is_some() {
+        file.dynamic_symbols().any(defines)
+    } else {
+        file.symbols().any(defines)
+    };
+    hit.then_some(exe)
+}
+
+/// Collapse allocator paths that refer to the same on-disk inode so containers
+/// sharing an image get exactly one set of uprobes. Returns surviving
+/// `(path, match-reason)` pairs plus the pre-dedup path-string count.
+fn dedup_by_inode(raw: HashMap<String, &'static str>) -> (Vec<(String, &'static str)>, usize) {
+    let raw_count = raw.len();
+    let mut seen: HashSet<(u64, u64)> = HashSet::new();
     let mut unique = Vec::new();
-    for p in raw_paths {
-        match std::fs::metadata(&p) {
-            // insert() returns false if the (dev, ino) was already present:
-            // drop this path as a duplicate of one we kept.
-            Ok(meta) if !seen_inodes.insert((meta.dev(), meta.ino())) => {}
-            _ => unique.push(p),
+    for (path, reason) in raw {
+        match std::fs::metadata(&path) {
+            Ok(meta) if !seen.insert((meta.dev(), meta.ino())) => {}
+            _ => unique.push((path, reason)),
         }
     }
     (unique, raw_count)
 }
 
-/// Attach malloc/free/... uprobes to each discovered libc. Probes are attached
-/// with pid=-1 so every process sharing that libc is covered; BPF-side
-/// `trace_task()` enforces the configured pid/cgroup filter.
+/// Resolve the set of distinct allocator binaries for the target processes.
+/// Resolution order per pid, first match wins: LD_PRELOAD-style override
+/// (`OVERRIDE_ALLOCATORS`) → the main exe if it statically defines `malloc`
+/// → libc/musl. Paths are deduplicated by `(st_dev, st_ino)`.
+fn discover_allocator_paths(pids: &[u32]) -> (Vec<(String, &'static str)>, usize) {
+    let mut raw: HashMap<String, &'static str> = HashMap::new();
+    'pid: for pid in pids {
+        for name in OVERRIDE_ALLOCATORS {
+            if let Some(p) = resolve_library_path_for_pid(*pid, name) {
+                raw.entry(p).or_insert(name);
+                continue 'pid;
+            }
+        }
+        if let Some(p) = exe_defines_malloc(*pid) {
+            raw.entry(p).or_insert("static in exe");
+            continue 'pid;
+        }
+        for name in LIBC_CANDIDATES {
+            if let Some(p) = resolve_library_path_for_pid(*pid, name) {
+                raw.entry(p).or_insert(name);
+                continue 'pid;
+            }
+        }
+    }
+    dedup_by_inode(raw)
+}
+
+/// Attach malloc/free/... uprobes to each discovered allocator library. Probes
+/// are attached with pid=-1 so every process sharing that library is covered;
+/// BPF-side `trace_task()` enforces the configured pid/cgroup filter.
 fn attach_memory_alloc_uprobes(
     skel: &mut SystingSystemSkel,
     opts: &Config,
@@ -2357,14 +2412,50 @@ fn attach_memory_alloc_uprobes(
         return Ok(Vec::new());
     }
 
-    let (libc_paths, raw_path_count) = discover_libc_paths(&pids);
-    if libc_paths.is_empty() {
-        eprintln!(
-            "Warning: memory-alloc recorder could not locate libc in /proc/<pid>/maps for any target; no uprobes attached"
-        );
-        return Ok(Vec::new());
+    let (alloc_paths, raw_path_count) = match &opts.memory_alloc_lib {
+        Some(lib) if std::path::Path::new(lib).is_absolute() => {
+            if !std::path::Path::new(lib).exists() {
+                eprintln!(
+                    "Warning: --memory-alloc-lib '{lib}' does not exist; no uprobes attached"
+                );
+                return Ok(Vec::new());
+            }
+            dedup_by_inode(HashMap::from([(lib.clone(), "--memory-alloc-lib")]))
+        }
+        Some(lib) => {
+            let mut raw: HashMap<String, &'static str> = HashMap::new();
+            for pid in &pids {
+                if let Some(p) = resolve_library_path_for_pid(*pid, lib) {
+                    raw.entry(p).or_insert("--memory-alloc-lib");
+                }
+            }
+            if raw.is_empty() {
+                eprintln!(
+                    "Warning: --memory-alloc-lib '{lib}' not found in any target's /proc/<pid>/maps; no uprobes attached"
+                );
+                return Ok(Vec::new());
+            }
+            dedup_by_inode(raw)
+        }
+        None => {
+            let (paths, raw_count) = discover_allocator_paths(&pids);
+            if paths.is_empty() {
+                eprintln!(
+                    "Warning: memory-alloc recorder could not locate an allocator (tried {}, /proc/<pid>/exe, {}); no uprobes attached",
+                    OVERRIDE_ALLOCATORS.join("/"),
+                    LIBC_CANDIDATES.join("/"),
+                );
+                return Ok(Vec::new());
+            }
+            (paths, raw_count)
+        }
+    };
+
+    for (path, reason) in &alloc_paths {
+        println!("memory-alloc: attaching to {path} (matched: {reason})");
     }
 
+    let prefix = opts.memory_alloc_symbol_prefix.as_deref().unwrap_or("");
     let probes: &[(&libbpf_rs::ProgramMut, &str, bool)] = &[
         (&skel.progs.systing_malloc_enter, "malloc", false),
         (&skel.progs.systing_malloc_exit, "malloc", true),
@@ -2396,15 +2487,16 @@ fn attach_memory_alloc_uprobes(
     ];
 
     let mut links = Vec::new();
-    for path in &libc_paths {
+    for (path, _) in &alloc_paths {
         for (prog, func, ret) in probes {
+            let func_name = format!("{prefix}{func}");
             match prog.attach_uprobe_with_opts(
                 -1,
                 path,
                 0,
                 UprobeOpts {
                     retprobe: *ret,
-                    func_name: Some(func.to_string()),
+                    func_name: Some(func_name.clone()),
                     ..Default::default()
                 },
             ) {
@@ -2413,16 +2505,16 @@ fn attach_memory_alloc_uprobes(
                     "Warning: failed to attach {}uprobe {}:{}: {}",
                     if *ret { "ret" } else { "" },
                     path,
-                    func,
+                    func_name,
                     e
                 ),
             }
         }
     }
     println!(
-        "memory-alloc: attached {} uprobe(s) across {} libc inode(s) (from {} path(s))",
+        "memory-alloc: attached {} uprobe(s) across {} allocator inode(s) (from {} path(s))",
         links.len(),
-        libc_paths.len(),
+        alloc_paths.len(),
         raw_path_count
     );
     Ok(links)
@@ -2842,7 +2934,7 @@ fn run_tracing_loop(
         println!("Missed packet events: {}", dump_missed_events(skel, 5));
         println!("Missed poll events: {}", dump_missed_events(skel, 6));
     }
-    if opts.memory {
+    if opts.memory || opts.memory_alloc {
         println!("Missed memory events: {}", dump_missed_events(skel, 8));
     }
     if opts.memory_alloc {

--- a/tests/memory_recorder.rs
+++ b/tests/memory_recorder.rs
@@ -380,3 +380,183 @@ fn test_memory_alloc_e2e() {
 
     eprintln!("\ntest_memory_alloc_e2e: all checks passed");
 }
+
+/// Trace `run_cmd` with the memory-alloc recorder and return the number of
+/// `malloc` rows attributed to the workload pid. Returns 0 if no parquet was
+/// emitted (i.e., no uprobes attached / no events).
+fn count_malloc_rows(run_cmd: Vec<String>, memory_alloc_lib: Option<String>) -> i64 {
+    setup_bpf_environment();
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let traced_child =
+        systing::traced_command::spawn_traced_child(&run_cmd).expect("Failed to spawn child");
+    let child_pid = traced_child.pid as i32;
+    let config = Config {
+        memory_alloc: true,
+        memory_alloc_sample_rate: 1,
+        memory_alloc_lib,
+        parquet_only: true,
+        output_dir: dir.path().to_path_buf(),
+        output: dir.path().join("trace.pb"),
+        ..Config::default()
+    };
+    let exit_code = systing(config, Some(traced_child)).expect("systing recording failed");
+    assert_eq!(exit_code, 0, "allocator workload should exit cleanly");
+    if !dir.path().join("memory_alloc.parquet").exists() {
+        return 0;
+    }
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "allotest")
+        .expect("DuckDB conversion failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+    conn.query_row(
+        &format!(
+            "SELECT COUNT(*) FROM memory_alloc WHERE op = 'malloc' AND utid IN {UTIDS_FOR_PID}"
+        ),
+        [child_pid],
+        |row| row.get(0),
+    )
+    .expect("Failed to query memory_alloc")
+}
+
+fn small_malloc_workload() -> Vec<String> {
+    vec![
+        "python3".to_string(),
+        "-c".to_string(),
+        "objs=[bytes(512) for _ in range(2000)]\ndel objs\nimport time; time.sleep(0.1)\n"
+            .to_string(),
+    ]
+}
+
+fn find_jemalloc() -> Option<String> {
+    let out = std::process::Command::new("ldconfig")
+        .arg("-p")
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .find(|l| l.contains("libjemalloc.so"))
+        .and_then(|l| l.split("=> ").nth(1))
+        .map(|p| p.trim().to_string())
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_memory_alloc_jemalloc_preload() {
+    let Some(jemalloc) = find_jemalloc() else {
+        eprintln!("SKIP: libjemalloc not found via ldconfig -p");
+        return;
+    };
+    eprintln!("Using LD_PRELOAD={jemalloc}");
+    setup_bpf_environment();
+    let dir = TempDir::new().expect("Failed to create temp dir");
+
+    // Spawn the workload independently (not via spawn_traced_child) so that
+    // allocator discovery scans a process that has already exec'd and mapped
+    // jemalloc. Run-command mode attaches pre-exec and would only see the
+    // parent's libc.
+    let mut child = std::process::Command::new("python3")
+        .env("LD_PRELOAD", &jemalloc)
+        .arg("-c")
+        .arg(
+            "import time\n\
+             for _ in range(1000):\n\
+             \x20 objs=[bytes(512) for _ in range(200)]\n\
+             \x20 del objs\n\
+             \x20 time.sleep(0.005)\n",
+        )
+        .spawn()
+        .expect("Failed to spawn jemalloc workload");
+    let child_pid = child.id();
+    let mut mapped = false;
+    for _ in 0..50 {
+        mapped = std::fs::read_to_string(format!("/proc/{child_pid}/maps"))
+            .map(|m| m.contains("libjemalloc"))
+            .unwrap_or(false);
+        if mapped {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(
+        mapped,
+        "libjemalloc never appeared in /proc/{child_pid}/maps; LD_PRELOAD ineffective?"
+    );
+
+    let config = Config {
+        memory_alloc: true,
+        memory_alloc_sample_rate: 1,
+        pid: vec![child_pid],
+        duration: 2,
+        parquet_only: true,
+        output_dir: dir.path().to_path_buf(),
+        output: dir.path().join("trace.pb"),
+        ..Config::default()
+    };
+    let exit_code = systing(config, None).expect("systing recording failed");
+    assert_eq!(exit_code, 0);
+    let _ = child.kill();
+    let _ = child.wait();
+
+    assert!(
+        dir.path().join("memory_alloc.parquet").exists(),
+        "memory_alloc.parquet not written (discovery missed jemalloc?)"
+    );
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "jetest")
+        .expect("DuckDB conversion failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+    let rows: i64 = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*) FROM memory_alloc WHERE op = 'malloc' AND utid IN {UTIDS_FOR_PID}"
+            ),
+            [child_pid as i64],
+            |row| row.get(0),
+        )
+        .expect("Failed to query memory_alloc");
+    assert!(
+        rows > 0,
+        "[memory_alloc] expected malloc rows with jemalloc preloaded, got 0"
+    );
+    eprintln!("    {rows} malloc events recorded under jemalloc");
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_memory_alloc_lib_override_name() {
+    // spawn_traced_child resolves the override against the forked child's
+    // pre-exec maps (== this test binary's maps). That's fine here because the
+    // test binary and python3 share the system libc.so.6.
+    let rows = count_malloc_rows(small_malloc_workload(), Some("libc.so.6".to_string()));
+    assert!(
+        rows > 0,
+        "[memory_alloc] expected malloc rows with --memory-alloc-lib libc.so.6, got 0"
+    );
+    eprintln!("    {rows} malloc events via --memory-alloc-lib name override");
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_memory_alloc_lib_override_bad_path() {
+    let rows = count_malloc_rows(
+        small_malloc_workload(),
+        Some("/nonexistent/liballoc.so".to_string()),
+    );
+    assert_eq!(
+        rows, 0,
+        "[memory_alloc] expected 0 rows for nonexistent --memory-alloc-lib, got {rows}"
+    );
+}
+
+/// Regression guard: a dynamically-linked binary lists `malloc` as an
+/// *undefined* import in `.dynsym`; `exe_defines_malloc` must not treat that
+/// as a locally-defined allocator.
+#[test]
+fn test_exe_defines_malloc_negative() {
+    let self_pid = std::process::id();
+    assert_eq!(
+        systing::systing_core::exe_defines_malloc(self_pid),
+        None,
+        "test binary is glibc-linked; exe_defines_malloc should return None"
+    );
+}


### PR DESCRIPTION
## Summary

- The memory-alloc recorder only targeted `libc.so.6`/`libc.so`/`ld-musl`. When jemalloc/tcmalloc/mimalloc/snmalloc is `LD_PRELOAD`'d it interposes `malloc`/`free`/... and libc's copies never run, so the uprobes fire on dead code and `memory_alloc` is silently empty. `discover_libc_paths` → `discover_allocator_paths` with a 3-tier per-pid resolution: override `.so` → `exe_defines_malloc()` (statically-linked allocators in the main binary) → libc/musl.
- Adds `--memory-alloc-lib <path|name>` (explicit override, container-safe in name form) and `--memory-alloc-symbol-prefix <p>` (for `je_`-prefixed jemalloc builds). Logs the chosen path(s) and match reason so a misfired attach is debuggable from stdout.
- Fixes a pre-existing bug: the memory-event consumer thread was gated on `opts.memory` only, so `--only-recorder memory-alloc` attached uprobes but never drained the ringbuf. Both recorders share one ringbuf/consumer, so start it if either is enabled.
- Factors the `(st_dev, st_ino)` dedup into `dedup_by_inode()` shared by discovery and the override branch.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --all-targets` — clean
- [x] `cargo test` — 355 passed incl. new `test_exe_defines_malloc_negative` regression guard
- [x] `./scripts/run-integration-tests.sh memory_recorder` — 5 passed: existing `test_memory_recorder_e2e` / `test_memory_alloc_e2e` unchanged; new `test_memory_alloc_jemalloc_preload` (LD_PRELOAD jemalloc, trace by pid, assert rows), `test_memory_alloc_lib_override_name`, `test_memory_alloc_lib_override_bad_path`
- [x] `./scripts/run-integration-tests.sh trace_validation` — 25 passed
- [x] `./scripts/run-integration-tests.sh network_throughput`, `analyze_commands` — passed
- [x] Added `libjemalloc2` to CI apt lists so the preload test runs in CI rather than skipping
- [x] Patch version bump (1.6.1 → 1.6.2), no schema change