### PR TITLE
Fix recorder selection for stack collection and pystacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.6.3"
+version = "1.6.4"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.6.2"
+version = "1.6.3"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ This will display all available recorders and their default states:
 - `interruptible-stacks` - Interruptible sleep stack traces (on by default, requires sleep-stacks)
 - `cpu-stacks` - CPU perf stack traces (on by default)
 - `network` - Network traffic recording (TCP/UDP send/receive and packet-level latency)
-- `pystacks` - Python stack tracing
+
+Python stack symbolization is not a recorder; enable it with `--collect-pystacks`, which resolves Python frames in whichever stacks the active recorders collect.
 
 Note: `sleep-stacks` acts as a master switch for all sleep stack collection. When enabled,
 both uninterruptible (D state) and interruptible (S state) sleep stacks are collected by

--- a/skills/systing-trace/SKILL.md
+++ b/skills/systing-trace/SKILL.md
@@ -50,7 +50,6 @@ systing --list-recorders
 | `interruptible-stacks` | on | Interruptible sleep (S-state) stacks |
 | `syscalls` | off | All syscall entry/exit |
 | `network` | off | TCP/UDP packets, syscalls, retransmits, RTT |
-| `pystacks` | off | Python stack frames (CPython 3.8–3.13) |
 | `markers` | off | Userspace marker events (via `faccessat2`) |
 | `tpu` | off | TPU op-level profile via XLA runtime gRPC (port 8466) |
 | `tpu-metrics` | off | TPU runtime metrics polling (port 8431, lightweight) |
@@ -74,7 +73,7 @@ sudo systing --only-recorder sched --only-recorder network -d 10 --output trace.
 | `-d <SEC>` | Duration in seconds (0 = until Ctrl-C or command exits) |
 | `--output <PATH>` | Output file; `.duckdb` extension → DuckDB, `.pb`/`.perfetto` → Perfetto |
 | `--output-dir <DIR>` | Directory for intermediate parquet files (default `./traces`) |
