### PR TITLE
Fix build failure with blazesym 0.2.x stable releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -663,15 +663,15 @@ dependencies = [
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-rc.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a810b7e5f883ad3c711208237841f051061bf59b6ee698ac4dc1fe12a3a5db"
+checksum = "48ceccc54b9c3e60e5f36b0498908c8c0f87387229cb0e0e5d65a074e00a8ba4"
 dependencies = [
  "cpp_demangle",
  "gimli 0.32.0",
  "libc",
  "memmap2 0.9.5",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "rustc-demangle",
 ]
 
@@ -933,9 +933,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -1223,7 +1223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -2081,6 +2081,15 @@ name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3220,9 +3229,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -3400,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"
@@ -17,7 +17,11 @@ duckdb-bundled = ["duckdb/bundled", "duckdb/parquet"]
 [dependencies]
 anyhow = "1.0"
 bitfield = "0.19.0"
-blazesym = "0.2.0-rc.4"
+# Pinned exactly: the old "0.2.0-rc.4" requirement also matched later stable
+# 0.2.x releases (where Sym::code_info became Option<Box<CodeInfo>>), so
+# `cargo install` without --locked picked an incompatible version. An exact pin
+# keeps fresh resolutions reproducible.
+blazesym = "=0.2.3"
 clap = { version = "4.5.20", features = ["derive"] }
 ctrlc = "3.4"
 dashmap = "6"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ cargo build
 sudo ./target/debug/systing --duration 60
 ```
 
+Alternatively, install directly with cargo. Use `--locked` so the build uses
+the dependency versions from `Cargo.lock`:
+
+```bash
+cargo install --locked --git https://github.com/josefbacik/systing.git
+```
+
 This will generate a `trace.pb` file which can be uploaded to a
 [Perfetto](https://perfetto.dev/) instance for further analysis.
 

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -370,8 +370,8 @@ impl StackRecorder {
 }
 
 /// Formats code location information as a string suffix (e.g., "[file.rs:123]")
-fn format_location_info(code_info: &Option<blazesym::symbolize::CodeInfo>) -> String {
-    code_info.as_ref().map_or(String::new(), |info| {
+fn format_location_info(code_info: Option<&blazesym::symbolize::CodeInfo>) -> String {
+    code_info.map_or(String::new(), |info| {
         let file_name = info.file.to_str().unwrap_or("unknown");
         if let Some(line) = info.line {
             format!(" [{file_name}:{line}]")
@@ -391,7 +391,7 @@ fn format_symbolized_frame(sym: &Sym, addr: u64, default_module: &str) -> String
         .and_then(|m| std::path::Path::new(m).file_name())
         .and_then(|f| f.to_str())
         .unwrap_or(default_module);
-    let location_info = format_location_info(&sym.code_info);
+    let location_info = format_location_info(sym.code_info.as_deref());
     format!(
         "{} ({}{}) <{:#x}>",
         sym.name, module_name, location_info, addr


### PR DESCRIPTION
## Summary

Fixes #111.

`cargo install --git ... --tag v1.6.0` (and against `main`) fails with:

```
error[E0308]: mismatched types
   --> src/stack_recorder.rs:388:46
    |
388 |     let location_info = format_location_info(&sym.code_info);
    |                         -------------------- ^^^^^^^^^^^^^^ expected `&Option<CodeInfo<'_>>`, found `&Option<Box<CodeInfo<'_>>>`
```

### Root cause

`Cargo.toml` requested `blazesym = "0.2.0-rc.4"`. That requirement also matches the later stable releases (0.2.0–0.2.3). The committed `Cargo.lock` pins rc.4 so local builds work, but `cargo install` ignores `Cargo.lock` unless `--locked` is passed, so fresh installs resolve blazesym 0.2.3 — where `Sym::code_info` changed from `Option<CodeInfo>` to `Option<Box<CodeInfo>>` — and the build breaks.

### Changes

- `src/stack_recorder.rs`: `format_location_info` now takes `Option<&CodeInfo>` and the call site passes `sym.code_info.as_deref()`, matching the boxed field in current blazesym.
- `Cargo.toml`: pin `blazesym = "=0.2.3"` (with a comment explaining why) so fresh resolutions are reproducible; `Cargo.lock` updated accordingly.
- `README.md`: document `cargo install --locked --git ...` as the recommended install command.
- Version bumped 1.7.1 → 1.7.2 (non-schema change).

### Testing

- `cargo build`, `cargo fmt --check`, `cargo clippy` clean
- Unit tests: all pass
- Integration suite (`./scripts/run-integration-tests.sh`): 30 passed, 0 failed — including the pystacks/symbolization tests that exercise the changed code path
- Verified a fresh resolve of `=0.2.3` (what `cargo install` does) locks to exactly 0.2.3