### PR TITLE
Remove unused dependencies: rayon, rusqlite, http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
  "cast",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.10.0",
+ "hashlink",
  "libduckdb-sys",
  "num-integer",
  "rust_decimal",
@@ -1431,9 +1431,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1449,15 +1446,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
-dependencies = [
- "hashbrown 0.14.5",
-]
 
 [[package]]
 name = "hashlink"
@@ -1980,16 +1968,6 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
-dependencies = [
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2936,20 +2914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
-dependencies = [
- "bitflags 2.6.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink 0.9.1",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rust_decimal"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,7 +3386,6 @@ dependencies = [
  "dns-lookup",
  "duckdb",
  "flate2",
- "http",
  "indicatif",
  "libbpf-cargo",
  "libbpf-rs",
@@ -3436,10 +3399,8 @@ dependencies = [
  "prost-types",
  "protobuf",
  "rand 0.9.0",
- "rayon",
  "regex",
  "rmcp",
- "rusqlite",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ duckdb = "1.1.1"
 parquet = "54"
 arrow = "54"
 flate2 = "1.0"
-http = "1"
 indicatif = "0.17"
 libbpf-rs = "0.25.0"
 libc = "0.2"
@@ -39,10 +38,8 @@ nix = { version = "0.29.0", features = ["ioctl"] }
 perfetto_protos = "0.48.1"
 plain = "0.2"
 protobuf = "3.7.1"
-rayon = "1.10"
 rand = "0.9.0"
 regex = "1.11.1"
-rusqlite = "0.32"
 rmcp = { version = "0.13", features = ["server", "transport-io", "macros"] }
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Drops three dependencies that are no longer (or were never) used:

- **rayon** — left behind when the rayon-based parallel trace loading was replaced by the bounded 2-worker/sync_channel implementation (fa1e175). No remaining references.
- **rusqlite** — added alongside systing-analyze but never used in code. Removing it also drops libsqlite3-sys (bundled SQLite C build) and hashlink from the dependency graph.
- **http** — only referenced by the generated tonic code under `src/tpu/gen/`, which resolves it through `tonic::codegen`, so it doesn't need to be a direct dependency.

No code changes; `cargo check --all-targets`, fmt, clippy, and tests all pass. No version bump since this doesn't affect behavior — can ride along with the next patch release.