-| `--collect-pystacks` | Enable Python stack tracing (shortcut for `--add-recorder pystacks`) |
+| `--collect-pystacks` | Enable Python stack symbolization (resolves Python frames in user stacks) |
 | `--enable-debuginfod` | Better symbol resolution (requires `DEBUGINFOD_URLS` env var) |
 | `--no-stack-traces` | Disable all stack trace collection |
 | `--marker-threshold <N>` | Stop after N marker instant events |

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -73,6 +73,9 @@ const volatile struct {
 	u32 memory_fault_sample_rate; /* Sample 1 in N page faults (0 or 1 = all) */
 	u32 memory_alloc_sample_rate; /* Sample 1 in N malloc/free calls (0 or 1 = all) */
 	u32 page_size;         /* sysconf(_SC_PAGESIZE) for page-count -> byte conversion */
+	u32 no_sched;          /* Sched recorder off: sched_switch still runs for
+				* cpu_running_pid and sleep stacks, but task_event
+				* emission is suppressed. */
 } tool_config = {};
 
 enum event_type {
@@ -1691,26 +1694,45 @@ static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev
 	if (!trace_task(prev) && !trace_task(next))
 		return 0;
 
-	event = reserve_task_event(&flags);
-	if (!event)
-		return handle_missed_event(MISSED_SCHED_EVENT);
-
-	event->ts = ts;
-	event->type = SCHED_SWITCH;
-	event->cpu = bpf_get_smp_processor_id();
-	record_task_info(&event->next, next);
-	record_task_info(&event->prev, prev);
 	/*
-	 * Convert raw task state to ftrace format (mask to TASK_REPORT bits + preemption).
-	 * The kernel stores exit states (EXIT_ZOMBIE, EXIT_DEAD) in a separate exit_state
-	 * field, so we must OR the kernel-provided prev_state (captured at the right moment)
-	 * with exit_state to get the complete task state.
-	 * See kernel's __task_state_index() in include/linux/sched.h.
+	 * Scheduler recorder may be off while stack collection is on (e.g.
+	 * `--only-recorder cpu-stacks`). The sched_switch program still has
+	 * to run unconditionally to keep cpu_running_pid current for
+	 * STACK_RUNNING gating and to emit sleep stacks, but we must not
+	 * emit the scheduler task_event itself in that mode.
 	 */
-	event->prev_state = preempt ? TASK_REPORT_MAX : ((prev_state | prev->exit_state) & TASK_REPORT);
-	event->next_prio = next->prio;
-	event->prev_prio = prev->prio;
-	bpf_ringbuf_submit(event, flags);
+	if (!tool_config.no_sched) {
+		event = reserve_task_event(&flags);
+		if (!event) {
+			/*
+			 * Intentional fall-through: previously this returned
+			 * early on missed events, but the sleep-stack ringbuf
+			 * is independent of `ringbufs`, so a full sched ring
+			 * shouldn't cascade into dropping the sleep stack.
+			 */
+			handle_missed_event(MISSED_SCHED_EVENT);
+		} else {
+			event->ts = ts;
+			event->type = SCHED_SWITCH;
+			event->cpu = bpf_get_smp_processor_id();
+			record_task_info(&event->next, next);
+			record_task_info(&event->prev, prev);
+			/*
+			 * Convert raw task state to ftrace format (mask to
+			 * TASK_REPORT bits + preemption). The kernel stores
+			 * exit states (EXIT_ZOMBIE, EXIT_DEAD) in a separate
+			 * exit_state field, so we must OR the kernel-provided
+			 * prev_state (captured at the right moment) with
+			 * exit_state to get the complete task state. See
+			 * kernel's __task_state_index() in include/linux/sched.h.
+			 */
+			event->prev_state = preempt ? TASK_REPORT_MAX :
+				((prev_state | prev->exit_state) & TASK_REPORT);
+			event->next_prio = next->prio;
+			event->prev_prio = prev->prio;
+			bpf_ringbuf_submit(event, flags);
+		}
+	}
 
 	/*
 	 * Record the blocked stack trace for sleep states.

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,6 @@ fn enable_recorder(opts: &mut Command, recorder_name: &str, enable: bool) {
                 opts.memory = true;
             }
         }
-        "pystacks" => opts.collect_pystacks = enable,
         "markers" => opts.markers = enable,
         "tpu-metrics" => opts.tpu_metrics = enable,
         _ => unreachable!("validated recorder name not handled: {recorder_name}"),
@@ -257,7 +256,6 @@ fn process_recorder_options(opts: &mut Command) -> Result<()> {
         opts.memory_alloc = false;
         opts.network = false;
         opts.network_packets = false;
-        opts.collect_pystacks = false;
         opts.markers = false;
         opts.tpu_profile = false;
         opts.tpu_metrics = false;

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -158,6 +158,18 @@ const SCHED_BPF_PROGRAMS: &[&str] = &[
     "systing_softirq_exit",
 ];
 
+/// Stack-collection recorders (cpu-stacks, sleep-stacks, interruptible-stacks)
+/// depend on `systing_sched_switch` even when the scheduler recorder is off:
+/// it populates `cpu_running_pid` (the gate for STACK_RUNNING samples) and is
+/// where sleep/interruptible stacks are emitted. The `task_event` emission for
+/// the scheduler itself is gated separately in BPF by `tool_config.no_sched`,
+/// so loading the program here does not produce sched events.
+///
+/// Because the program references the `ringbufs` map, that family must also
+/// be autocreated whenever this program is loaded (see
+/// `get_required_ringbuf_families`).
+const SCHED_SWITCH_FOR_STACKS: &[&str] = &["systing_sched_switch"];
+
 const SYSCALL_BPF_PROGRAMS: &[&str] = &[
     "tracepoint__raw_syscalls__sys_enter",
     "tracepoint__raw_syscalls__sys_exit",
@@ -253,22 +265,22 @@ pub fn get_available_recorders() -> Vec<RecorderInfo> {
             name: "sleep-stacks",
             description: "Sleep stack traces",
             default_enabled: true,
-            bpf_programs: &[],
-            ringbuf_families: &[],
+            bpf_programs: SCHED_SWITCH_FOR_STACKS,
+            ringbuf_families: &["ringbufs"],
         },
         RecorderInfo {
             name: "interruptible-stacks",
             description: "Interruptible sleep stack traces",
             default_enabled: true,
-            bpf_programs: &[],
-            ringbuf_families: &[],
+            bpf_programs: SCHED_SWITCH_FOR_STACKS,
+            ringbuf_families: &["ringbufs"],
         },
         RecorderInfo {
             name: "cpu-stacks",
             description: "CPU perf stack traces",
             default_enabled: true,
-            bpf_programs: &[],
-            ringbuf_families: &[],
+            bpf_programs: SCHED_SWITCH_FOR_STACKS,
+            ringbuf_families: &["ringbufs"],
         },
         RecorderInfo {
             name: "network",
@@ -1991,6 +2003,7 @@ fn configure_bpf_skeleton(
         rodata.tool_config.no_sleep_stack_traces = opts.no_sleep_stack_traces as u32;
         rodata.tool_config.no_interruptible_stack_traces =
             opts.no_interruptible_stack_traces as u32;
+        rodata.tool_config.no_sched = opts.no_sched as u32;
         rodata.tool_config.confidentiality_mode = detect_confidentiality_mode();
         if !opts.cgroup.is_empty() {
             rodata.tool_config.filter_cgroup = 1;

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -299,13 +299,6 @@ pub fn get_available_recorders() -> Vec<RecorderInfo> {
             ringbuf_families: &["memory_ringbufs"],
         },
         RecorderInfo {
-            name: "pystacks",
-            description: "Python stack tracing",
-            default_enabled: false,
-            bpf_programs: &[],
-            ringbuf_families: &[],
-        },
-        RecorderInfo {
             name: "markers",
             description: "Userspace marker events (faccessat2 with mode=-975)",
             default_enabled: false,
@@ -362,7 +355,6 @@ fn is_recorder_enabled(name: &str, opts: &Config) -> bool {
         "memory-alloc" => opts.memory_alloc,
         "network" => opts.network,
         "network-packets" => opts.network_packets,
-        "pystacks" => opts.collect_pystacks,
         "markers" => opts.markers,
         "tpu" => opts.tpu_profile,
         "tpu-metrics" => opts.tpu_metrics,

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -3450,3 +3450,133 @@ fn test_network_dns_resolution() {
 
     eprintln!("  All DNS resolution checks passed");
 }
+
+/// Regression test: `--only-recorder cpu-stacks` must still emit STACK_RUNNING
+/// samples even though the scheduler recorder is disabled.
+///
+/// CPU stack samples are gated in BPF by `cpu_running_pid`, which is populated
+/// by `systing_sched_switch`. If the sched programs are not loaded when only
+/// cpu-stacks is requested, `cpu_running_pid` stays empty and every
+/// STACK_RUNNING sample from the perf clock is dropped. The fix is to load the
+/// sched_switch program when stack collection is enabled and to gate the
+/// scheduler `task_event` emission separately on the sched recorder.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_e2e_only_cpu_stacks_emits_samples() {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+
+    setup_bpf_environment();
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+
+    // CPU-bound workload to give the perf clock something to sample.
+    let stop = Arc::new(AtomicBool::new(false));
+    let workload_handle = {
+        let stop = stop.clone();
+        thread::spawn(move || {
+            let mut acc: u64 = 0;
+            while !stop.load(Ordering::Relaxed) {
+                for i in 0..100_000u64 {
+                    acc = acc.wrapping_add(i.wrapping_mul(i));
+                }
+                std::hint::black_box(acc);
+            }
+        })
+    };
+
+    // Mirror what `--only-recorder cpu-stacks` produces in main.rs:
+    // every other recorder is off, including the scheduler.
+    let config = Config {
+        duration: 4,
+        output_dir: dir.path().to_path_buf(),
+        no_sched: true,
+        no_cpu_stack_traces: false,
+        no_sleep_stack_traces: true,
+        no_interruptible_stack_traces: true,
+        syscalls: false,
+        memory: false,
+        memory_alloc: false,
+        network: false,
+        network_packets: false,
+        markers: false,
+        collect_pystacks: false,
+        parquet_only: true,
+        ..Config::default()
+    };
+
+    systing(config, None).expect("systing recording failed");
+    stop.store(true, Ordering::Relaxed);
+    workload_handle.join().expect("Workload thread panicked");
+
+    let stack_sample_path = dir.path().join("stack_sample.parquet");
+    assert!(
+        stack_sample_path.exists(),
+        "stack_sample.parquet not produced by --only-recorder cpu-stacks"
+    );
+
+    let file = File::open(&stack_sample_path).expect("Failed to open stack_sample.parquet");
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).expect("Failed to create reader");
+    let reader = builder.build().expect("Failed to build reader");
+
+    let mut running_samples = 0u64;
+    let mut other_samples = 0u64;
+    for batch_result in reader {
+        let batch = batch_result.expect("Failed to read batch");
+        let event_type_col = batch
+            .column_by_name("stack_event_type")
+            .expect("stack_event_type column missing")
+            .as_any()
+            .downcast_ref::<arrow::array::Int8Array>()
+            .expect("stack_event_type should be Int8");
+        for i in 0..batch.num_rows() {
+            match event_type_col.value(i) {
+                1 => running_samples += 1,
+                _ => other_samples += 1,
+            }
+        }
+    }
+
+    eprintln!(
+        "  --only-recorder cpu-stacks produced running={running_samples}, other={other_samples}"
+    );
+    // The perf clock samples at ~1 kHz per CPU and the workload pegs a core
+    // for 4s, so we expect hundreds of samples. Setting a floor (rather than
+    // `> 0`) catches a "only one CPU's cpu_running_pid ever populated"
+    // regression that a single sample would mask.
+    assert!(
+        running_samples > 10,
+        "--only-recorder cpu-stacks produced too few STACK_RUNNING samples \
+         (running={running_samples}, other={other_samples}); \
+         sched_switch must load to populate cpu_running_pid on every CPU"
+    );
+
+    // Scheduler recorder is off, so no sleep stacks should sneak in.
+    assert_eq!(
+        other_samples, 0,
+        "Unexpected non-RUNNING stack samples emitted while --only-recorder cpu-stacks: \
+         got {other_samples}"
+    );
+
+    // Sanity: scheduler outputs must not be produced when sched is disabled.
+    let sched_slice = dir.path().join("sched_slice.parquet");
+    if sched_slice.exists() {
+        let file = File::open(&sched_slice).expect("Failed to open sched_slice.parquet");
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+            .expect("Failed to create sched_slice reader");
+        let reader = builder.build().expect("Failed to build sched_slice reader");
+        let mut sched_rows = 0u64;
+        for batch_result in reader {
+            let batch = batch_result.expect("Failed to read sched_slice batch");
+            sched_rows += batch.num_rows() as u64;
+        }
+        assert_eq!(
+            sched_rows, 0,
+            "--only-recorder cpu-stacks produced {sched_rows} sched_slice rows; \
+             scheduler events should not be emitted to userspace when sched is off"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Drop pystacks from the recorder list — it's a symbolization feature, not a recorder. `--collect-pystacks` is the single source of truth; recorder selection no longer silently turns off Python symbolization.
- Fix `--only-recorder cpu-stacks` (and sibling stack recorders) emitting no samples. Stack recorders now declare `sched_switch` + ringbufs as dependencies, and a `no_sched` rodata gate suppresses the scheduler `task_event` while keeping `sched_switch` available for stack tracking.

## Test plan
- [ ] `cargo test`
- [ ] `./scripts/run-integration-tests.sh trace_validation`
- [ ] Manually verify `--only-recorder cpu-stacks` produces stack samples
- [ ] Manually verify `--only-recorder X --collect-pystacks` still symbolizes Python frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)