### PR TITLE
Disable DuckDB external access in systing-analyze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.7.2"
+version = "1.7.3"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.7.2"
+version = "1.7.3"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -143,12 +143,17 @@ impl AnalyzeDb {
             bail!("Database not found: {}", path.display());
         }
 
-        let conn = if read_only {
-            let config = duckdb::Config::default().access_mode(duckdb::AccessMode::ReadOnly)?;
-            Connection::open_with_flags(path, config)?
-        } else {
-            Connection::open(path)?
-        };
+        // Disable external access (reading/writing files, ATTACH, loading
+        // extensions) so SQL run against an untrusted trace database -- e.g.
+        // queries an AI assistant was prompt-injected into running via the MCP
+        // server -- cannot touch anything outside the trace database. DuckDB
+        // refuses to re-enable this setting while the database is running, so
+        // it cannot be undone with a SET statement.
+        let mut config = duckdb::Config::default().enable_external_access(false)?;
+        if read_only {
+            config = config.access_mode(duckdb::AccessMode::ReadOnly)?;
+        }
+        let conn = Connection::open_with_flags(path, config)?;
 
         Ok(Self {
             conn,
@@ -542,5 +547,85 @@ mod tests {
     fn test_to_u64_negative() {
         assert_eq!(to_u64(-1), 0);
         assert_eq!(to_u64(i64::MIN), 0);
+    }
+
+    /// Assert that an error is DuckDB refusing an operation because external
+    /// access is disabled. DuckDB 1.4 phrases this "disabled by configuration"
+    /// for file access and "disabled through configuration" for extension
+    /// loading (older releases used the latter for both).
+    fn assert_external_access_blocked(err: &anyhow::Error) {
+        let msg = err.to_string();
+        assert!(
+            msg.contains("disabled by configuration")
+                || msg.contains("disabled through configuration"),
+            "expected external-access error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_open_blocks_external_access() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.duckdb");
+
+        // Create a small database to analyze.
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1);")
+                .unwrap();
+        }
+
+        // An external file that queries must not be able to read.
+        let csv_path = dir.path().join("external.csv");
+        std::fs::write(&csv_path, "a,b\n1,2\n").unwrap();
+
+        for read_only in [true, false] {
+            let db = AnalyzeDb::open(&db_path, read_only).unwrap();
+
+            // Queries against the trace database itself still work.
+            let result = db.query("SELECT x FROM t").unwrap();
+            assert_eq!(result.row_count, 1);
+
+            // Reading external files is blocked.
+            let read_err = db
+                .query(&format!(
+                    "SELECT * FROM read_csv_auto('{}')",
+                    csv_path.display()
+                ))
+                .unwrap_err();
+            assert_external_access_blocked(&read_err);
+
+            // Writing external files is blocked.
+            let copy_err = db
+                .query(&format!(
+                    "COPY (SELECT 1) TO '{}'",
+                    dir.path().join("out.csv").display()
+                ))
+                .unwrap_err();
+            assert_external_access_blocked(&copy_err);
+
+            // Attaching other database files is blocked.
+            let attach_err = db
+                .query(&format!(
+                    "ATTACH '{}' AS other",
+                    dir.path().join("other.duckdb").display()
+                ))
+                .unwrap_err();
+            assert_external_access_blocked(&attach_err);
+
+            // Installing or loading external extensions (e.g. httpfs for
+            // network egress) is blocked.
+            assert!(db.query("INSTALL httpfs").is_err());
+            let load_err = db.query("LOAD httpfs").unwrap_err();
+            assert_external_access_blocked(&load_err);
+
+            // The setting cannot be re-enabled at runtime.
+            let set_err = db.query("SET enable_external_access = true").unwrap_err();
+            assert!(
+                set_err
+                    .to_string()
+                    .contains("Cannot change enable_external_access"),
+                "unexpected error: {set_err}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Motivation

systing-analyze runs SQL against trace databases, including arbitrary queries issued through the MCP server's `query` tool. A malicious or attacker-influenced trace could steer those queries into using DuckDB's external-access features — `read_csv`/`read_parquet` of arbitrary files, `COPY TO`, `ATTACH`, extension install/load (and thus httpfs network egress) — to read or exfiltrate files outside the trace database, or write to disk.

## Fix

`AnalyzeDb::open()` now always builds the DuckDB config with `enable_external_access(false)` and opens via `Connection::open_with_flags` for both read-only and read-write modes (previously the read-write path used a plain `Connection::open` with no config).

Properties of the mitigation (verified against the bundled DuckDB 1.4.2 sources):

- The setting cannot be re-enabled or reset while the database is running, and `allowed_paths`/`allowed_directories` cannot be modified while it is disabled — so it cannot be undone by a `SET` statement in a query.
- The trace database path, its WAL, and the default temp/spill directory are allowlisted by DuckDB at open, so normal analysis (including large queries that spill) is unaffected.
- The parquet extension is statically bundled, so no runtime INSTALL/LOAD is needed.
- Blocked: external file reads (`read_csv*`, `read_parquet`, `glob`, ...), external file writes (`COPY TO`, `EXPORT`), `ATTACH` of other databases, and external extension install/load.

All systing-analyze CLI subcommands and the MCP server go through `AnalyzeDb::open`, so this covers every analyze connection. The trace-recording path (`src/duckdb.rs`) is a separate code path and is unchanged.

## Testing

- New unit test `analyze::tests::test_open_blocks_external_access`: verifies queries against the trace database still work while external file reads/writes, `ATTACH`, `INSTALL httpfs`/`LOAD httpfs`, and re-enabling the setting all fail, in both read-only and read-write modes.
- `cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` (330 unit tests plus the non-ignored integration suites) all pass.

## Versioning

Non-schema change: patch bump 1.7.2 → 1.7.3.