### PR TITLE
Fix CPU stack samples being dropped before first sched_switch on a CPU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.6.4"
+version = "1.6.5"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.6.4"
+version = "1.6.5"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -1510,14 +1510,20 @@ static void emit_stack_event_with_ts(void *ctx, struct task_struct *task,
 	 * window between sched_switch (where we update cpu_running_pid) and
 	 * the actual context switch (where 'current' is updated).
 	 *
-	 * At startup (before any sched_switch on this CPU), expected_pid is 0
-	 * and samples are dropped. The userspace validation handles this by
-	 * skipping samples that occur before the first sched_slice.
+	 * At startup (before any sched_switch on this CPU), expected_pid is 0.
+	 * The race we're guarding against requires sched_switch to have set
+	 * the slot to a real PID, so a 0 slot cannot indicate a race — let the
+	 * sample through. This matters on idle many-core machines: a CPU-bound
+	 * task that was already running when the trace started can run for the
+	 * entire trace without a single sched_switch on its CPU, and dropping
+	 * those samples loses all CPU stacks for that task.
 	 */
 	if (type == STACK_RUNNING) {
 		u32 key = 0;
 		u32 *expected_pid = bpf_map_lookup_elem(&cpu_running_pid, &key);
-		if (!expected_pid || *expected_pid != task->pid)
+		if (!expected_pid)
+			return;
+		if (*expected_pid != 0 && *expected_pid != task->pid)
 			return;
 	}
 


### PR DESCRIPTION
## Problem

The pystacks integration tests were intermittently failing on a 64-core box (`test_pystacks_python311`, `test_pystacks_python313`, `test_pystacks_symbol_resolution` — different test each run). Failure mode was always the same: zero Python frames captured for the busy-looping workload.

Debug stats from a captured failure:
```
[pystacks debug] stats: with_pystack=0 without_pystack=20534 ...
```
Stacks were captured fine for other processes — just none for the Python workload.

## Root cause

The `cpu_running_pid` gate added in 7cc4505 drops a STACK_RUNNING sample whenever the per-CPU slot doesn't match the current task. The slot is only populated by `sched_switch`, so it stays `0` from trace start until the first context switch on that CPU. Until then, every CPU sample on that CPU is silently discarded.

On an idle many-core machine, a CPU-bound process that was already running when the trace started can run for the entire trace duration without a single `sched_switch` ever firing on its CPU — nothing else needs that core, so the scheduler never preempts it. Whether a stray kworker/RCU/timer happens to wake on that exact CPU within the window is essentially random, hence the flakiness.

This isn't just a test problem: anyone profiling a CPU-bound process that was already running before `systing` started, on a machine with idle headroom, would silently lose all CPU stacks for that process.

## Fix

The race the gate guards against — a perf event firing in the window between the `sched_switch` tracepoint updating `cpu_running_pid` and the actual `current` swap — can only occur after `sched_switch` has set the slot to a real PID. A `0` slot cannot indicate a race, so allow those samples through.

The parquet validation (`src/validation/parquet_queries.rs:455`) already skips samples that lack a corresponding `sched_slice`, so this introduces no false positives there.

## Verification

- 8/8 loops of the 3 most flaky pystacks tests passed (the same loop hit a failure on run 4 before the fix)
- Full integration suite: 26 passed; 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` all clean
- Bumped to 1.6.5 (non-schema patch)