### PR TITLE
Propagate pystacks config across fork so forked Python workers keep stacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.6.5"
+version = "1.6.6"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.6.5"
+version = "1.6.6"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -379,8 +379,20 @@ struct memory_event {
  * `struct task_event`
  */
 #ifdef SYSTING_PYSTACKS
+/*
+ * Notify userspace that a traced process exec'd or forked so it can update
+ * the pystacks discovery state. The handler in handle_exec_events() reads
+ * /proc/<pid>/{exe,maps}, so this only carries the pid and a flag describing
+ * what kernel event produced it (exec vs. fork) for logging/diagnostics.
+ */
 struct exec_event {
 	u32 pid;
+	/* 1 if produced by sched_process_fork (Python parent forked a new
+	 * process), 0 if produced by sched_process_exec. u32 (not u8/bool) so
+	 * the struct has no padding bytes -- bpf_ringbuf_reserve() does not
+	 * zero its allocation, so padding would leak uninitialized kernel
+	 * memory to userspace. */
+	u32 is_fork;
 };
 #endif
 
@@ -712,7 +724,15 @@ struct memory_ringbuf_map {
 #ifdef SYSTING_PYSTACKS
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
-	__uint(max_entries, 4096 /* 4KB - exec events are tiny and rare */);
+	/*
+	 * 16KB. Carries both exec events and Python-process-fork events, both
+	 * tiny (~16 bytes with ringbuf header). Pre-fork servers and
+	 * multiprocessing pools can fork in bursts; if a reservation does
+	 * fail, the BPF maps are already correct (fork propagation happens
+	 * before the ringbuf write) and only the userspace pid->version hint
+	 * is missed.
+	 */
+	__uint(max_entries, 16384);
 } ringbuf_exec_events SEC(".maps");
 #endif
 
@@ -1800,6 +1820,25 @@ static int handle_sched_process_exit(struct task_struct *task)
 	if (!trace_task(task))
 		return 0;
 
+#ifdef SYSTING_PYSTACKS
+	/*
+	 * Drop the pystacks config when the *last* thread of a process exits.
+	 * Forked Python children that exit without exec'ing (multiprocessing
+	 * workers, plain os.fork()) would otherwise leak entries in the
+	 * bounded targeted_pids/pystacks_pid_config maps and starve later
+	 * forks once those maps fill (1024 entries each).
+	 *
+	 * sched_process_exit fires per *thread*, but both maps are keyed by
+	 * tgid. do_exit() decrements signal->live before this tracepoint
+	 * fires, so 0 here means this thread is the last one in the group;
+	 * earlier-exiting threads see > 0 and leave the config alone (the
+	 * remaining threads still need it).
+	 */
+	if (tool_config.collect_pystacks &&
+	    BPF_CORE_READ(task, signal, live.counter) == 0)
+		pystacks_clear_pid(task->tgid);
+#endif
+
 	event = reserve_task_event(&flags);
 	if (!event)
 		return handle_missed_event(MISSED_SCHED_EVENT);
@@ -1830,6 +1869,36 @@ static int handle_sched_process_fork(struct task_struct *parent,
 	u8 val = 1;
 	bpf_map_update_elem(&pids, &child_pid, &val, BPF_ANY);
 
+#ifdef SYSTING_PYSTACKS
+	/*
+	 * If the parent is a registered Python process, the forked child shares
+	 * its address space (CoW) until it execs, so the parent's pystacks
+	 * config is valid for the child too. Propagate it immediately so the
+	 * child's very first samples have working pystacks (no userspace round
+	 * trip), then notify userspace so the symbol resolver learns the
+	 * child's Python version (used for line-table parsing).
+	 *
+	 * Threads (CLONE_THREAD) share the parent's tgid; pystacks_propagate_fork
+	 * detects that and returns false without touching the maps.
+	 */
+	if (tool_config.collect_pystacks &&
+	    pystacks_propagate_fork(parent->tgid, child->tgid)) {
+		struct exec_event *event = bpf_ringbuf_reserve(
+			&ringbuf_exec_events, sizeof(*event), 0);
+		if (event) {
+			event->pid = child->tgid;
+			event->is_fork = 1;
+			bpf_ringbuf_submit(event, 0);
+		}
+		/*
+		 * If the ringbuf reservation fails the BPF maps are still
+		 * correct (populated above); only the userspace pid->version
+		 * mapping is missed, which degrades line numbers but keeps
+		 * function-level symbolization working.
+		 */
+	}
+#endif
+
 	return 0;
 }
 
@@ -1850,11 +1919,34 @@ int BPF_PROG(systing_sched_process_exec, struct task_struct *task,
 	if (!trace_task(task))
 		return 0;
 
+	/*
+	 * Reserve the ringbuf slot *before* clearing the stale pystacks config.
+	 * If the reservation fails, userspace never learns about this exec, so
+	 * leaving the (now-stale) config in place is the lesser evil: stale
+	 * config produces unreadable garbage that walks to a 0-frame stack,
+	 * but no config means we'd silently never re-register if the new image
+	 * is still Python.
+	 */
 	struct exec_event *event =
 		bpf_ringbuf_reserve(&ringbuf_exec_events, sizeof(*event), 0);
 	if (!event)
 		return 0;
+
+	/*
+	 * Exec replaces the address space, so any pystacks config we have for
+	 * this pid (whether registered at startup, dynamically discovered, or
+	 * inherited from a parent at fork time) is now stale. Drop it; the
+	 * exec event triggers userspace re-discovery, which re-registers the
+	 * pid if the new image is still Python.
+	 *
+	 * This is what keeps subprocess.Popen() from a Python parent from
+	 * leaking a stale entry per call: fork propagates the parent's config
+	 * to the child, then exec into the subprocess binary clears it again.
+	 */
+	pystacks_clear_pid(task->tgid);
+
 	event->pid = task->tgid;
+	event->is_fork = 0;
 	bpf_ringbuf_submit(event, 0);
 	return 0;
 }

--- a/src/pystacks/bpf/pystacks.bpf.c
+++ b/src/pystacks/bpf/pystacks.bpf.c
@@ -1127,3 +1127,57 @@ __hidden int pystacks_read_stacks(
 struct pystacks_message* pystacks_get_msg(void) {
   return bpf_map_lookup_elem(&pystacks_msg_heap, &zero);
 }
+
+/* See pystacks.bpf.h for the rationale.
+ *
+ * Note both maps are keyed by tgid, so this is a process-level operation.
+ * Threads (CLONE_THREAD) share their parent's tgid and need no propagation;
+ * they're handled here as a no-op (parent_pid == child_pid).
+ */
+__hidden bool pystacks_propagate_fork(pid_t parent_pid, pid_t child_pid) {
+  if (parent_pid == child_pid) {
+    /* Same tgid -> a new thread, not a forked process. The existing
+     * per-tgid entry already covers it. */
+    return false;
+  }
+
+  PyPidData* cfg = bpf_map_lookup_elem(&pystacks_pid_config, &parent_pid);
+  if (!cfg) {
+    /* Parent isn't a registered Python process — or it is, but its config
+     * was just cleared by pystacks_clear_pid() on exec and userspace hasn't
+     * re-registered it yet. The latter is a real (small) gap: a process that
+     * execs into Python and immediately forks workers before the userspace
+     * exec handler catches up will miss propagation for those early forks.
+     * Closing it would require waiting for userspace acks in the BPF fork
+     * path, which isn't worth the complexity given the window is sub-100ms. */
+    return false;
+  }
+
+  /* The forked child shares the parent's address space (CoW), so the
+   * parent's offsets / runtime addresses are valid for the child until it
+   * execs (at which point pystacks_clear_pid drops this entry).
+   *
+   * Both updates must succeed or neither: a child in targeted_pids without
+   * a pystacks_pid_config entry makes the sampler walk the binary-id
+   * fallback chain on every sample to no effect, and a config entry that
+   * isn't targeted is just a wasted slot. Either map can fill up under
+   * heavy fork churn (1024 entries each); when that happens, fail closed. */
+  if (bpf_map_update_elem(&pystacks_pid_config, &child_pid, cfg, BPF_ANY))
+    return false;
+
+  bool targeted = true;
+  if (bpf_map_update_elem(&targeted_pids, &child_pid, &targeted, BPF_ANY)) {
+    bpf_map_delete_elem(&pystacks_pid_config, &child_pid);
+    return false;
+  }
+
+  return true;
+}
+
+/* See pystacks.bpf.h for the rationale.
+ * bpf_map_delete_elem returns -ENOENT for missing keys; safe to call
+ * unconditionally on every exec from a traced task. */
+__hidden void pystacks_clear_pid(pid_t pid) {
+  bpf_map_delete_elem(&pystacks_pid_config, &pid);
+  bpf_map_delete_elem(&targeted_pids, &pid);
+}

--- a/src/pystacks/bpf/pystacks.bpf.h
+++ b/src/pystacks/bpf/pystacks.bpf.h
@@ -54,6 +54,29 @@ int pystacks_read_stacks(
     struct task_struct* task,
     struct pystacks_message* py_msg_buffer);
 
+/* Propagate the parent's pystacks pid configuration to a forked child.
+ *
+ * Forked children share the parent's address space (CoW) until they exec, so
+ * the parent's PyPidData (struct offsets, _PyRuntime address, TLS key, ...)
+ * is valid for the child too. Without this, every fork() of a Python process
+ * (multiprocessing workers, gunicorn pre-forks, plain os.fork()) gets a fresh
+ * tgid that fails the targeted_pids / pystacks_pid_config lookups and silently
+ * drops every Python stack for the child.
+ *
+ * Returns true if the parent was a registered Python process and the config
+ * was propagated. Threads (same tgid) are a no-op and return false.
+ */
+bool pystacks_propagate_fork(pid_t parent_pid, pid_t child_pid);
+
+/* Drop a pid from the pystacks targeting maps. Called on exec: the address
+ * space (and any inherited PyPidData) is replaced, so the cached config is
+ * stale. The exec event handler in userspace re-discovers the new binary and
+ * re-registers if it is still Python. Without this cleanup, fork+exec from a
+ * Python parent (subprocess.Popen) leaks a stale entry per call and steadily
+ * fills the bounded pid maps. Safe to call for pids that were never registered.
+ */
+void pystacks_clear_pid(pid_t pid);
+
 struct pystacks_msg_heap_map {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
   __uint(max_entries, 1);

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -729,13 +729,21 @@ unsafe impl Plain for marker_event {}
 unsafe impl Plain for memory_event {}
 unsafe impl Plain for memory_event_header {}
 
-/// BPF exec event - delivered via dedicated ringbuf when a traced process execs.
-/// Used to dynamically discover Python PIDs for pystacks.
+/// BPF exec/fork event - delivered via the `ringbuf_exec_events` ringbuf when
+/// a traced process execs (any traced task) or forks (Python parents only).
+/// Used to dynamically keep pystacks discovery in sync with the process tree.
+/// Layout must match `struct exec_event` in `systing_system.bpf.c`.
 #[repr(C)]
 #[derive(Default, Clone, Copy)]
 #[allow(non_camel_case_types)]
 struct exec_event {
     pid: u32,
+    /// 1 if produced by sched_process_fork (the BPF side already copied the
+    /// parent's pystacks config to this pid), 0 if produced by
+    /// sched_process_exec (the BPF side cleared this pid's pystacks config
+    /// and we need to re-discover from scratch). u32 to match the BPF struct,
+    /// which uses u32 to keep the struct padding-free.
+    is_fork: u32,
 }
 unsafe impl Plain for exec_event {}
 
@@ -1544,18 +1552,31 @@ fn discover_python_processes(debug: bool) -> Vec<u32> {
     discovered
 }
 
-/// Handles exec events from the BPF ringbuf, dynamically adding Python PIDs to pystacks.
+/// Handles exec/fork events from the BPF ringbuf, keeping pystacks discovery
+/// in sync with the process tree.
 ///
-/// When a traced process execs into Python directly, adds it to pystacks immediately.
-/// When a traced process execs into a pyenv launcher (e.g., forkapple's `fa`), scans
-/// /proc for all Python processes since the actual Python workers may be outside the
-/// traced process tree (pre-forked by a server like forkapple).
+/// Exec events: a traced process replaced its image. The BPF side already
+/// dropped any stale pystacks config for the pid; if the new image is Python
+/// (or embeds libpython) we re-register it. When the exec'd binary is a pyenv
+/// launcher (e.g., forkapple's `fa`), we additionally scan /proc once for
+/// Python workers that may live outside the traced process tree.
+///
+/// Fork events: a registered Python process forked. The BPF side already
+/// copied the parent's pystacks config to the child (the address space is
+/// CoW-shared until exec, so the parent's config is valid); we only need to
+/// teach the symbol resolver the child's Python version for line-table
+/// parsing. `psr.add_pid()` does that as a side effect of re-discovering the
+/// child via /proc.
 fn handle_exec_events(
     exec_rx: Receiver<exec_event>,
     psr: Arc<crate::pystacks::stack_walker::StackWalkerRun>,
     pids_map: libbpf_rs::MapHandle,
     pystacks_debug: bool,
 ) {
+    // Pids we've successfully registered with pystacks. Used only to keep the
+    // logging quiet on repeat events; it does NOT short-circuit re-discovery,
+    // because exec invalidates the registration (BPF clears the maps and we
+    // must re-register the new image) and forks always carry a fresh pid.
     let mut added_pids = std::collections::HashSet::new();
     // Single scan flag: we only scan /proc once per trace session because
     // the forkapple server's Python workers are long-lived and pre-forked,
@@ -1563,22 +1584,24 @@ fn handle_exec_events(
     let mut did_scan = false;
     while let Ok(event) = exec_rx.recv() {
         let pid = event.pid;
+        let is_fork = event.is_fork != 0;
+        let kind = if is_fork { "Fork" } else { "Exec" };
         let Ok(exe) = std::fs::read_link(format!("/proc/{pid}/exe")) else {
             if pystacks_debug {
                 eprintln!(
-                    "[pystacks debug] Exec event for PID {} but readlink failed",
-                    pid
+                    "[pystacks debug] {} event for PID {} but readlink failed (process exited?)",
+                    kind, pid
                 );
             }
             continue;
         };
         let exe_str = exe.to_string_lossy();
+        let was_registered = added_pids.contains(&pid);
 
-        // Try every traced exec: check_python_process() scans maps for
-        // libpython, so embedders (uwsgi, gunicorn, etc.) are covered and
-        // non-python processes are rejected there. Only mark the pid as
-        // handled on success so exec chains (e.g. bash -> `exec python3`)
-        // re-probe on the later exec.
+        // Try discovery on every event. check_python_process() scans
+        // /proc/pid/exe and /proc/pid/maps for libpython, so embedders
+        // (uwsgi, gunicorn, ...) are covered and non-python processes are
+        // rejected cheaply.
         //
         // sched_process_exec fires before ld.so maps libpython, so for
         // dynamically-linked python stubs the first maps scan often finds
@@ -1586,32 +1609,57 @@ fn handle_exec_events(
         // exec-handler thread for up to 100ms per miss, which is acceptable
         // given the dedicated 100K-deep channel; a non-blocking retry queue
         // is a follow-up if python fork-storms become an issue.
-        if !added_pids.contains(&pid) {
-            let looks_like_python = exe_str.contains("python");
-            let mut registered = psr.add_pid(pid as i32);
-            if !registered && looks_like_python {
-                for delay_ms in [10, 30, 60] {
-                    std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-                    if psr.add_pid(pid as i32) {
-                        registered = true;
-                        break;
-                    }
+        //
+        // Forks don't need the retry: the child's address space is fully set
+        // up at fork time (CoW from the parent), and the BPF maps are already
+        // populated regardless of whether this userspace pass succeeds.
+        let looks_like_python = exe_str.contains("python");
+        let mut registered = psr.add_pid(pid as i32);
+        if !registered && looks_like_python && !is_fork {
+            for delay_ms in [10, 30, 60] {
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                if psr.add_pid(pid as i32) {
+                    registered = true;
+                    break;
                 }
             }
-            if registered {
+        }
+        if registered {
+            if !was_registered {
                 added_pids.insert(pid);
                 eprintln!(
-                    "[pystacks] Dynamically added Python PID {} ({})",
-                    pid, exe_str
-                );
-            } else if looks_like_python && pystacks_debug {
-                eprintln!(
-                    "[pystacks debug] python-named exe PID {} ({}) but libpython/_PyRuntime not found after retries",
-                    pid, exe_str
+                    "[pystacks] Dynamically added Python PID {} ({}{})",
+                    pid,
+                    exe_str,
+                    if is_fork { ", forked" } else { "" }
                 );
             }
+        } else if was_registered && !is_fork {
+            // Was a Python process; the new image isn't (or its libpython
+            // hasn't been mapped yet). BPF already dropped its pystacks
+            // config; drop our tracking too so a later exec back into Python
+            // re-logs the add.
+            added_pids.remove(&pid);
+            if pystacks_debug {
+                if looks_like_python {
+                    eprintln!(
+                        "[pystacks debug] PID {} re-exec'd ({}) but libpython/_PyRuntime not found; dropped",
+                        pid, exe_str
+                    );
+                } else {
+                    eprintln!(
+                        "[pystacks debug] PID {} exec'd from Python into non-Python ({}); dropped",
+                        pid, exe_str
+                    );
+                }
+            }
+        } else if looks_like_python && pystacks_debug {
+            eprintln!(
+                "[pystacks debug] python-named exe PID {} ({}, {}) but libpython/_PyRuntime not found",
+                pid, exe_str, kind
+            );
         }
-        if !did_scan && exe_str.contains(".pyenv/") && !exe_str.contains("python") {
+        if !did_scan && !is_fork && exe_str.contains(".pyenv/") && !exe_str.contains("python") {
             // A pyenv binary but not Python itself (e.g., forkapple's `fa`).
             // The actual Python process may be outside our traced tree.
             // Scan /proc for all Python processes and add them.

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -1928,6 +1928,379 @@ fn test_pystacks_python313() {
 }
 
 // =============================================================================
+// Pystacks dynamic process discovery
+//
+// These tests exercise the paths where Python work runs in a process that did
+// NOT exist (or was not yet a Python process) when systing started. The
+// recorder must keep the BPF `targeted_pids` / `pystacks_pid_config` maps in
+// sync as the process tree changes:
+//
+//   - new threads share the parent's tgid, so they "just work" once the
+//     process is registered (test_pystacks_threads validates this stays true)
+//   - forked children get a new tgid, so the BPF fork tracepoint must
+//     propagate the parent's pystacks config to the child
+//     (test_pystacks_fork, test_pystacks_multiprocessing)
+//   - fork+exec into a different python (subprocess re-exec) must re-discover
+//     via the exec event handler (test_pystacks_fork_exec)
+// =============================================================================
+
+/// Run a pystacks workload, record a trace, and assert that `target_function`
+/// shows up as a Python frame in `stack.parquet`.
+///
+/// `defs` and `loop_body` are passed straight to `spawn_python_workload`.
+fn run_pystacks_workload_and_check(
+    test_label: &str,
+    defs: &str,
+    loop_body: &str,
+    target_function: &str,
+    duration: u64,
+) {
+    setup_bpf_environment();
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let trace_path = dir.path().join("trace.pb");
+
+    let workload = spawn_python_workload(
+        pyenv_python(PYTHON_313_VERSION),
+        dir.path(),
+        &format!("{test_label}.py"),
+        defs,
+        loop_body,
+    );
+    eprintln!("[{test_label}] Started Python parent PID: {}", workload.pid);
+
+    let config = Config {
+        duration,
+        parquet_only: true,
+        collect_pystacks: true,
+        // Filter to the workload pid so the trace stays small. Forked
+        // descendants are added to the BPF `pids` map automatically by the
+        // sched_process_fork tracepoint, so they remain in scope. We do NOT
+        // pass `pystacks_pids` so the `--pid` filter path is exercised
+        // (the more common usage and the one that drives auto-discovery).
+        pid: vec![workload.pid],
+        output_dir: dir.path().to_path_buf(),
+        output: trace_path,
+        ..Config::default()
+    };
+
+    systing(config, None).expect("systing recording failed");
+    drop(workload);
+
+    let stack_parquet = dir.path().join("stack.parquet");
+    assert!(
+        stack_parquet.exists(),
+        "[{test_label}] stack.parquet not found"
+    );
+
+    let (found_python_symbols, found_target) =
+        find_python_symbols_in_parquet(&stack_parquet, target_function);
+
+    assert!(
+        found_python_symbols,
+        "[{test_label}] No Python symbols found in stack.parquet at all"
+    );
+    assert!(
+        found_target,
+        "[{test_label}] Expected python function '{target_function}' not found in stack.parquet. \
+         Python stacks for the spawned worker were not captured."
+    );
+
+    eprintln!("[{test_label}] passed");
+}
+
+/// New threads share the parent's tgid, so the `targeted_pids` /
+/// `pystacks_pid_config` lookups (keyed by tgid) cover them automatically.
+/// This is a regression guard so that future changes don't accidentally key
+/// on the per-thread pid.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_pystacks_threads() {
+    let defs = r#"
+import threading
+
+state = {"calls": 0}
+
+def systing_thread_worker_function():
+    """Runs only on the spawned thread; must show up in pystacks samples."""
+    while True:
+        total = 0
+        for i in range(1000000):
+            total += i * i
+
+def systing_thread_step():
+    state["calls"] += 1
+    if state["calls"] == 1:
+        # Warm-up iteration runs before the ready marker is written -- just
+        # busy spin so the parent looks like a real python process.
+        total = 0
+        for i in range(1000000):
+            total += i * i
+        return
+    if state["calls"] == 2:
+        # Spawn the worker thread on the first post-ready iteration so it's
+        # born after systing has started (and possibly after BPF attach).
+        # Either way the tgid lookup covers it -- that's what the test
+        # asserts -- but spawning here exercises the "thread born during
+        # the trace" case rather than only "thread already alive at attach."
+        t = threading.Thread(target=systing_thread_worker_function, daemon=True)
+        t.start()
+        return
+    # Steady state: parent stays mostly idle so the worker thread gets the GIL.
+    time.sleep(0.1)
+"#;
+
+    run_pystacks_workload_and_check(
+        "test_pystacks_threads",
+        defs,
+        "systing_thread_step()",
+        "systing_thread_worker_function",
+        5,
+    );
+}
+
+/// `os.fork()` children get a new tgid. The BPF sched_process_fork tracepoint
+/// must propagate the parent's pystacks config to the child or all of the
+/// child's Python stacks are dropped.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_pystacks_fork() {
+    let defs = r#"
+import os
+
+state = {"calls": 0, "worker": None}
+PARENT_PID = os.getpid()
+
+def systing_fork_worker_function():
+    """Runs only in the forked child; must show up in pystacks samples."""
+    total = 0
+    for i in range(1000000):
+        total += i * i
+    return total
+
+def systing_fork_step():
+    state["calls"] += 1
+    if state["calls"] == 1:
+        # Warm-up iteration runs before the ready marker is written -- just
+        # busy spin so the parent looks like a real python process.
+        total = 0
+        for i in range(1000000):
+            total += i * i
+        return
+    # Kill the previous worker (if any) and fork a fresh one. systing's BPF
+    # setup time is variable (skel.load() alone can take 2-3s on a debug
+    # build), so a single fork at a fixed delay races against the
+    # sched_process_fork tracepoint attaching. Re-forking once a second is
+    # robust: at least one fork lands after the tracepoint is live, and
+    # that fork's pystacks config gets propagated.
+    if state["worker"] is not None:
+        try:
+            os.kill(state["worker"], 9)
+            os.waitpid(state["worker"], 0)
+        except (OSError, ChildProcessError):
+            pass
+    pid = os.fork()
+    if pid == 0:
+        # Exit when the parent disappears (drop() SIGKILLs it) so we
+        # don't leave an orphan spinning forever after the test ends.
+        while os.getppid() == PARENT_PID:
+            systing_fork_worker_function()
+        os._exit(0)
+    state["worker"] = pid
+    time.sleep(1.0)
+"#;
+
+    run_pystacks_workload_and_check(
+        "test_pystacks_fork",
+        defs,
+        "systing_fork_step()",
+        "systing_fork_worker_function",
+        6,
+    );
+}
+
+/// `multiprocessing.Process` with the (Linux default) `fork` start method
+/// is the most common way Python apps fan out CPU work. It's the same
+/// kernel-level fork as `os.fork()`, but goes through the multiprocessing
+/// bootstrap, so it exercises a deeper Python stack and a longer setup
+/// window before the worker reaches its target function.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_pystacks_multiprocessing() {
+    let defs = r#"
+import multiprocessing, os
+
+state = {"calls": 0, "worker": None}
+PARENT_PID = os.getpid()
+
+def systing_mp_worker_function():
+    """multiprocessing target; must show up in pystacks samples."""
+    # Exit when the parent disappears (drop() SIGKILLs it -- bypasses
+    # multiprocessing's own daemon cleanup, which uses atexit).
+    while os.getppid() == PARENT_PID:
+        total = 0
+        for i in range(1000000):
+            total += i * i
+
+def systing_mp_step():
+    state["calls"] += 1
+    if state["calls"] == 1:
+        # Warm-up iteration: just busy spin (see test_pystacks_fork).
+        total = 0
+        for i in range(1000000):
+            total += i * i
+        return
+    # Re-fork once a second so at least one fork lands after BPF attach
+    # (see test_pystacks_fork for why a fixed delay is racy).
+    if state["worker"] is not None:
+        try:
+            state["worker"].kill()
+            state["worker"].join(timeout=2)
+        except Exception:
+            pass
+    ctx = multiprocessing.get_context("fork")
+    p = ctx.Process(target=systing_mp_worker_function, daemon=True)
+    p.start()
+    state["worker"] = p
+    time.sleep(1.0)
+"#;
+
+    run_pystacks_workload_and_check(
+        "test_pystacks_multiprocessing",
+        defs,
+        "systing_mp_step()",
+        "systing_mp_worker_function",
+        6,
+    );
+}
+
+/// fork + exec into a fresh python (`subprocess.Popen([sys.executable, ...])`)
+/// — the most common subprocess pattern for Python services. The forked child
+/// inherits the parent's pystacks config (from the fork tracepoint) but then
+/// execs into a brand new address space, so the inherited config is stale and
+/// must be cleared. The exec event handler should then re-discover the new
+/// python and re-register it.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_pystacks_fork_exec() {
+    setup_bpf_environment();
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let trace_path = dir.path().join("trace.pb");
+
+    // The subprocess script: a busy loop with a unique function name so we
+    // can find it in stack.parquet.
+    let child_script = dir.path().join("test_pystacks_fork_exec_child.py");
+    std::fs::write(
+        &child_script,
+        r#"
+import os
+_initial_ppid = os.getppid()
+
+def systing_fork_exec_child_function():
+    total = 0
+    for i in range(1000000):
+        total += i * i
+    return total
+
+# Exit when the parent disappears so we don't leave an orphan spinning forever.
+while os.getppid() == _initial_ppid:
+    systing_fork_exec_child_function()
+"#,
+    )
+    .expect("write child script");
+    let child_script_str = child_script.to_string_lossy();
+
+    let defs = format!(
+        r#"
+import os, subprocess
+
+state = {{"calls": 0, "worker": None}}
+CHILD_SCRIPT = "{child_script_str}"
+
+def systing_fork_exec_step():
+    state["calls"] += 1
+    if state["calls"] == 1:
+        total = 0
+        for i in range(1000000):
+            total += i * i
+        return
+    # Re-fork+exec once a second so at least one lands after BPF attach
+    # (see test_pystacks_fork for why a fixed delay is racy).
+    if state["worker"] is not None:
+        try:
+            state["worker"].kill()
+            state["worker"].wait(timeout=2)
+        except Exception:
+            pass
+    # subprocess.Popen forks then execs into a fresh python. The forked
+    # child briefly inherits the parent's pystacks config (correct, since
+    # the address space is shared CoW until exec) and then execs into a
+    # brand new address space (the inherited config must be cleared).
+    p = subprocess.Popen([sys.executable, CHILD_SCRIPT])
+    state["worker"] = p
+    time.sleep(1.0)
+"#
+    );
+
+    let workload = spawn_python_workload(
+        pyenv_python(PYTHON_313_VERSION),
+        dir.path(),
+        "test_pystacks_fork_exec.py",
+        &defs,
+        "systing_fork_exec_step()",
+    );
+    eprintln!(
+        "[test_pystacks_fork_exec] Started Python parent PID: {}",
+        workload.pid
+    );
+
+    let config = Config {
+        // Longer duration: the exec re-discovery path goes through userspace
+        // (read /proc/<pid>/maps, parse ELF, ...) and may need the retry
+        // backoff (~100ms). Give it plenty of room.
+        duration: 8,
+        parquet_only: true,
+        collect_pystacks: true,
+        pid: vec![workload.pid],
+        output_dir: dir.path().to_path_buf(),
+        output: trace_path,
+        ..Config::default()
+    };
+
+    systing(config, None).expect("systing recording failed");
+    drop(workload);
+
+    // subprocess child can outlive the workload's drop; clean it up so it
+    // doesn't keep burning CPU after the test.
+    let _ = std::process::Command::new("pkill")
+        .args(["-f", &child_script_str])
+        .status();
+
+    let stack_parquet = dir.path().join("stack.parquet");
+    assert!(
+        stack_parquet.exists(),
+        "[test_pystacks_fork_exec] stack.parquet not found"
+    );
+
+    let (found_python_symbols, found_target) =
+        find_python_symbols_in_parquet(&stack_parquet, "systing_fork_exec_child_function");
+
+    assert!(
+        found_python_symbols,
+        "[test_pystacks_fork_exec] No Python symbols found in stack.parquet at all"
+    );
+    assert!(
+        found_target,
+        "[test_pystacks_fork_exec] Expected python function 'systing_fork_exec_child_function' \
+         not found in stack.parquet. The exec-event re-discovery path is not registering the \
+         re-exec'd python."
+    );
+
+    eprintln!("[test_pystacks_fork_exec] passed");
+}
+
+// =============================================================================
 // Consolidated run command suite
 //
 // Tests the `systing -- <command>` mode. Each sub-test needs its own systing


### PR DESCRIPTION
## Problem

Pystacks gates symbolization on two BPF maps — `targeted_pids` and `pystacks_pid_config` — both keyed by **tgid**. Only PIDs discovered at startup or via the `sched_process_exec` tracepoint were ever inserted. Any Python process created by `fork()` **without** a subsequent `exec` therefore got a fresh tgid that missed both lookups and **silently dropped every Python stack** for the child. This hits the common cases:

- `multiprocessing` pool workers (default `fork` start method on Linux)
- plain `os.fork()`
- gunicorn / uWSGI-style pre-forked workers

Threads were *not* affected — they share the parent's tgid, and per-thread Python state is read from TLS at sample time — but that wasn't covered by a test, so it could regress.

## Fix

- **Propagate on fork.** In `sched_process_fork`, copy the parent's `pystacks_pid_config` to the child and add it to `targeted_pids`. The child shares the parent's address space (CoW) until it execs, so the parent's struct offsets and runtime addresses are valid for the child. The propagation is atomic-or-nothing: if either map update fails (e.g. map full), it rolls back and reports failure rather than leaving the child targeted-but-unconfigured. Threads (matching parent/child tgid) no-op.
- **Clear on exec.** `exec` replaces the address space, so any inherited or previously-discovered config is stale. Clearing it also stops fork+exec patterns (`subprocess.Popen`) from leaking a stale entry per call. The exec event still triggers userspace re-discovery, which re-registers the PID if the new image is Python. The ringbuf slot is reserved *before* clearing, so a ringbuf-full condition leaves the stale-but-present config rather than no config at all.
- **Clear on last-thread exit.** Forked workers that exit without exec'ing would otherwise leak entries and eventually exhaust the bounded (1024-entry) maps during long traces. Gated on `signal->live == 0` so a single thread exiting doesn't tear down config still needed by its siblings.
- The exec/fork ringbuf event grew an `is_fork` flag (`u32`, kept padding-free to avoid leaking uninitialized ringbuf memory to userspace), and the userspace handler now distinguishes fork from exec.

## Tests

New integration tests in `tests/trace_validation.rs` (require root/BPF, `#[ignore]`d):

- `test_pystacks_fork` — `os.fork()` worker
- `test_pystacks_multiprocessing` — `multiprocessing.Process` worker
- `test_pystacks_fork_exec` — `subprocess.Popen([sys.executable, ...])` re-discovery
- `test_pystacks_threads` — regression guard that threads stay covered by the parent's tgid

All four were confirmed to **fail before** the fix (except the threads guard, which passed) and **pass after**. The full `test_pystacks_*` suite (15 tests) passes.

## Versioning

Patch bump 1.6.5 → 1.6.6 (no schema change).