### PR TITLE
Record per-process cgroup id so short-lived processes stay attributable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.6.6"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.6.6"
+version = "1.7.0"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -106,3 +106,25 @@ Switched network per-thread tables to key on `utid`, matching `sched_slice`/`sta
 - `network_poll`: dropped `tid INTEGER, pid INTEGER`; added `utid BIGINT` (joins `thread.utid`).
 
 For process attribution join through `network_*.utid -> thread.utid -> thread.upid -> process.upid`.
+
+---
+
+## Schema Version 8 (systing 1.7.0) — 2026-05-21
+
+Record each process's cgroup so short-lived processes can still be attributed to a
+cgroup even when they exit before their `/proc` entry can be read. The numeric
+cgroup id is captured in-kernel at event time (BPF `task_info`), and resolved to a
+path by walking the live cgroup v2 hierarchy when the trace is written.
+
+### Added columns
+- `process`: added `cgroup_id UBIGINT NOT NULL DEFAULT 0` — the cgroup directory's
+  kernfs node id (its inode) in the v2 unified hierarchy. `0` means unknown.
+- `process`: added `cgroup_path VARCHAR` — best-effort path of that cgroup relative
+  to the cgroup root (e.g. `/system.slice/foo.service`); `NULL` if it could not be
+  resolved (e.g. the cgroup was removed before the trace was written). Resolution is
+  racy and reflects the hierarchy at write time; because kernfs inode numbers can be
+  reused, a removed-and-replaced id may resolve to a different cgroup's path. Trust
+  `cgroup_id`; treat `cgroup_path` as a hint.
+
+Older databases without these columns import cleanly: `cgroup_id` falls back to its
+`0` default and `cgroup_path` to `NULL`.

--- a/src/bin/systing_util.rs
+++ b/src/bin/systing_util.rs
@@ -6,7 +6,7 @@
 use anyhow::{bail, Context, Result};
 use arrow::array::{
     BooleanBuilder, Float64Builder, Int32Builder, Int64Builder, ListBuilder, RecordBatch,
-    StringBuilder,
+    StringBuilder, UInt64Builder,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use clap::{Parser, Subcommand};
@@ -2097,6 +2097,8 @@ fn write_data_to_parquet(trace_id: &str, data: &ExtractedData, paths: &ParquetPa
                 false,
             ),
             Field::new("is_kernel_thread", DataType::Boolean, false),
+            Field::new("cgroup_id", DataType::UInt64, false),
+            Field::new("cgroup_path", DataType::Utf8, true),
         ]));
 
         let mut trace_id_builder = StringBuilder::new();
@@ -2106,6 +2108,8 @@ fn write_data_to_parquet(trace_id: &str, data: &ExtractedData, paths: &ParquetPa
         let mut parent_upid_builder = Int64Builder::new();
         let mut cmdline_builder = ListBuilder::new(StringBuilder::new());
         let mut is_kernel_thread_builder = BooleanBuilder::new();
+        let mut cgroup_id_builder = UInt64Builder::new();
+        let mut cgroup_path_builder = StringBuilder::new();
 
         for proc in &data.processes {
             trace_id_builder.append_value(trace_id);
@@ -2119,6 +2123,9 @@ fn write_data_to_parquet(trace_id: &str, data: &ExtractedData, paths: &ParquetPa
             }
             cmdline_builder.append(true);
             is_kernel_thread_builder.append_value(proc.is_kernel_thread);
+            // Perfetto traces do not carry cgroup info, so default to unknown.
+            cgroup_id_builder.append_value(0);
+            cgroup_path_builder.append_null();
         }
 
         let batch = RecordBatch::try_new(
@@ -2131,6 +2138,8 @@ fn write_data_to_parquet(trace_id: &str, data: &ExtractedData, paths: &ParquetPa
                 Arc::new(parent_upid_builder.finish()),
                 Arc::new(cmdline_builder.finish()),
                 Arc::new(is_kernel_thread_builder.finish()),
+                Arc::new(cgroup_id_builder.finish()),
+                Arc::new(cgroup_path_builder.finish()),
             ],
         )?;
 

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -96,8 +96,21 @@ enum stack_event_type {
 	STACK_SLEEP_INTERRUPTIBLE,
 };
 
+/*
+ * Per-task identity shipped inline with every event that references a task.
+ *
+ * cgid (the task's cgroup id) is constant per task and is ultimately consumed
+ * only once, when userspace first creates the process record. It is nonetheless
+ * carried inline here - rather than via a separate BPF-populated map read at
+ * finalize - to stay consistent with comm, which is already shipped inline the
+ * same way. The cost is 8 bytes per task_info (so +16 bytes on sched_switch's
+ * task_event, which embeds prev+next). If event size ever becomes a concern,
+ * comm and cgid should move to a per-task metadata map together rather than
+ * splitting the two.
+ */
 struct task_info {
 	u64 tgidpid;
+	u64 cgid;
 	u8 comm[TASK_COMM_LEN];
 };
 
@@ -1491,6 +1504,13 @@ static __always_inline long safe_probe_read_user_str(void *dst, u32 size, const 
 static void record_task_info(struct task_info *info, struct task_struct *task)
 {
 	info->tgidpid = task_key(task);
+	// Record the cgroup id so that short-lived tasks (which may exit before
+	// userspace can read /proc) can still be attributed to a cgroup. This uses
+	// direct BTF field reads (not a restricted probe-read helper), so it is safe
+	// under kernel lockdown confidentiality mode too - the same way the cgroup
+	// filter already reads task_cg_id() unconditionally. Done before the comm
+	// read below, which IS skipped under lockdown.
+	info->cgid = task_cg_id(task);
 
 	// In confidentiality mode, use NULL comm (all zeros)
 	if (tool_config.confidentiality_mode) {

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -1,0 +1,174 @@
+//! Resolution of numeric cgroup ids to human-readable cgroup paths.
+//!
+//! The BPF side records, for every task, the id of its cgroup in the v2 unified
+//! hierarchy (`dfl_cgrp->kn->id`). For cgroup v2 that id is the inode number of
+//! the cgroup's directory under the cgroup2 mount, which is the same convention the
+//! cgroup filter uses (it keys the BPF filter map by `std::fs::metadata(...).ino()`).
+//!
+//! This module walks the live cgroup2 hierarchy and builds a map from that id to the
+//! cgroup's path (relative to the cgroup root, matching the `/proc/<pid>/cgroup`
+//! representation, e.g. `/system.slice/foo.service`; the root cgroup is `/`).
+//!
+//! Resolution is best-effort and racy: it reflects the cgroup hierarchy as it
+//! exists when the trace is written, not when each task was sampled. A cgroup that
+//! has been removed by then is simply absent from the map, so its `cgroup_path` is
+//! left unresolved. Note also that kernfs inode numbers can be reused: if a
+//! captured id was freed and reassigned to a *different* cgroup before the walk, it
+//! resolves to that different cgroup's path. The numeric id is always recorded
+//! faithfully; treat the resolved path as a best-effort hint.
+
+use std::collections::HashMap;
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+
+/// Locate the cgroup v2 unified hierarchy mount point by parsing
+/// `/proc/self/mountinfo`. Falls back to the conventional `/sys/fs/cgroup` only if
+/// it is actually a cgroup v2 hierarchy. Returns `None` when there is no cgroup v2
+/// hierarchy (e.g. a pure cgroup v1 host).
+pub fn cgroup2_root() -> Option<PathBuf> {
+    if let Ok(contents) = fs::read_to_string("/proc/self/mountinfo") {
+        for line in contents.lines() {
+            // mountinfo lines have an optional set of fields, then a literal " - "
+            // separator, then the filesystem type / source. Example:
+            //   31 23 0:26 / /sys/fs/cgroup rw,nosuid ... - cgroup2 cgroup2 rw,...
+            // The mount point is field index 4 (0-based) of the part before " - ".
+            if let Some((mount_fields, fs_fields)) = line.split_once(" - ") {
+                let fstype = fs_fields.split_whitespace().next().unwrap_or("");
+                if fstype == "cgroup2" {
+                    if let Some(mount_point) = mount_fields.split_whitespace().nth(4) {
+                        return Some(PathBuf::from(unescape_mountinfo(mount_point)));
+                    }
+                }
+            }
+        }
+    }
+    // Fallback only if mountinfo was unavailable/unparseable. Crucially, validate
+    // that the conventional path is really cgroup v2: on a pure cgroup v1 host
+    // `/sys/fs/cgroup` is a tmpfs of v1 controller subdirs whose inodes are
+    // unrelated to the BPF `dfl_cgrp->kn->id`, so walking it would yield a bogus
+    // id->path map (paths all NULL at best, silently wrong on inode collision).
+    let fallback = PathBuf::from("/sys/fs/cgroup");
+    is_cgroup2_root(&fallback).then_some(fallback)
+}
+
+/// A cgroup v2 hierarchy root always contains a `cgroup.controllers` file; cgroup
+/// v1 tmpfs roots and v1 controller subdirectories do not.
+fn is_cgroup2_root(path: &Path) -> bool {
+    path.join("cgroup.controllers").exists()
+}
+
+/// Decode the octal escapes (`\NNN`) that mountinfo uses for space, tab, newline
+/// and backslash within path fields, passing everything else through verbatim.
+fn unescape_mountinfo(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        // An escape is a backslash followed by exactly three octal digits encoding
+        // one byte (e.g. space -> \040). Operate on raw bytes rather than `&s[..]`
+        // slices so a backslash adjacent to a multi-byte UTF-8 character can never
+        // slice on a non-char boundary (which would panic).
+        if bytes[i] == b'\\' && i + 4 <= bytes.len() {
+            let d = &bytes[i + 1..i + 4];
+            if d.iter().all(|b| b.is_ascii_digit() && *b <= b'7') {
+                let code = (u32::from(d[0] - b'0') << 6)
+                    | (u32::from(d[1] - b'0') << 3)
+                    | u32::from(d[2] - b'0');
+                // Only valid single-byte escapes (\000..\377) are decoded; anything
+                // larger is left literal.
+                if code <= 0xFF {
+                    out.push(code as u8);
+                    i += 4;
+                    continue;
+                }
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    // Paths are conventionally UTF-8; tolerate the rare non-UTF-8 byte rather than
+    // panicking or mangling it into Latin-1.
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Build a map from cgroup id (the cgroup directory's inode, matching the BPF
+/// `dfl_cgrp->kn->id`) to the cgroup's path relative to the cgroup root.
+///
+/// The root cgroup maps to `/`; nested cgroups map to e.g.
+/// `/system.slice/foo.service`. Returns an empty map if no cgroup2 hierarchy is
+/// found.
+pub fn build_cgroup_id_map() -> HashMap<u64, String> {
+    let mut map = HashMap::new();
+    if let Some(root) = cgroup2_root() {
+        walk_cgroup_dir(&root, &root, &mut map);
+    }
+    map
+}
+
+fn walk_cgroup_dir(root: &Path, dir: &Path, map: &mut HashMap<u64, String>) {
+    if let Ok(meta) = fs::metadata(dir) {
+        let rel = relative_cgroup_path(root, dir);
+        map.insert(meta.ino(), rel);
+    }
+
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        // cgroupfs contains no inter-cgroup symlinks, so file_type() (which does not
+        // follow symlinks) safely identifies child cgroups while avoiding extra stats.
+        if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            walk_cgroup_dir(root, &entry.path(), map);
+        }
+    }
+}
+
+/// Render `dir` (a path under `root`) as a cgroup path relative to the cgroup root,
+/// with a leading slash. The root itself becomes `/`.
+fn relative_cgroup_path(root: &Path, dir: &Path) -> String {
+    match dir.strip_prefix(root) {
+        Ok(rel) if rel.as_os_str().is_empty() => "/".to_string(),
+        Ok(rel) => format!("/{}", rel.to_string_lossy()),
+        Err(_) => dir.to_string_lossy().into_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unescape_mountinfo() {
+        assert_eq!(unescape_mountinfo("/sys/fs/cgroup"), "/sys/fs/cgroup");
+        assert_eq!(
+            unescape_mountinfo("/path\\040with\\040space"),
+            "/path with space"
+        );
+        // tab (\011) and newline (\012) escapes.
+        assert_eq!(unescape_mountinfo("a\\011b\\012c"), "a\tb\nc");
+        // A trailing lone backslash must not panic and is preserved verbatim.
+        assert_eq!(unescape_mountinfo("/trailing\\"), "/trailing\\");
+        // A backslash NOT followed by three octal digits is literal (note `é` is a
+        // multi-byte UTF-8 char; byte-slicing here previously panicked).
+        assert_eq!(unescape_mountinfo("/a\\xxé"), "/a\\xxé");
+        // A genuine escape adjacent to a multi-byte char is decoded, char preserved.
+        assert_eq!(unescape_mountinfo("/café\\040x"), "/café x");
+        // Non-octal digits (8,9) are not an escape.
+        assert_eq!(unescape_mountinfo("\\089"), "\\089");
+    }
+
+    #[test]
+    fn test_relative_cgroup_path() {
+        let root = Path::new("/sys/fs/cgroup");
+        assert_eq!(relative_cgroup_path(root, root), "/");
+        assert_eq!(
+            relative_cgroup_path(root, Path::new("/sys/fs/cgroup/system.slice")),
+            "/system.slice"
+        );
+        assert_eq!(
+            relative_cgroup_path(root, Path::new("/sys/fs/cgroup/a/b/c")),
+            "/a/b/c"
+        );
+    }
+}

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -116,7 +116,7 @@ pub struct TraceImportMapping {
 }
 
 /// Current schema version. See SCHEMA_CHANGES.md for history.
-pub const SCHEMA_VERSION: u32 = 7;
+pub const SCHEMA_VERSION: u32 = 8;
 
 /// All data tables in the DuckDB schema (excludes the `_traces` metadata table).
 pub const DATA_TABLES: &[&str] = &[
@@ -192,7 +192,9 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
             name VARCHAR,
             parent_upid BIGINT,
             cmdline VARCHAR[],
-            is_kernel_thread BOOLEAN NOT NULL DEFAULT FALSE
+            is_kernel_thread BOOLEAN NOT NULL DEFAULT FALSE,
+            cgroup_id UBIGINT NOT NULL DEFAULT 0,
+            cgroup_path VARCHAR
         );
 
         CREATE TABLE IF NOT EXISTS thread (

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -1878,6 +1878,7 @@ fn test_stack_field_with_args() {
 fn create_test_task_info(tgid: u32, pid: u32) -> task_info {
     task_info {
         tgidpid: ((tgid as u64) << 32) | (pid as u64),
+        cgid: 0,
         comm: [0; 16],
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod analyze;
 pub mod mcp;
 
 // Core library modules
+pub mod cgroup;
 pub mod duckdb;
 pub mod parquet_paths;
 pub mod validation;

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use arrow::array::{
     BooleanBuilder, Float64Builder, Int32Builder, Int64Builder, Int8Builder, ListBuilder,
-    RecordBatch, StringBuilder,
+    RecordBatch, StringBuilder, UInt64Builder,
 };
 use arrow::datatypes::Schema;
 use parquet::arrow::ArrowWriter;
@@ -1418,6 +1418,8 @@ fn build_process_batch(records: &[ProcessRecord], schema: &Arc<Schema>) -> Resul
     let mut parent_upid_builder = Int64Builder::with_capacity(records.len());
     let mut cmdline_builder = ListBuilder::new(StringBuilder::new());
     let mut is_kernel_thread_builder = BooleanBuilder::with_capacity(records.len());
+    let mut cgroup_id_builder = UInt64Builder::with_capacity(records.len());
+    let mut cgroup_path_builder = StringBuilder::with_capacity(records.len(), records.len() * 32);
 
     for record in records {
         upid_builder.append_value(record.upid);
@@ -1432,6 +1434,8 @@ fn build_process_batch(records: &[ProcessRecord], schema: &Arc<Schema>) -> Resul
         cmdline_builder.append(true);
 
         is_kernel_thread_builder.append_value(record.is_kernel_thread);
+        cgroup_id_builder.append_value(record.cgroup_id);
+        cgroup_path_builder.append_option(record.cgroup_path.as_deref());
     }
 
     Ok(RecordBatch::try_new(
@@ -1443,6 +1447,8 @@ fn build_process_batch(records: &[ProcessRecord], schema: &Arc<Schema>) -> Resul
             Arc::new(parent_upid_builder.finish()),
             Arc::new(cmdline_builder.finish()),
             Arc::new(is_kernel_thread_builder.finish()),
+            Arc::new(cgroup_id_builder.finish()),
+            Arc::new(cgroup_path_builder.finish()),
         ],
     )?)
 }

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -83,6 +83,11 @@ pub struct SessionRecorder {
     pub process_descriptors: RwLock<HashMap<u64, ProcessDescriptor>>,
     pub processes: RwLock<HashMap<u64, ProtoProcess>>,
     pub threads: RwLock<HashMap<u64, ThreadDescriptor>>,
+    /// Maps process tgidpid -> cgroup id (the cgroup directory's kernfs node id,
+    /// i.e. its inode) as observed in-kernel at event time. This lets us attribute
+    /// even short-lived processes to a cgroup, since the id rides in on the event
+    /// and does not depend on /proc still existing when userspace runs discovery.
+    pub process_cgroups: RwLock<HashMap<u64, u64>>,
     /// Set of pids for processes detected as kernel threads.
     kernel_threads: RwLock<HashSet<u32>>,
     /// Shared utid generator for consistent thread IDs across all recorders.
@@ -477,6 +482,7 @@ impl SessionRecorder {
             process_descriptors: RwLock::new(HashMap::new()),
             processes: RwLock::new(HashMap::new()),
             threads: RwLock::new(HashMap::new()),
+            process_cgroups: RwLock::new(HashMap::new()),
             kernel_threads: RwLock::new(HashSet::new()),
             utid_generator,
         }
@@ -589,6 +595,17 @@ impl SessionRecorder {
             .write()
             .unwrap()
             .insert(info.tgidpid, proto_process);
+
+        // Record the cgroup id observed for this process. `info` may be a synthetic
+        // parent built from a thread we saw (when the main thread was never observed),
+        // in which case this carries that thread's cgroup id. We attribute the whole
+        // process to the first-observed task's cgroup; in a cgroup v2 threaded
+        // subtree (or cgroup v1) sibling threads can live in different cgroups, so
+        // this is the representative cgroup rather than a guaranteed per-thread one.
+        self.process_cgroups
+            .write()
+            .unwrap()
+            .insert(info.tgidpid, info.cgid);
     }
 
     fn record_new_thread(&self, info: &task_info) {
@@ -942,6 +959,11 @@ impl SessionRecorder {
         // Write process records using the shared upid generator
         let processes = self.processes.read().unwrap();
         let kernel_threads = self.kernel_threads.read().unwrap();
+        let process_cgroups = self.process_cgroups.read().unwrap();
+        // Snapshot the live cgroup hierarchy once so we can resolve the numeric
+        // cgroup id recorded for each process into a human-readable path. This is
+        // best-effort: cgroups removed before this point simply will not resolve.
+        let cgroup_id_map = crate::cgroup::build_cgroup_id_map();
         for (tgidpid, process) in self.process_descriptors.read().unwrap().iter() {
             let pid = process.pid();
             let upid = self.utid_generator.get_or_create_upid(pid);
@@ -960,6 +982,9 @@ impl SessionRecorder {
 
             let is_kernel_thread = kernel_threads.contains(&((*tgidpid >> 32) as u32));
 
+            let cgroup_id = process_cgroups.get(tgidpid).copied().unwrap_or(0);
+            let cgroup_path = cgroup_id_map.get(&cgroup_id).cloned();
+
             writer.add_process(ProcessRecord {
                 upid,
                 pid,
@@ -967,9 +992,12 @@ impl SessionRecorder {
                 parent_upid: None, // Could be set from parent_pid if needed
                 cmdline,
                 is_kernel_thread,
+                cgroup_id,
+                cgroup_path,
             })?;
         }
         drop(processes);
+        drop(process_cgroups);
 
         // Write thread records using the shared utid generator
         // Threads seen during streaming already have utids assigned; new threads get new utids
@@ -1263,6 +1291,7 @@ mod tests {
     fn create_test_task_info(tgid: u32, pid: u32, comm: &str) -> task_info {
         let mut task = task_info {
             tgidpid: ((tgid as u64) << 32) | (pid as u64),
+            cgid: 0,
             comm: [0; 16],
         };
 
@@ -1292,6 +1321,7 @@ mod tests {
             process_descriptors: RwLock::new(HashMap::new()),
             processes: RwLock::new(HashMap::new()),
             threads: RwLock::new(HashMap::new()),
+            process_cgroups: RwLock::new(HashMap::new()),
             kernel_threads: RwLock::new(HashSet::new()),
             utid_generator,
             tpu_metrics_recorder: None,

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -15,6 +15,17 @@
 ///   or for kernel threads which have no cmdline (see `is_kernel_thread`).
 /// - `is_kernel_thread`: Whether this process is a kernel thread (e.g., kworker,
 ///   migration, ksoftirqd). Kernel threads have no executable or cmdline.
+/// - `cgroup_id`: Numeric id of the process's cgroup in the v2 unified hierarchy
+///   (the cgroup directory's kernfs node id / inode). Captured in-kernel at event
+///   time, so it is available even for short-lived processes that exit before their
+///   `/proc` entry can be read. `0` means unknown.
+/// - `cgroup_path`: Best-effort path of that cgroup relative to the cgroup root
+///   (e.g. `/system.slice/foo.service`), resolved by walking the live cgroup
+///   hierarchy when the trace is written. `None` if the cgroup could not be
+///   resolved (e.g. it was removed before the trace was written). Resolution is
+///   racy: because kernfs inode numbers can be reused, an id whose cgroup was
+///   removed and replaced before the walk may resolve to a *different* cgroup's
+///   path. `cgroup_id` is always faithful; treat the path as a hint.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ProcessRecord {
     pub upid: i64,
@@ -23,6 +34,8 @@ pub struct ProcessRecord {
     pub parent_upid: Option<i64>,
     pub cmdline: Vec<String>,
     pub is_kernel_thread: bool,
+    pub cgroup_id: u64,
+    pub cgroup_path: Option<String>,
 }
 
 /// Thread information extracted from trace.

--- a/src/trace/schema.rs
+++ b/src/trace/schema.rs
@@ -32,6 +32,8 @@ pub fn process_schema() -> Arc<Schema> {
             false,
         ),
         Field::new("is_kernel_thread", DataType::Boolean, false),
+        Field::new("cgroup_id", DataType::UInt64, false),
+        Field::new("cgroup_path", DataType::Utf8, true),
     ]))
 }
 

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -43,6 +43,16 @@ fn setup_bpf_environment() {
     bump_memlock_rlimit().expect("Failed to bump memlock rlimit");
 }
 
+/// Read the current process's cgroup v2 path (relative to the cgroup root, e.g.
+/// "/system.slice/foo.service") from `/proc/self/cgroup`. Returns `None` on a
+/// system without a cgroup v2 unified hierarchy (no `0::` line).
+fn current_cgroup_v2_path() -> Option<String> {
+    let contents = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    contents
+        .lines()
+        .find_map(|line| line.strip_prefix("0::").map(|p| p.to_string()))
+}
+
 /// Python versions used by pystacks integration tests.
 /// Install these via: ./scripts/setup-pystacks.sh
 ///
@@ -599,6 +609,126 @@ fn test_e2e_validation_suite() {
         duckdb_result.errors,
         duckdb_result.warnings
     );
+
+    // --- Check: cgroup ids recorded and resolved to paths (test_e2e_cgroup_resolution) ---
+    eprintln!("  cgroup id resolution (duckdb)...");
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+
+        if systing::cgroup::cgroup2_root().is_none() {
+            eprintln!("    skipping: no cgroup v2 unified hierarchy on this system");
+        } else {
+            // cgroup_id is captured in-kernel for every task; cgroup_path is resolved
+            // by walking the live cgroup hierarchy when the trace is written. At least
+            // some processes must therefore end up with a resolved cgroup_path.
+            let resolved: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM process \
+                     WHERE cgroup_id != 0 AND cgroup_path IS NOT NULL",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("Failed to query process cgroup columns");
+            assert!(
+                resolved > 0,
+                "[cgroup resolution] no processes had a resolved cgroup_path"
+            );
+            eprintln!("    {resolved} processes have a resolved cgroup_path");
+
+            // Correctness: every distinct (cgroup_id, cgroup_path) stored in the trace
+            // must match what the live cgroup hierarchy resolves that id to. cgroups
+            // that have since been removed simply won't be in the live map, so we skip
+            // those and require at least one positive match.
+            let live_map = systing::cgroup::build_cgroup_id_map();
+            let mut stmt = conn
+                .prepare(
+                    "SELECT DISTINCT cgroup_id, cgroup_path FROM process \
+                     WHERE cgroup_path IS NOT NULL",
+                )
+                .expect("Failed to prepare distinct cgroup query");
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, u64>(0)?, row.get::<_, String>(1)?))
+                })
+                .expect("Failed to query distinct cgroups");
+
+            let mut matched = 0usize;
+            for row in rows {
+                let (id, path) = row.expect("Failed to read cgroup row");
+                if let Some(live_path) = live_map.get(&id) {
+                    assert_eq!(
+                        &path, live_path,
+                        "[cgroup resolution] cgroup_id {id} resolved to {path:?} in the trace \
+                         but {live_path:?} in the live hierarchy"
+                    );
+                    matched += 1;
+                }
+            }
+            assert!(
+                matched > 0,
+                "[cgroup resolution] no recorded cgroup id could be cross-checked against \
+                 the live cgroup hierarchy"
+            );
+            eprintln!("    cross-checked {matched} cgroup id(s) against the live hierarchy");
+
+            // Strongest check: the test harness drives the recording in-process, so its
+            // own pid is captured. Verify the recorded id/path exactly match the cgroup
+            // the test is running in, derived independently from /proc/self/cgroup.
+            //
+            // Assumption: the cgroup2 mount root equals this process's cgroup-namespace
+            // root, so mount-relative paths (what build_cgroup_id_map produces) agree
+            // with the namespace-relative `0::` path from /proc/self/cgroup. This holds
+            // for the normal/container cases but can diverge if the host hierarchy is
+            // bind-mounted in without a cgroup namespace; the broader `matched > 0`
+            // cross-check above does not depend on it.
+            if let Some(expected_path) = current_cgroup_v2_path() {
+                let cgroup_root = systing::cgroup::cgroup2_root()
+                    .expect("cgroup v2 path present but no cgroup2 mount found");
+                let abs = if expected_path == "/" {
+                    cgroup_root
+                } else {
+                    cgroup_root.join(expected_path.trim_start_matches('/'))
+                };
+                let expected_id = std::fs::metadata(&abs)
+                    .unwrap_or_else(|e| panic!("Failed to stat cgroup dir {}: {e}", abs.display()))
+                    .ino();
+
+                let my_pid = std::process::id() as i32;
+                let present: i64 = conn
+                    .query_row(
+                        "SELECT COUNT(*) FROM process WHERE pid = ?",
+                        [my_pid],
+                        |row| row.get(0),
+                    )
+                    .expect("Failed to count current pid in process table");
+                if present > 0 {
+                    let (db_id, db_path): (u64, Option<String>) = conn
+                        .query_row(
+                            "SELECT cgroup_id, cgroup_path FROM process WHERE pid = ?",
+                            [my_pid],
+                            |row| Ok((row.get(0)?, row.get(1)?)),
+                        )
+                        .expect("Failed to query current process row");
+                    assert_eq!(
+                        db_id, expected_id,
+                        "[cgroup resolution] cgroup_id mismatch for the current process"
+                    );
+                    assert_eq!(
+                        db_path.as_deref(),
+                        Some(expected_path.as_str()),
+                        "[cgroup resolution] cgroup_path mismatch for the current process"
+                    );
+                    eprintln!(
+                        "    current process cgroup resolved: id={db_id} path={expected_path}"
+                    );
+                } else {
+                    eprintln!("    current pid {my_pid} not captured; skipping self check");
+                }
+            }
+        }
+    }
 
     // --- Check: exit states in duckdb (test_e2e_task_exit_states) ---
     eprintln!("  exit states (duckdb)...");


### PR DESCRIPTION
## Problem

Process names and ids are resolved through the `pidtgid`, but that falls apart for short-lived processes: the process can exit before userspace reads `/proc`, leaving the task unattributable. Even when we can't resolve the process itself, we'd still like to know which cgroup it belonged to.

## Approach

Capture each task's cgroup id (the v2 unified hierarchy's `dfl_cgrp->kn->id`) **in-kernel at event time** and carry it inline in `task_info`, alongside `pidtgid` and `comm`. Because the id rides in on the event, a process that has already exited by the time userspace drains the ringbuf can still be attributed to a cgroup.

- When a process is only ever seen via one of its threads, the synthesized process record inherits that thread's cgroup id (the existing `*info` copy in `maybe_record_task` carries the new field through).
- At trace-write time the numeric id is resolved to a human-readable cgroup path by walking the live cgroup2 hierarchy. The cgroup directory's inode equals the recorded id — the same convention the existing cgroup filter relies on (`metadata.ino()` vs `task_cg_id()`).
- Resolution is best-effort: a cgroup removed before the walk is left unresolved. It is also racy w.r.t. kernfs inode reuse, so `cgroup_id` is the source of truth and `cgroup_path` is a hint (documented).

## Schema change

Two new columns on the `process` table:
- `cgroup_id` (`UBIGINT`) — always recorded; `0` means unknown
- `cgroup_path` (`VARCHAR`) — best-effort resolved path, `NULL` if unavailable

`SCHEMA_VERSION` 7 → 8, `SCHEMA_CHANGES.md` entry added, version bumped 1.6.6 → 1.7.0 (minor, per the schema-change policy). Both the by-name recorder import path and the positional `systing_util` perfetto→duckdb import path are kept consistent with the new columns; old databases import cleanly (id defaults to 0, path to NULL).

## Design notes

- `cgid` is kept **inline** in `task_info` for consistency with `comm` (already shipped inline per event), rather than via a separate BPF-populated map. Trade-off documented on the struct.
- `confidentiality_mode` is a kernel-lockdown compatibility flag, not a privacy toggle. `task_cg_id()` uses direct BTF reads (allowed under lockdown, unlike the restricted probe-read used for `comm`), so `cgid` is recorded unconditionally.
- `cgroup2_root()` validates the `/sys/fs/cgroup` fallback is really cgroup v2 (checks for `cgroup.controllers`) so a cgroup v1 host doesn't get a bogus id→path map.

## Testing

- `cargo build`, `cargo clippy --all-targets`, `cargo fmt --check`, unit tests (incl. new `cgroup` module tests covering mountinfo octal-escape decoding and edge cases) — all clean.
- End-to-end integration test folded into `test_e2e_validation_suite` (reuses the single recording). It asserts processes get resolved cgroup paths, cross-checks every recorded `(cgroup_id, cgroup_path)` against a fresh live-hierarchy map, and independently verifies the test process's own row against `/proc/self/cgroup`. Live run: 3893 processes resolved, 23 cgroup ids cross-checked, self-check matched exactly.