### PR TITLE
Fix perf-counter data loss when --cpu-frequency is also enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.7.4"
+version = "1.7.5"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2021"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -21,7 +21,7 @@ use crate::ringbuf::RingBuffer;
 use crate::systing_core::types::probe_event;
 use crate::systing_core::SystingRecordEvent;
 use crate::trace::{ArgRecord, InstantArgRecord, InstantRecord, SliceRecord, TrackRecord};
-use crate::utid::{ThreadAwareRecorder, UtidGenerator};
+use crate::utid::{ThreadAwareRecorder, TrackEventIdGenerator, UtidGenerator};
 
 use anyhow::Result;
 use plain::Plain;
@@ -116,9 +116,9 @@ pub struct SystingProbeRecorder {
 
     // Streaming support
     streaming_collector: Option<Box<dyn RecordCollector + Send>>,
-    track_id_counter: i64,
-    slice_id_counter: i64,
-    instant_id_counter: i64,
+    /// Shared with every other recorder that emits track/slice/instant rows
+    /// (e.g. the marker recorder) so IDs stay unique across them.
+    track_event_ids: Arc<TrackEventIdGenerator>,
     track_cache: HashMap<TrackCacheKey, i64>,
 
     // Shared utid generator for consistent thread IDs across all recorders
@@ -254,8 +254,12 @@ impl ThreadAwareRecorder for SystingProbeRecorder {
 }
 
 impl SystingProbeRecorder {
-    /// Create a new SystingProbeRecorder with the given utid generator.
-    pub fn new(utid_generator: Arc<UtidGenerator>) -> Self {
+    /// Create a new SystingProbeRecorder with the given utid generator and
+    /// shared track-event ID generator.
+    pub fn new(
+        utid_generator: Arc<UtidGenerator>,
+        track_event_ids: Arc<TrackEventIdGenerator>,
+    ) -> Self {
         Self {
             ringbuf: RingBuffer::default(),
             cookies: HashMap::new(),
@@ -273,9 +277,7 @@ impl SystingProbeRecorder {
             ranges: HashMap::new(),
             pending_syscalls: HashMap::new(),
             streaming_collector: None,
-            track_id_counter: 0,
-            slice_id_counter: 0,
-            instant_id_counter: 0,
+            track_event_ids,
             track_cache: HashMap::new(),
             utid_generator,
         }
@@ -296,8 +298,7 @@ impl SystingProbeRecorder {
             return Ok(id);
         }
 
-        self.track_id_counter += 1;
-        let track_id = self.track_id_counter;
+        let track_id = self.track_event_ids.next_track_id();
 
         let name = match &key {
             TrackCacheKey::Thread { track_name, .. } => track_name.clone(),
@@ -366,8 +367,7 @@ impl SystingProbeRecorder {
                         track_name: SYSCALLS_TRACK_NAME.to_string(),
                     };
                     if let Ok(track_id) = self.get_or_create_track(key, &mut *collector) {
-                        self.slice_id_counter += 1;
-                        let slice_id = self.slice_id_counter;
+                        let slice_id = self.track_event_ids.next_slice_id();
 
                         let tid = tgidpid as i32;
                         let utid = Some(self.utid_generator.get_or_create_utid(tid));
@@ -421,8 +421,7 @@ impl SystingProbeRecorder {
                     track_name: instant_track,
                 };
                 if let Ok(track_id) = self.get_or_create_track(key, &mut *collector) {
-                    self.instant_id_counter += 1;
-                    let instant_id = self.instant_id_counter;
+                    let instant_id = self.track_event_ids.next_instant_id();
 
                     if let Err(e) = collector.add_instant(InstantRecord {
                         id: instant_id,
@@ -470,8 +469,7 @@ impl SystingProbeRecorder {
                                 track_name: track_name.clone(),
                             };
                             if let Ok(track_id) = self.get_or_create_track(key, &mut *collector) {
-                                self.slice_id_counter += 1;
-                                let slice_id = self.slice_id_counter;
+                                let slice_id = self.track_event_ids.next_slice_id();
 
                                 if let Err(e) = collector.add_slice(SliceRecord {
                                     id: slice_id,
@@ -560,8 +558,7 @@ impl SystingProbeRecorder {
                     track_name: instant_track,
                 };
                 if let Ok(track_id) = self.get_or_create_track(key, &mut *collector) {
-                    self.instant_id_counter += 1;
-                    let instant_id = self.instant_id_counter;
+                    let instant_id = self.track_event_ids.next_instant_id();
                     let tid = event.task.tgidpid as i32;
                     let utid = Some(self.utid_generator.get_or_create_utid(tid));
 
@@ -620,8 +617,7 @@ impl SystingProbeRecorder {
                                 track_name: track_name.clone(),
                             };
                             if let Ok(track_id) = self.get_or_create_track(key, &mut *collector) {
-                                self.slice_id_counter += 1;
-                                let slice_id = self.slice_id_counter;
+                                let slice_id = self.track_event_ids.next_slice_id();
                                 let tid = event.task.tgidpid as i32;
                                 let utid = Some(self.utid_generator.get_or_create_utid(tid));
 

--- a/src/events/tests.rs
+++ b/src/events/tests.rs
@@ -1,12 +1,15 @@
 use super::*;
 use crate::record::collector::InMemoryCollector;
 use crate::systing_core::types::task_info;
-use crate::utid::UtidGenerator;
+use crate::utid::{TrackEventIdGenerator, UtidGenerator};
 use rand::rngs::mock::StepRng;
 use std::sync::Arc;
 
 fn new_recorder() -> SystingProbeRecorder {
-    SystingProbeRecorder::new(Arc::new(UtidGenerator::new()))
+    SystingProbeRecorder::new(
+        Arc::new(UtidGenerator::new()),
+        Arc::new(TrackEventIdGenerator::new()),
+    )
 }
 
 /// Create a test recorder with a streaming collector already set,
@@ -2130,4 +2133,96 @@ fn test_range_mismatched_scope_is_rejected() {
     let result = recorder.load_config_from_json(json, &mut rng);
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("scope"));
+}
+
+#[test]
+fn test_track_event_ids_shared_with_marker_recorder() {
+    // The probe recorder and the marker recorder both emit track/slice/instant
+    // rows into the same tables, so they share a TrackEventIdGenerator. IDs
+    // allocated by one recorder must never be reused by the other.
+    use crate::marker_recorder::{
+        MarkerRecorder, MARKER_TYPE_END, MARKER_TYPE_INSTANT, MARKER_TYPE_START,
+    };
+    use crate::systing_core::marker_event;
+
+    let utid_gen = Arc::new(UtidGenerator::new());
+    let track_event_ids = Arc::new(TrackEventIdGenerator::new());
+
+    // Probe recorder streams a syscall slice (track + slice + arg) and a
+    // trace-event instant (track + instant).
+    let mut rng = StepRng::new(0, 1);
+    let mut probe_recorder =
+        SystingProbeRecorder::new(Arc::clone(&utid_gen), Arc::clone(&track_event_ids));
+    probe_recorder.set_streaming_collector(Box::new(InMemoryCollector::new()));
+    probe_recorder
+        .add_event_from_str("tracepoint:category:tp_name", &mut rng)
+        .unwrap();
+    probe_recorder.handle_event(create_syscall_enter_event(100, 101, 1000, 1));
+    probe_recorder.handle_event(create_syscall_exit_event(100, 101, 2000, 1, 42));
+    probe_recorder.handle_event(probe_event {
+        task: task_info {
+            tgidpid: (100u64 << 32) | 101u64,
+            ..Default::default()
+        },
+        ts: 1200,
+        cookie: 0, // matches the StepRng-generated cookie for the tracepoint event
+        ..Default::default()
+    });
+    let probe_data = probe_recorder.finish_in_memory();
+
+    // Marker recorder writes a range slice and an instant on its own track.
+    let marker_event_for = |marker_type: u32, name: &str, ts: u64| -> marker_event {
+        let mut event = marker_event {
+            marker_type,
+            ts,
+            ..Default::default()
+        };
+        event.task.tgidpid = (100u64 << 32) | 101u64;
+        event.name[..name.len()].copy_from_slice(name.as_bytes());
+        event
+    };
+    let mut marker_recorder =
+        MarkerRecorder::new(Arc::clone(&utid_gen), Arc::clone(&track_event_ids));
+    marker_recorder.handle_event(marker_event_for(MARKER_TYPE_START, "MyTrack:range", 1100));
+    marker_recorder.handle_event(marker_event_for(MARKER_TYPE_END, "MyTrack:range", 1900));
+    marker_recorder.handle_event(marker_event_for(MARKER_TYPE_INSTANT, "checkpoint", 1500));
+    let mut marker_collector = InMemoryCollector::new();
+    marker_recorder
+        .write_records(&mut marker_collector)
+        .unwrap();
+    let marker_data = marker_collector.into_data();
+
+    // Both recorders produced rows...
+    assert!(!probe_data.tracks.is_empty());
+    assert!(!probe_data.slices.is_empty());
+    assert!(!probe_data.instants.is_empty());
+    assert!(!marker_data.tracks.is_empty());
+    assert!(!marker_data.slices.is_empty());
+    assert!(!marker_data.instants.is_empty());
+
+    // ...and no track, slice, or instant ID is shared between them.
+    for probe_track in &probe_data.tracks {
+        assert!(
+            marker_data.tracks.iter().all(|t| t.id != probe_track.id),
+            "track id {} allocated by both recorders",
+            probe_track.id
+        );
+    }
+    for probe_slice in &probe_data.slices {
+        assert!(
+            marker_data.slices.iter().all(|s| s.id != probe_slice.id),
+            "slice id {} allocated by both recorders",
+            probe_slice.id
+        );
+    }
+    for probe_instant in &probe_data.instants {
+        assert!(
+            marker_data
+                .instants
+                .iter()
+                .all(|i| i.id != probe_instant.id),
+            "instant id {} allocated by both recorders",
+            probe_instant.id
+        );
+    }
 }

--- a/src/marker_recorder.rs
+++ b/src/marker_recorder.rs
@@ -8,7 +8,7 @@ use crate::record::RecordCollector;
 use crate::ringbuf::RingBuffer;
 use crate::systing_core::{marker_event, SystingRecordEvent};
 use crate::trace::{ArgRecord, InstantArgRecord, InstantRecord, SliceRecord, TrackRecord};
-use crate::utid::{ThreadAwareRecorder, UtidGenerator};
+use crate::utid::{ThreadAwareRecorder, TrackEventIdGenerator, UtidGenerator};
 
 struct MarkerRange {
     track: String,
@@ -42,6 +42,9 @@ pub struct MarkerRecorder {
     // ingestion path (before events enter the ring buffer), while `handle_event`
     // runs on the drain path. They observe events at different times.
     outstanding_triggers: HashMap<(u64, String, String), u64>,
+    /// Shared with every other recorder that emits track/slice/instant rows
+    /// (e.g. the probe recorder) so IDs stay unique across them.
+    track_event_ids: Arc<TrackEventIdGenerator>,
     utid_generator: Arc<UtidGenerator>,
 }
 
@@ -169,7 +172,10 @@ impl SystingRecordEvent<marker_event> for MarkerRecorder {
 }
 
 impl MarkerRecorder {
-    pub fn new(utid_generator: Arc<UtidGenerator>) -> Self {
+    pub fn new(
+        utid_generator: Arc<UtidGenerator>,
+        track_event_ids: Arc<TrackEventIdGenerator>,
+    ) -> Self {
         Self {
             ringbuf: RingBuffer::default(),
             outstanding_ranges: HashMap::new(),
@@ -179,6 +185,7 @@ impl MarkerRecorder {
             threshold: None,
             duration_threshold_ns: None,
             outstanding_triggers: HashMap::new(),
+            track_event_ids,
             utid_generator,
         }
     }
@@ -203,13 +210,7 @@ impl MarkerRecorder {
         [range_min, instant_min].into_iter().flatten().min()
     }
 
-    pub fn write_records(
-        &self,
-        collector: &mut dyn RecordCollector,
-        track_id_counter: &mut i64,
-        slice_id_counter: &mut i64,
-        instant_id_counter: &mut i64,
-    ) -> Result<()> {
+    pub fn write_records(&self, collector: &mut dyn RecordCollector) -> Result<()> {
         if !self.outstanding_ranges.is_empty() {
             eprintln!(
                 "Warning: {} marker range(s) had START but no END and will be dropped",
@@ -233,11 +234,7 @@ impl MarkerRecorder {
                 .entry(tid)
                 .or_default()
                 .entry(&r.track)
-                .or_insert_with(|| {
-                    let id = *track_id_counter;
-                    *track_id_counter += 1;
-                    id
-                });
+                .or_insert_with(|| self.track_event_ids.next_track_id());
             range_track_ids.push(id);
         }
         for i in &self.instants {
@@ -246,16 +243,12 @@ impl MarkerRecorder {
                 .entry(tid)
                 .or_default()
                 .entry(&i.track)
-                .or_insert_with(|| {
-                    let id = *track_id_counter;
-                    *track_id_counter += 1;
-                    id
-                });
+                .or_insert_with(|| self.track_event_ids.next_track_id());
             instant_track_ids.push(id);
         }
 
         // Emit track descriptors in stable id order (HashMap iteration is
-        // non-deterministic; ids are monotonic from track_id_counter).
+        // non-deterministic; ids are monotonic from the shared generator).
         let mut ordered_tracks: Vec<(&str, i64)> = track_ids
             .values()
             .flat_map(|inner| inner.iter().map(|(&name, &id)| (name, id)))
@@ -273,8 +266,7 @@ impl MarkerRecorder {
         for (r, &track_id) in self.recorded_ranges.iter().zip(range_track_ids.iter()) {
             let tid = r.tgidpid as i32;
             let utid = Some(self.utid_generator.get_or_create_utid(tid));
-            let slice_id = *slice_id_counter;
-            *slice_id_counter += 1;
+            let slice_id = self.track_event_ids.next_slice_id();
 
             collector.add_slice(SliceRecord {
                 id: slice_id,
@@ -300,8 +292,7 @@ impl MarkerRecorder {
         for (i, &track_id) in self.instants.iter().zip(instant_track_ids.iter()) {
             let tid = i.tgidpid as i32;
             let utid = Some(self.utid_generator.get_or_create_utid(tid));
-            let instant_id = *instant_id_counter;
-            *instant_id_counter += 1;
+            let instant_id = self.track_event_ids.next_instant_id();
 
             collector.add_instant(InstantRecord {
                 id: instant_id,
@@ -331,7 +322,10 @@ mod tests {
     use crate::systing_core::task_info;
 
     fn new_recorder() -> MarkerRecorder {
-        MarkerRecorder::new(Arc::new(UtidGenerator::new()))
+        MarkerRecorder::new(
+            Arc::new(UtidGenerator::new()),
+            Arc::new(TrackEventIdGenerator::new()),
+        )
     }
 
     fn make_event(marker_type: u32, name: &str, tgidpid: u64, ts: u64) -> marker_event {
@@ -438,9 +432,7 @@ mod tests {
         recorder.handle_event(make_event(2, "T:instant", 1, 150));
 
         let mut collector = crate::record::collector::InMemoryCollector::new();
-        recorder
-            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
-            .unwrap();
+        recorder.write_records(&mut collector).unwrap();
 
         let data = collector.into_data();
         // Only one track "T" should be created
@@ -586,9 +578,7 @@ mod tests {
         recorder.handle_event(make_event_with_info(2, "T:instant", 1, 150, 77));
 
         let mut collector = crate::record::collector::InMemoryCollector::new();
-        recorder
-            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
-            .unwrap();
+        recorder.write_records(&mut collector).unwrap();
 
         let data = collector.into_data();
         // Should have one arg for the slice
@@ -611,15 +601,14 @@ mod tests {
         let gen = Arc::new(UtidGenerator::new());
         let tid: i32 = 4242;
         let tgidpid = ((tid as u64) << 32) | (tid as u64);
-        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        let mut recorder =
+            MarkerRecorder::new(Arc::clone(&gen), Arc::new(TrackEventIdGenerator::new()));
         recorder.handle_event(make_event(0, "T:evt", tgidpid, 1000));
         recorder.handle_event(make_event(1, "T:evt", tgidpid, 2000));
         recorder.handle_event(make_event(2, "T:inst", tgidpid, 1500));
 
         let mut collector = crate::record::collector::InMemoryCollector::new();
-        recorder
-            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
-            .unwrap();
+        recorder.write_records(&mut collector).unwrap();
         let data = collector.into_data();
 
         let expected_utid = gen.get_utid(tid).expect("utid should exist after write");
@@ -639,16 +628,15 @@ mod tests {
         let tid_b: i32 = 1002;
         let tgidpid_a = ((tid_a as u64) << 32) | (tid_a as u64);
         let tgidpid_b = ((tid_b as u64) << 32) | (tid_b as u64);
-        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        let mut recorder =
+            MarkerRecorder::new(Arc::clone(&gen), Arc::new(TrackEventIdGenerator::new()));
         recorder.handle_event(make_event(0, "T:evt", tgidpid_a, 100));
         recorder.handle_event(make_event(1, "T:evt", tgidpid_a, 200));
         recorder.handle_event(make_event(0, "T:evt", tgidpid_b, 150));
         recorder.handle_event(make_event(1, "T:evt", tgidpid_b, 250));
 
         let mut collector = crate::record::collector::InMemoryCollector::new();
-        recorder
-            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
-            .unwrap();
+        recorder.write_records(&mut collector).unwrap();
         let data = collector.into_data();
 
         assert_eq!(data.tracks.len(), 2, "expected one track per thread");
@@ -683,15 +671,14 @@ mod tests {
         let gen = Arc::new(UtidGenerator::new());
         let tid: i32 = 77;
         let tgidpid = ((tid as u64) << 32) | (tid as u64);
-        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        let mut recorder =
+            MarkerRecorder::new(Arc::clone(&gen), Arc::new(TrackEventIdGenerator::new()));
         recorder.handle_event(make_event(0, "T:range", tgidpid, 100));
         recorder.handle_event(make_event(1, "T:range", tgidpid, 200));
         recorder.handle_event(make_event(2, "T:inst", tgidpid, 150));
 
         let mut collector = crate::record::collector::InMemoryCollector::new();
-        recorder
-            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
-            .unwrap();
+        recorder.write_records(&mut collector).unwrap();
         let data = collector.into_data();
 
         let expected_utid = gen.get_utid(tid).unwrap();
@@ -710,15 +697,14 @@ mod tests {
         let tgid: i32 = 99;
         let tid: i32 = 42;
         let tgidpid = ((tgid as u64) << 32) | (tid as u32 as u64);
-        let mut recorder = MarkerRecorder::new(Arc::clone(&gen));
+        let mut recorder =
+            MarkerRecorder::new(Arc::clone(&gen), Arc::new(TrackEventIdGenerator::new()));
         recorder.handle_event(make_event(0, "T:evt", tgidpid, 100));
         recorder.handle_event(make_event(1, "T:evt", tgidpid, 200));
         recorder.handle_event(make_event(2, "T:inst", tgidpid, 150));
 
         let mut collector = crate::record::collector::InMemoryCollector::new();
-        recorder
-            .write_records(&mut collector, &mut 0, &mut 0, &mut 0)
-            .unwrap();
+        recorder.write_records(&mut collector).unwrap();
         let data = collector.into_data();
 
         let utid = gen.get_utid(tid).expect("utid should exist for tid");

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -2762,4 +2762,122 @@ mod tests {
         assert_eq!(metric_name, "test.metric");
         assert!((value - 42.0).abs() < f64::EPSILON);
     }
+
+    #[test]
+    fn test_shared_collector_counter_round_trip() {
+        use crate::record::SharedCollector;
+
+        let dir = TempDir::new().unwrap();
+
+        // Two recorders sharing one writer (the perf-counter and CPU-frequency
+        // recorders do this in production): both write counter tracks and
+        // counter samples, and every row must survive in the single
+        // counter.parquet / counter_track.parquet pair.
+        let shared =
+            SharedCollector::new(Box::new(StreamingParquetWriter::new(dir.path()).unwrap()));
+        let mut perf_handle = shared.clone();
+        let mut freq_handle = shared;
+
+        perf_handle
+            .add_counter_track(CounterTrackRecord {
+                id: 1,
+                name: "instructions CPU 0".to_string(),
+                unit: Some("count".to_string()),
+            })
+            .unwrap();
+        perf_handle
+            .add_counter(CounterRecord {
+                ts: 1_000,
+                track_id: 1,
+                value: 42.0,
+            })
+            .unwrap();
+        freq_handle
+            .add_counter_track(CounterTrackRecord {
+                id: 2,
+                name: "CPU 0 frequency".to_string(),
+                unit: Some("Hz".to_string()),
+            })
+            .unwrap();
+        freq_handle
+            .add_counter(CounterRecord {
+                ts: 2_000,
+                track_id: 2,
+                value: 2_400.0,
+            })
+            .unwrap();
+
+        // Finishing the first handle must not finalize the shared writer ...
+        perf_handle.finish().unwrap();
+        // ... the surviving handle can still write ...
+        freq_handle
+            .add_counter(CounterRecord {
+                ts: 3_000,
+                track_id: 2,
+                value: 2_500.0,
+            })
+            .unwrap();
+        // ... and only the last handle's finish closes the files.
+        freq_handle.finish().unwrap();
+
+        // Read back counter_track.parquet: both recorders' tracks are present.
+        let file = File::open(dir.path().join("counter_track.parquet")).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let batches: Vec<_> = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        let mut track_names = Vec::new();
+        for batch in &batches {
+            let names: &arrow::array::StringArray = batch.column(1).as_string();
+            for i in 0..batch.num_rows() {
+                track_names.push(names.value(i).to_string());
+            }
+        }
+        track_names.sort();
+        assert_eq!(
+            track_names,
+            vec![
+                "CPU 0 frequency".to_string(),
+                "instructions CPU 0".to_string()
+            ],
+            "tracks from both handles should survive in counter_track.parquet"
+        );
+
+        // Read back counter.parquet: all samples from both recorders are present.
+        let file = File::open(dir.path().join("counter.parquet")).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let batches: Vec<_> = reader.collect::<Result<Vec<_>, _>>().unwrap();
+        let mut samples = Vec::new();
+        for batch in &batches {
+            let track_ids = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let values = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            for i in 0..batch.num_rows() {
+                samples.push((track_ids.value(i), values.value(i)));
+            }
+        }
+        samples.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.total_cmp(&b.1)));
+        assert_eq!(
+            samples.len(),
+            3,
+            "samples from both handles should survive in counter.parquet"
+        );
+        assert_eq!(samples[0].0, 1);
+        assert!((samples[0].1 - 42.0).abs() < f64::EPSILON);
+        assert_eq!(samples[1].0, 2);
+        assert!((samples[1].1 - 2_400.0).abs() < f64::EPSILON);
+        assert_eq!(samples[2].0, 2);
+        assert!((samples[2].1 - 2_500.0).abs() < f64::EPSILON);
+    }
 }

--- a/src/perf_recorder.rs
+++ b/src/perf_recorder.rs
@@ -8,7 +8,7 @@ use crate::ringbuf::RingBuffer;
 use crate::systing_core::types::perf_counter_event;
 use crate::systing_core::SystingRecordEvent;
 use crate::trace::{CounterRecord, CounterTrackRecord};
-use crate::utid::{ThreadAwareRecorder, UtidGenerator};
+use crate::utid::{CounterTrackIdGenerator, ThreadAwareRecorder, UtidGenerator};
 
 #[derive(Default, PartialEq, Eq, Hash)]
 struct PerfCounterKey {
@@ -22,7 +22,9 @@ pub struct PerfCounterRecorder {
     // Streaming support
     streaming_collector: Option<Box<dyn RecordCollector + Send>>,
     track_ids: HashMap<PerfCounterKey, i64>,
-    next_track_id: i64,
+    /// Shared with every other recorder that emits counter tracks (e.g. the
+    /// sysinfo/CPU-frequency recorder) so track IDs stay unique across them.
+    counter_track_ids: Arc<CounterTrackIdGenerator>,
     utid_generator: Arc<UtidGenerator>,
 }
 
@@ -33,13 +35,16 @@ impl ThreadAwareRecorder for PerfCounterRecorder {
 }
 
 impl PerfCounterRecorder {
-    pub fn new(utid_generator: Arc<UtidGenerator>) -> Self {
+    pub fn new(
+        utid_generator: Arc<UtidGenerator>,
+        counter_track_ids: Arc<CounterTrackIdGenerator>,
+    ) -> Self {
         Self {
             ringbuf: RingBuffer::default(),
             perf_counters: Vec::new(),
             streaming_collector: None,
             track_ids: HashMap::new(),
-            next_track_id: 1,
+            counter_track_ids,
             utid_generator,
         }
     }
@@ -90,8 +95,7 @@ impl SystingRecordEvent<perf_counter_event> for PerfCounterRecorder {
             id
         } else {
             // First event for this key - create the track
-            let track_id = self.next_track_id;
-            self.next_track_id += 1;
+            let track_id = self.counter_track_ids.next_id();
 
             let track_name = format!("{} CPU {}", counter_name, key.cpu);
 
@@ -138,7 +142,6 @@ impl PerfCounterRecorder {
             collector.flush()?;
             // Clear track_ids cache
             self.track_ids.clear();
-            self.next_track_id = 1;
             Ok(Some(collector))
         } else {
             Ok(None)
@@ -154,7 +157,10 @@ mod tests {
     fn test_perf_counter_streaming() {
         use crate::record::collector::InMemoryCollector;
 
-        let mut recorder = PerfCounterRecorder::new(Arc::new(UtidGenerator::new()));
+        let mut recorder = PerfCounterRecorder::new(
+            Arc::new(UtidGenerator::new()),
+            Arc::new(CounterTrackIdGenerator::new()),
+        );
         recorder.perf_counters.push("cycles".to_string());
 
         // Set up streaming with InMemoryCollector

--- a/src/record/collector.rs
+++ b/src/record/collector.rs
@@ -4,6 +4,8 @@
 //! Implementations can buffer records and flush them to storage (e.g., Parquet files)
 //! when thresholds are reached.
 
+use std::sync::{Arc, Mutex, MutexGuard};
+
 use anyhow::Result;
 
 use crate::trace::{
@@ -143,6 +145,131 @@ pub trait RecordCollector {
     /// Finish writing and close all files (boxed version for trait objects).
     /// This is the same as finish() but takes a Box to work with trait objects.
     fn finish_boxed(self: Box<Self>) -> Result<()>;
+}
+
+/// A cloneable, thread-safe handle that lets several recorders stream into one
+/// shared underlying collector.
+///
+/// Some recorders emit rows for the same logical tables: the perf-counter
+/// recorder and the sysinfo (CPU frequency) recorder both emit `counter` /
+/// `counter_track` rows. If each held its own `StreamingParquetWriter`, both
+/// writers would target the same `counter.parquet` / `counter_track.parquet`
+/// paths and the last one to finish would silently clobber the other's data.
+/// Wrapping a single writer in a `SharedCollector` and handing a clone to each
+/// recorder makes them append to the same writer instead.
+///
+/// `finish()` / `finish_boxed()` only finalize the inner collector when called
+/// on the last live handle; earlier handles just flush. This keeps the existing
+/// per-recorder "finish your collector when you're done" flow unchanged.
+///
+/// Usage requirements:
+/// - Every handle must eventually be finished (or dropped) during trace
+///   generation; a handle whose finish is skipped keeps the inner collector
+///   open and the data only gets closed by the writer's `Drop` fallback.
+/// - Handles must not be finished concurrently from different threads: the
+///   "last live handle" check is not atomic across racing finishes, so two
+///   concurrent finishes could both see another live handle and neither would
+///   finalize the writer. `SessionRecorder::generate_parquet_trace` finishes
+///   all recorders sequentially on one thread, which satisfies this.
+pub struct SharedCollector {
+    inner: Arc<Mutex<Box<dyn RecordCollector + Send>>>,
+}
+
+impl SharedCollector {
+    /// Wrap a collector so it can be shared by multiple recorders.
+    pub fn new(inner: Box<dyn RecordCollector + Send>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Box<dyn RecordCollector + Send>> {
+        // A poisoned mutex means another recorder panicked mid-write; trace
+        // generation is already broken at that point, so propagate the panic.
+        self.inner.lock().unwrap()
+    }
+
+    /// Finish this handle. The inner collector is only finalized once the last
+    /// handle finishes (i.e. this handle holds the only remaining reference);
+    /// earlier handles just flush what they have written. Handles are expected
+    /// to be finished sequentially - see the type-level docs.
+    fn finish_shared(self) -> Result<()> {
+        match Arc::try_unwrap(self.inner) {
+            Ok(mutex) => mutex.into_inner().unwrap().finish_boxed(),
+            Err(arc) => arc.lock().unwrap().flush(),
+        }
+    }
+}
+
+impl Clone for SharedCollector {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+/// Generates the record-forwarding methods of [`RecordCollector`] for
+/// [`SharedCollector`]: each method locks the shared inner collector and
+/// delegates to it.
+macro_rules! shared_delegate {
+    ($($method:ident($record:ty)),* $(,)?) => {
+        $(
+            fn $method(&mut self, record: $record) -> Result<()> {
+                self.lock().$method(record)
+            }
+        )*
+    };
+}
+
+impl RecordCollector for SharedCollector {
+    shared_delegate! {
+        add_process(ProcessRecord),
+        add_thread(ThreadRecord),
+        add_sched_slice(SchedSliceRecord),
+        add_thread_state(ThreadStateRecord),
+        add_irq_slice(IrqSliceRecord),
+        add_softirq_slice(SoftirqSliceRecord),
+        add_wakeup_new(WakeupNewRecord),
+        add_process_exit(ProcessExitRecord),
+        add_counter(CounterRecord),
+        add_counter_track(CounterTrackRecord),
+        add_slice(SliceRecord),
+        add_track(TrackRecord),
+        add_instant(InstantRecord),
+        add_arg(ArgRecord),
+        add_instant_arg(InstantArgRecord),
+        add_network_interface(NetworkInterfaceRecord),
+        add_socket_connection(SocketConnectionRecord),
+        add_clock_snapshot(ClockSnapshotRecord),
+        add_stack(StackRecord),
+        add_stack_sample(StackSampleRecord),
+        add_network_syscall(NetworkSyscallRecord),
+        add_network_packet(NetworkPacketRecord),
+        add_network_socket(NetworkSocketRecord),
+        add_network_poll(NetworkPollRecord),
+        add_network_dns(NetworkDnsRecord),
+        add_memory_rss(MemoryRssRecord),
+        add_memory_map(MemoryMapRecord),
+        add_memory_fault(MemoryFaultRecord),
+        add_memory_alloc(MemoryAllocRecord),
+        set_sysinfo(SysInfoRecord),
+        add_tpu_device(TpuDeviceRecord),
+        add_tpu_op(TpuOpRecord),
+        add_tpu_metric(TpuMetricRecord),
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.lock().flush()
+    }
+
+    fn finish(self) -> Result<()> {
+        self.finish_shared()
+    }
+
+    fn finish_boxed(self: Box<Self>) -> Result<()> {
+        (*self).finish_shared()
+    }
 }
 
 /// A simple in-memory collector that stores all records in `ExtractedData`.

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -5,4 +5,4 @@
 
 pub mod collector;
 
-pub use collector::{InMemoryCollector, RecordCollector};
+pub use collector::{InMemoryCollector, RecordCollector, SharedCollector};

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -22,7 +22,9 @@ use crate::tpu::metrics_recorder::TpuMetricsRecorder;
 use crate::trace::{
     ClockSnapshotRecord, CounterRecord, CounterTrackRecord, ProcessRecord, ThreadRecord,
 };
-use crate::utid::{CounterTrackIdGenerator, ThreadAwareRecorder, UtidGenerator};
+use crate::utid::{
+    CounterTrackIdGenerator, ThreadAwareRecorder, TrackEventIdGenerator, UtidGenerator,
+};
 
 use perfetto_protos::builtin_clock::BuiltinClock;
 use perfetto_protos::clock_snapshot::clock_snapshot::Clock;
@@ -461,6 +463,10 @@ impl SessionRecorder {
         // (CPU frequency) recorders into the same counter_track table, so they
         // share one ID generator to keep track IDs unique.
         let counter_track_ids = Arc::new(CounterTrackIdGenerator::new());
+        // Track/slice/instant rows are written by both the probe recorder
+        // (trace-events/syscalls) and the marker recorder, so they share one ID
+        // generator for the same reason.
+        let track_event_ids = Arc::new(TrackEventIdGenerator::new());
         Self {
             clock_snapshot: Mutex::new(ClockSnapshot::default()),
             event_recorder: Mutex::new(SchedEventRecorder::new(Arc::clone(&utid_generator))),
@@ -476,14 +482,17 @@ impl SessionRecorder {
                 Arc::clone(&utid_generator),
                 Arc::clone(&counter_track_ids),
             )),
-            probe_recorder: Mutex::new(SystingProbeRecorder::new(Arc::clone(&utid_generator))),
+            probe_recorder: Mutex::new(SystingProbeRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&track_event_ids),
+            )),
             network_recorder: Mutex::new(NetworkRecorder::new(
                 Arc::clone(&utid_generator),
                 resolve_network_addresses,
             )),
             memory_recorder: Mutex::new(MemoryRecorder::new(Arc::clone(&utid_generator))),
             marker_recorder: Mutex::new(
-                MarkerRecorder::new(Arc::clone(&utid_generator))
+                MarkerRecorder::new(Arc::clone(&utid_generator), Arc::clone(&track_event_ids))
                     .with_threshold(marker_threshold)
                     .with_duration_threshold(marker_duration_threshold),
             ),
@@ -856,7 +865,11 @@ impl SessionRecorder {
             .unwrap()
             .set_streaming_collector(Box::new(memory_writer));
 
-        // Set up streaming collector for probe recorder (events emitted on completion)
+        // Set up streaming collector for probe recorder (events emitted on completion).
+        // Note: marker records are also written through this collector during
+        // generate_parquet_trace - markers share the track/slice/instant tables with
+        // probe events, so writing them through a separate writer would clobber the
+        // probe data (see the marker-write step in generate_parquet_trace).
         let probe_writer = StreamingParquetWriter::new(output_dir)?;
         self.probe_recorder
             .lock()
@@ -918,11 +931,6 @@ impl SessionRecorder {
         let mut writer: Box<dyn RecordCollector + Send> = collector_opt.ok_or_else(|| {
             anyhow::anyhow!("streaming collector must be initialized before generating trace")
         })?;
-
-        // ID counters for generating unique IDs across all records
-        let mut track_id_counter: i64 = 1;
-        let mut slice_id_counter: i64 = 1;
-        let mut instant_id_counter: i64 = 1;
 
         // Step 2: Generate clock snapshot records
         eprintln!("Writing clock snapshot...");
@@ -1077,29 +1085,41 @@ impl SessionRecorder {
             sysinfo_collector.finish_boxed()?;
         }
 
+        // The probe recorder (trace-events/syscalls) and the marker recorder both
+        // emit track/slice/instant/args rows, which map to the same parquet files.
+        // Markers must therefore be written through the probe recorder's collector:
+        // writing them through the main writer would recreate the same files and
+        // whichever writer closed last would clobber the other's data. (Track/slice/
+        // instant IDs can't collide either - both recorders allocate them from the
+        // shared TrackEventIdGenerator.)
         eprintln!("Flushing probe trace records...");
-        if let Some(probe_collector) = self.probe_recorder.lock().unwrap().finish()? {
-            probe_collector.finish_boxed()?;
-        }
+        let mut track_writer = self
+            .probe_recorder
+            .lock()
+            .unwrap()
+            .finish()?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "probe streaming collector must be initialized before generating trace"
+                )
+            })?;
 
         // Write marker records (only if any were collected)
         {
             let marker_recorder = self.marker_recorder.lock().unwrap();
             if marker_recorder.has_data() {
                 eprintln!("Writing marker records...");
-                marker_recorder.write_records(
-                    &mut *writer,
-                    &mut track_id_counter,
-                    &mut slice_id_counter,
-                    &mut instant_id_counter,
-                )?;
+                marker_recorder.write_records(&mut *track_writer)?;
             }
         }
+        track_writer.finish_boxed()?;
 
-        // Write TPU profiling records (if any were captured)
+        // Write TPU profiling records (if any were captured). TPU device/op IDs are
+        // only referenced within the tpu_* tables, which nothing else writes, so
+        // write_records assigns them internally.
         if let Some(tpu) = tpu_recorder {
             eprintln!("Writing TPU profiling records...");
-            tpu.write_records(&mut *writer, &mut slice_id_counter)?;
+            tpu.write_records(&mut *writer)?;
         }
 
         // Finish TPU metrics streaming collector (if enabled)
@@ -1319,6 +1339,7 @@ mod tests {
     fn create_test_session_recorder() -> SessionRecorder {
         let utid_generator = Arc::new(UtidGenerator::new());
         let counter_track_ids = Arc::new(CounterTrackIdGenerator::new());
+        let track_event_ids = Arc::new(TrackEventIdGenerator::new());
         SessionRecorder {
             clock_snapshot: Mutex::new(ClockSnapshot::default()),
             event_recorder: Mutex::new(SchedEventRecorder::new(Arc::clone(&utid_generator))),
@@ -1331,10 +1352,16 @@ mod tests {
                 Arc::clone(&utid_generator),
                 Arc::clone(&counter_track_ids),
             )),
-            probe_recorder: Mutex::new(SystingProbeRecorder::new(Arc::clone(&utid_generator))),
+            probe_recorder: Mutex::new(SystingProbeRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&track_event_ids),
+            )),
             network_recorder: Mutex::new(NetworkRecorder::new(Arc::clone(&utid_generator), false)),
             memory_recorder: Mutex::new(MemoryRecorder::new(Arc::clone(&utid_generator))),
-            marker_recorder: Mutex::new(MarkerRecorder::new(Arc::clone(&utid_generator))),
+            marker_recorder: Mutex::new(MarkerRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&track_event_ids),
+            )),
             process_descriptors: RwLock::new(HashMap::new()),
             processes: RwLock::new(HashMap::new()),
             threads: RwLock::new(HashMap::new()),

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -12,7 +12,7 @@ use crate::memory_recorder::MemoryRecorder;
 use crate::network_recorder::NetworkRecorder;
 use crate::parquet::StreamingParquetWriter;
 use crate::perf_recorder::PerfCounterRecorder;
-use crate::record::RecordCollector;
+use crate::record::{RecordCollector, SharedCollector};
 use crate::ringbuf::RingBuffer;
 use crate::sched::SchedEventRecorder;
 use crate::stack_recorder::StackRecorder;
@@ -22,7 +22,7 @@ use crate::tpu::metrics_recorder::TpuMetricsRecorder;
 use crate::trace::{
     ClockSnapshotRecord, CounterRecord, CounterTrackRecord, ProcessRecord, ThreadRecord,
 };
-use crate::utid::{ThreadAwareRecorder, UtidGenerator};
+use crate::utid::{CounterTrackIdGenerator, ThreadAwareRecorder, UtidGenerator};
 
 use perfetto_protos::builtin_clock::BuiltinClock;
 use perfetto_protos::clock_snapshot::clock_snapshot::Clock;
@@ -47,7 +47,9 @@ pub struct SysinfoRecorder {
     // Streaming support
     streaming_collector: Option<Box<dyn RecordCollector + Send>>,
     track_ids: HashMap<u32, i64>,
-    next_track_id: i64,
+    /// Shared with every other recorder that emits counter tracks (e.g. the
+    /// perf-counter recorder) so track IDs stay unique across them.
+    counter_track_ids: Arc<CounterTrackIdGenerator>,
     utid_generator: Arc<UtidGenerator>,
 }
 
@@ -58,12 +60,15 @@ impl ThreadAwareRecorder for SysinfoRecorder {
 }
 
 impl SysinfoRecorder {
-    pub fn new(utid_generator: Arc<UtidGenerator>) -> Self {
+    pub fn new(
+        utid_generator: Arc<UtidGenerator>,
+        counter_track_ids: Arc<CounterTrackIdGenerator>,
+    ) -> Self {
         Self {
             ringbuf: RingBuffer::default(),
             streaming_collector: None,
             track_ids: HashMap::new(),
-            next_track_id: 1,
+            counter_track_ids,
             utid_generator,
         }
     }
@@ -388,8 +393,8 @@ impl SystingRecordEvent<SysInfoEvent> for SysinfoRecorder {
         let track_id = if let Some(&id) = self.track_ids.get(&cpu) {
             id
         } else {
-            let track_id = self.next_track_id;
-            self.next_track_id += 1;
+            // First event for this CPU - create the track
+            let track_id = self.counter_track_ids.next_id();
 
             if let Err(e) = collector.add_counter_track(CounterTrackRecord {
                 id: track_id,
@@ -419,8 +424,9 @@ impl SysinfoRecorder {
     /// When set, events will be streamed directly to the collector during
     /// handle_event() instead of being accumulated in memory.
     ///
-    /// Note: Each streaming recorder gets its own StreamingParquetWriter instance,
-    /// so local track IDs (starting at 1) are safe - they write to separate files.
+    /// Note: This recorder writes counter / counter_track rows, the same tables
+    /// the perf-counter recorder writes to, so the collector passed here must
+    /// share its underlying writer with that recorder (see `SharedCollector`).
     pub fn set_streaming_collector(&mut self, collector: Box<dyn RecordCollector + Send>) {
         self.streaming_collector = Some(collector);
     }
@@ -433,9 +439,8 @@ impl SysinfoRecorder {
         if let Some(mut collector) = self.streaming_collector.take() {
             // Data already streamed during handle_event, just flush
             collector.flush()?;
-            // Clear track_ids cache and reset counter
+            // Clear track_ids cache
             self.track_ids.clear();
-            self.next_track_id = 1;
             Ok(Some(collector))
         } else {
             Ok(None)
@@ -452,6 +457,10 @@ impl SessionRecorder {
         tpu_metrics_enabled: bool,
     ) -> Self {
         let utid_generator = Arc::new(UtidGenerator::new());
+        // Counter tracks are written by both the perf-counter and the sysinfo
+        // (CPU frequency) recorders into the same counter_track table, so they
+        // share one ID generator to keep track IDs unique.
+        let counter_track_ids = Arc::new(CounterTrackIdGenerator::new());
         Self {
             clock_snapshot: Mutex::new(ClockSnapshot::default()),
             event_recorder: Mutex::new(SchedEventRecorder::new(Arc::clone(&utid_generator))),
@@ -459,10 +468,14 @@ impl SessionRecorder {
                 enable_debuginfod,
                 Arc::clone(&utid_generator),
             )),
-            perf_counter_recorder: Mutex::new(PerfCounterRecorder::new(Arc::clone(
-                &utid_generator,
-            ))),
-            sysinfo_recorder: Mutex::new(SysinfoRecorder::new(Arc::clone(&utid_generator))),
+            perf_counter_recorder: Mutex::new(PerfCounterRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&counter_track_ids),
+            )),
+            sysinfo_recorder: Mutex::new(SysinfoRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&counter_track_ids),
+            )),
             probe_recorder: Mutex::new(SystingProbeRecorder::new(Arc::clone(&utid_generator))),
             network_recorder: Mutex::new(NetworkRecorder::new(
                 Arc::clone(&utid_generator),
@@ -850,23 +863,22 @@ impl SessionRecorder {
             .unwrap()
             .set_streaming_collector(Box::new(probe_writer));
 
-        // Set up streaming collector for perf counter recorder (events emitted immediately).
-        // Perf counters get their own writer because counter tracks are self-contained and
-        // the local track_id counter (starting at 1) is safe since each writer outputs to
-        // separate parquet files (counter.parquet, counter_track.parquet).
-        let perf_writer = StreamingParquetWriter::new(output_dir)?;
+        // The perf-counter and sysinfo (CPU frequency) recorders both emit
+        // counter / counter_track rows, which map to the same counter.parquet /
+        // counter_track.parquet files. They must share a single writer: with
+        // separate writers both would create the same files and the last one to
+        // finish would clobber the other's data. Track IDs come from the shared
+        // CounterTrackIdGenerator so they never collide either.
+        let counter_writer =
+            SharedCollector::new(Box::new(StreamingParquetWriter::new(output_dir)?));
         self.perf_counter_recorder
             .lock()
             .unwrap()
-            .set_streaming_collector(Box::new(perf_writer));
-
-        // Set up streaming collector for sysinfo recorder (CPU frequency events).
-        // Like perf counters, sysinfo gets its own writer for counter tracks.
-        let sysinfo_writer = StreamingParquetWriter::new(output_dir)?;
+            .set_streaming_collector(Box::new(counter_writer.clone()));
         self.sysinfo_recorder
             .lock()
             .unwrap()
-            .set_streaming_collector(Box::new(sysinfo_writer));
+            .set_streaming_collector(Box::new(counter_writer));
 
         // Set up streaming collector for TPU metrics recorder (if enabled).
         if let Some(ref tpu_metrics) = self.tpu_metrics_recorder {
@@ -1306,14 +1318,19 @@ mod tests {
 
     fn create_test_session_recorder() -> SessionRecorder {
         let utid_generator = Arc::new(UtidGenerator::new());
+        let counter_track_ids = Arc::new(CounterTrackIdGenerator::new());
         SessionRecorder {
             clock_snapshot: Mutex::new(ClockSnapshot::default()),
             event_recorder: Mutex::new(SchedEventRecorder::new(Arc::clone(&utid_generator))),
             stack_recorder: Mutex::new(StackRecorder::new(false, Arc::clone(&utid_generator))),
-            perf_counter_recorder: Mutex::new(PerfCounterRecorder::new(Arc::clone(
-                &utid_generator,
-            ))),
-            sysinfo_recorder: Mutex::new(SysinfoRecorder::new(Arc::clone(&utid_generator))),
+            perf_counter_recorder: Mutex::new(PerfCounterRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&counter_track_ids),
+            )),
+            sysinfo_recorder: Mutex::new(SysinfoRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&counter_track_ids),
+            )),
             probe_recorder: Mutex::new(SystingProbeRecorder::new(Arc::clone(&utid_generator))),
             network_recorder: Mutex::new(NetworkRecorder::new(Arc::clone(&utid_generator), false)),
             memory_recorder: Mutex::new(MemoryRecorder::new(Arc::clone(&utid_generator))),

--- a/src/tpu/recorder.rs
+++ b/src/tpu/recorder.rs
@@ -15,8 +15,8 @@ use crate::tpu::xspace::{self, TpuRecordData};
 ///
 /// Created with a target service address (discovered or user-specified) and
 /// the desired profiling duration. Runs `capture()` in a dedicated thread,
-/// then `write_records()` is called during `generate_parquet_trace` with the
-/// shared ID counters.
+/// then `write_records()` is called during `generate_parquet_trace`
+/// finalization.
 pub struct TpuRecorder {
     service_addr: String,
     duration_ms: u64,
@@ -72,13 +72,10 @@ impl TpuRecorder {
 
     /// Write TPU records to the collector during `generate_parquet_trace`.
     ///
-    /// Uses the shared ID counter to assign globally unique IDs.
+    /// TPU device/op IDs are only referenced within the tpu_* tables, which
+    /// nothing else writes, so they are assigned from a local counter here.
     /// Returns `Ok(())` even if no TPU data was captured.
-    pub fn write_records(
-        self,
-        collector: &mut dyn RecordCollector,
-        id_counter: &mut i64,
-    ) -> Result<()> {
+    pub fn write_records(self, collector: &mut dyn RecordCollector) -> Result<()> {
         let records = match self.records {
             Some(r) => r,
             None => return Ok(()),
@@ -88,13 +85,14 @@ impl TpuRecorder {
             return Ok(());
         }
 
-        // Assign globally unique IDs and remap device references.
+        // Assign unique IDs and remap device references.
+        let mut id_counter: i64 = 1;
         let mut device_id_map: std::collections::HashMap<i64, i64> =
             std::collections::HashMap::new();
 
         for device in &records.devices {
-            let final_id = *id_counter;
-            *id_counter += 1;
+            let final_id = id_counter;
+            id_counter += 1;
             device_id_map.insert(device.id, final_id);
         }
 
@@ -105,8 +103,8 @@ impl TpuRecorder {
         }
 
         for mut op in records.ops {
-            let final_id = *id_counter;
-            *id_counter += 1;
+            let final_id = id_counter;
+            id_counter += 1;
             op.id = final_id;
             op.tpu_device_id = match device_id_map.get(&op.tpu_device_id) {
                 Some(&id) => id,

--- a/src/tpu/xspace.rs
+++ b/src/tpu/xspace.rs
@@ -15,7 +15,7 @@ use crate::trace::{TpuDeviceRecord, TpuOpRecord};
 /// Parsed TPU record data ready for writing to Parquet.
 ///
 /// All timestamps have been converted from CLOCK_REALTIME to CLOCK_BOOTTIME.
-/// IDs are placeholders — final globally-unique IDs are assigned during
+/// IDs are placeholders — final unique IDs are assigned during
 /// `TpuRecorder::write_records()`.
 #[derive(Debug, Default)]
 pub struct TpuRecordData {

--- a/src/utid.rs
+++ b/src/utid.rs
@@ -148,9 +148,50 @@ impl Default for UtidGenerator {
     }
 }
 
+/// Thread-safe generator for `counter_track` IDs.
+///
+/// More than one recorder emits counter tracks (the perf-counter recorder and
+/// the sysinfo/CPU-frequency recorder), and all of their rows land in the same
+/// `counter_track` table, so the IDs must come from a single shared sequence to
+/// stay unique. Every recorder that creates counter tracks should hold a clone
+/// of the same `Arc<CounterTrackIdGenerator>`.
+#[derive(Debug)]
+pub struct CounterTrackIdGenerator {
+    next_id: AtomicI64,
+}
+
+impl CounterTrackIdGenerator {
+    /// Create a new generator with IDs starting at 1.
+    pub fn new() -> Self {
+        Self {
+            next_id: AtomicI64::new(1),
+        }
+    }
+
+    /// Allocate the next unique counter-track ID.
+    pub fn next_id(&self) -> i64 {
+        // Relaxed ordering is sufficient - we only need uniqueness, not synchronization.
+        self.next_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl Default for CounterTrackIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_counter_track_id_generator_sequential() {
+        let gen = CounterTrackIdGenerator::new();
+        assert_eq!(gen.next_id(), 1);
+        assert_eq!(gen.next_id(), 2);
+        assert_eq!(gen.next_id(), 3);
+    }
 
     #[test]
     fn test_utid_generator_handles_tid_zero() {

--- a/src/utid.rs
+++ b/src/utid.rs
@@ -181,6 +181,54 @@ impl Default for CounterTrackIdGenerator {
     }
 }
 
+/// Thread-safe generator for `track`, `slice`, and `instant` IDs.
+///
+/// More than one recorder emits rows for these tables (the probe recorder for
+/// trace-events/syscalls and the marker recorder for userspace markers), and
+/// `args` / `instant_args` rows reference slice and instant IDs, so all IDs
+/// must come from a single shared sequence to stay unique. Every recorder that
+/// emits track/slice/instant rows should hold a clone of the same
+/// `Arc<TrackEventIdGenerator>`.
+#[derive(Debug)]
+pub struct TrackEventIdGenerator {
+    next_track_id: AtomicI64,
+    next_slice_id: AtomicI64,
+    next_instant_id: AtomicI64,
+}
+
+impl TrackEventIdGenerator {
+    /// Create a new generator with all ID sequences starting at 1.
+    pub fn new() -> Self {
+        Self {
+            next_track_id: AtomicI64::new(1),
+            next_slice_id: AtomicI64::new(1),
+            next_instant_id: AtomicI64::new(1),
+        }
+    }
+
+    /// Allocate the next unique track ID.
+    pub fn next_track_id(&self) -> i64 {
+        // Relaxed ordering is sufficient - we only need uniqueness, not synchronization.
+        self.next_track_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Allocate the next unique slice ID.
+    pub fn next_slice_id(&self) -> i64 {
+        self.next_slice_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// Allocate the next unique instant ID.
+    pub fn next_instant_id(&self) -> i64 {
+        self.next_instant_id.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl Default for TrackEventIdGenerator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,6 +239,19 @@ mod tests {
         assert_eq!(gen.next_id(), 1);
         assert_eq!(gen.next_id(), 2);
         assert_eq!(gen.next_id(), 3);
+    }
+
+    #[test]
+    fn test_track_event_id_generator_independent_sequences() {
+        let gen = TrackEventIdGenerator::new();
+        // Each ID kind has its own sequence...
+        assert_eq!(gen.next_track_id(), 1);
+        assert_eq!(gen.next_track_id(), 2);
+        assert_eq!(gen.next_slice_id(), 1);
+        assert_eq!(gen.next_instant_id(), 1);
+        // ...and they advance independently.
+        assert_eq!(gen.next_slice_id(), 2);
+        assert_eq!(gen.next_track_id(), 3);
     }
 
     #[test]

--- a/tests/perf_counter.rs
+++ b/tests/perf_counter.rs
@@ -1,0 +1,201 @@
+//! Integration test for the perf-counter recorder.
+//!
+//! Records a trace with both `--perf-counter` and `--cpu-frequency` enabled and
+//! verifies that the per-CPU perf-counter tracks and the CPU-frequency tracks
+//! both survive into the final trace. This is a regression test for the
+//! sysinfo (CPU frequency) writer clobbering `counter.parquet` /
+//! `counter_track.parquet`, which silently dropped every perf-counter sample
+//! whenever the two options were combined.
+//!
+//! Requires root/BPF privileges; run via:
+//! ```
+//! ./scripts/run-integration-tests.sh perf_counter
+//! ```
+
+use systing::{bump_memlock_rlimit, systing, Config};
+use tempfile::TempDir;
+
+/// Counters used by the test. `instructions` and `cpu-cycles` are backed by
+/// fixed counters on x86, making them the events most likely to exist (and
+/// actually count) even on virtualized hosts with a restricted vPMU.
+const TEST_COUNTERS: [&str; 2] = ["instructions", "cpu-cycles"];
+
+/// How long the busy workload (and therefore the recording) runs, in seconds.
+/// Long enough for the sampling clock to read the counters many times and for
+/// the CPU-frequency poller (100ms interval) to record plenty of samples.
+const RECORDING_SECS: u64 = 3;
+
+fn setup_bpf_environment() {
+    bump_memlock_rlimit().expect("Failed to bump memlock rlimit");
+}
+
+/// Returns true if the host can actually open the hardware perf counters used
+/// by the test. Virtualized/CI hosts frequently expose no PMU at all; in that
+/// case the test is skipped rather than failed.
+///
+/// Note: the counter names come from the sysfs aliases of the `cpu` PMU, which
+/// are spelled differently on some architectures (e.g. ARM uses `cpu_cycles` /
+/// `inst_retired`), so the test also skips there.
+fn perf_counters_available() -> bool {
+    use systing::perf::{PerfCounters, PerfOpenEvents};
+
+    let mut counters = PerfCounters::default();
+    if counters.discover().is_err() {
+        return false;
+    }
+    for name in TEST_COUNTERS {
+        let Some(hwevents) = counters.event(name) else {
+            return false;
+        };
+        // Probing a single CPU is enough to know whether the PMU is usable.
+        let Some(mut event) = hwevents.into_iter().next() else {
+            return false;
+        };
+        let Some(&cpu) = event.cpus.first() else {
+            return false;
+        };
+        event.cpus = vec![cpu];
+
+        let mut files = PerfOpenEvents::default();
+        if files.add_hw_event(event).is_err() {
+            return false;
+        }
+        if files.open_events(None, 0).is_err() {
+            return false;
+        }
+        // open_events() tolerates ENODEV, so make sure an event fd was really
+        // opened before declaring the counter usable.
+        if files.iter().next().is_none() {
+            return false;
+        }
+    }
+    true
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_perf_counter_with_cpu_frequency() {
+    setup_bpf_environment();
+
+    if !perf_counters_available() {
+        eprintln!("skipping: hardware perf counters are not available on this host");
+        return;
+    }
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let trace_path = dir.path().join("trace.pb");
+
+    // Busy workload so the sampling clock fires on its CPU and the counters
+    // accumulate non-zero deltas while the traced task is running.
+    let run_cmd = vec![
+        "bash".to_string(),
+        "-c".to_string(),
+        format!("end=$((SECONDS+{RECORDING_SECS})); while [ $SECONDS -lt $end ]; do :; done"),
+    ];
+    let traced_child =
+        systing::traced_command::spawn_traced_child(&run_cmd).expect("Failed to spawn child");
+
+    eprintln!(
+        "Recording perf counters {:?} + CPU frequency (pid {}, ~{}s)...",
+        TEST_COUNTERS, traced_child.pid, RECORDING_SECS
+    );
+
+    let config = Config {
+        perf_counter: TEST_COUNTERS.iter().map(|s| s.to_string()).collect(),
+        cpu_frequency: true,
+        parquet_only: true,
+        output_dir: dir.path().to_path_buf(),
+        output: trace_path,
+        ..Config::default()
+    };
+
+    let exit_code = systing(config, Some(traced_child)).expect("systing recording failed");
+    assert_eq!(exit_code, 0, "busy workload should exit with code 0");
+    eprintln!("Recording complete.\n");
+
+    // --- Convert to DuckDB for SQL assertions ---
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "perfcounter")
+        .expect("DuckDB conversion failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+
+    // --- Check: perf-counter tracks survived alongside the frequency tracks ---
+    // (regression: the sysinfo writer used to clobber counter.parquet, wiping
+    // every perf-counter sample whenever --cpu-frequency was also enabled)
+    for counter in TEST_COUNTERS {
+        eprintln!("  {counter} tracks...");
+        let pattern = format!("{counter} CPU %");
+        let (tracks, samples, max_value): (i64, i64, f64) = conn
+            .query_row(
+                "SELECT COUNT(DISTINCT ct.id), COUNT(c.ts), COALESCE(MAX(c.value), 0)
+                 FROM counter_track ct
+                 LEFT JOIN counter c ON c.track_id = ct.id
+                 WHERE ct.name LIKE ?",
+                [pattern.as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("Failed to query perf counter tracks");
+        assert!(
+            tracks > 0,
+            "[{counter}] no '{counter} CPU <n>' tracks in counter_track"
+        );
+        assert!(samples > 0, "[{counter}] no counter samples for any track");
+        assert!(max_value > 0.0, "[{counter}] all counter samples are zero");
+        eprintln!("    {tracks} tracks, {samples} samples, max delta {max_value}");
+    }
+
+    // --- Check: CPU-frequency tracks are also present ---
+    eprintln!("  cpu-frequency tracks...");
+    let (freq_tracks, freq_samples): (i64, i64) = conn
+        .query_row(
+            "SELECT COUNT(DISTINCT ct.id), COUNT(c.ts)
+             FROM counter_track ct
+             LEFT JOIN counter c ON c.track_id = ct.id
+             WHERE ct.name LIKE 'CPU % frequency'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("Failed to query frequency tracks");
+    assert!(
+        freq_tracks > 0,
+        "[cpu-frequency] no 'CPU <n> frequency' tracks in counter_track"
+    );
+    assert!(
+        freq_samples > 0,
+        "[cpu-frequency] no frequency samples recorded"
+    );
+    eprintln!("    {freq_tracks} tracks, {freq_samples} samples");
+
+    // --- Check: counter_track IDs are unique across both recorders ---
+    eprintln!("  counter_track id uniqueness...");
+    let duplicate_ids: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT id FROM counter_track GROUP BY id HAVING COUNT(*) > 1
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query duplicate counter_track ids");
+    assert_eq!(
+        duplicate_ids, 0,
+        "counter_track has duplicate track ids (perf-counter and cpu-frequency \
+         tracks must come from a shared id sequence)"
+    );
+
+    // --- Check: every counter sample resolves to exactly one track ---
+    eprintln!("  counter -> counter_track referential integrity...");
+    let orphans: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM counter c
+             LEFT JOIN counter_track ct ON c.track_id = ct.id
+             WHERE ct.id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query orphaned counter samples");
+    assert_eq!(
+        orphans, 0,
+        "counter rows reference missing counter_track ids"
+    );
+}

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -3013,6 +3013,9 @@ struct MarkerWorkloadConfig {
     range_info: i64,
     /// Info value passed as arg 3 (flags) for INSTANT events.
     instant_info: i64,
+    /// Also enable syscall tracing (`--syscalls`). The probe recorder then streams
+    /// syscall slices into the same track/slice tables the markers are written to.
+    syscalls: bool,
 }
 
 /// Run a marker-only systing recording while a workload thread emits faccessat2 marker events.
@@ -3073,6 +3076,7 @@ fn run_marker_recording(cfg: MarkerWorkloadConfig) -> TempDir {
         network: false,
         collect_pystacks: false,
         markers: true,
+        syscalls: cfg.syscalls,
         parquet_only: true,
         ..Config::default()
     };
@@ -3099,6 +3103,7 @@ fn test_e2e_marker_recording() {
         instant_name: "checkpoint",
         range_info: 42,
         instant_info: 77,
+        syscalls: false,
     });
 
     // --- Validate slice.parquet contains the range event ---
@@ -3202,6 +3207,7 @@ fn test_e2e_marker_recording_zero_extended() {
         instant_name: "ze_instant",
         range_info: 0,
         instant_info: 0,
+        syscalls: false,
     });
 
     eprintln!("  zero-extended marker: validating slice.parquet...");
@@ -3235,6 +3241,167 @@ fn test_e2e_marker_recording_zero_extended() {
     );
 
     eprintln!("  All zero-extended marker recording checks passed");
+}
+
+/// Regression test: markers and syscall tracing (probe recorder) enabled together.
+///
+/// Both the probe recorder (which streams syscall slices during recording) and the
+/// marker recorder (which writes buffered markers at trace-generation time) emit rows
+/// into the same track/slice/instant/args tables. They used to write through two
+/// separate parquet writers targeting the same files, so whichever writer closed last
+/// silently clobbered the other's data (markers won; all syscall slices were lost).
+/// They also allocated track/slice/instant IDs from independent counters starting at
+/// 1, so even without the clobber the merged tables would have had colliding IDs.
+///
+/// This test records with both enabled and verifies both data sets survive with
+/// unique, mutually-consistent IDs.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_e2e_marker_syscall_no_clobber() {
+    setup_bpf_environment();
+
+    // The marker workload's own syscalls (faccessat2 + nanosleep) provide the
+    // syscall activity, so no extra workload is needed.
+    let dir = run_marker_recording(MarkerWorkloadConfig {
+        mode: -975i64,
+        range_name: "ClobberTrack:clobber_range",
+        instant_name: "clobber_checkpoint",
+        range_info: 42,
+        instant_info: 77,
+        syscalls: true,
+    });
+
+    // --- Convert to DuckDB for SQL assertions ---
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "marker_syscall")
+        .expect("DuckDB conversion failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+
+    // --- Check: syscall slices (probe recorder) survived ---
+    eprintln!("  syscall slices...");
+    let syscall_slices: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM slice WHERE category = 'syscall'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query syscall slices");
+    assert!(
+        syscall_slices > 0,
+        "no syscall slices in the trace - the marker writer clobbered the probe \
+         recorder's slice data"
+    );
+    eprintln!("    {syscall_slices} syscall slices");
+
+    // --- Check: marker slices and instants (marker recorder) survived ---
+    eprintln!("  marker slices and instants...");
+    let marker_slices: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM slice WHERE name = 'clobber_range'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query marker slices");
+    assert!(
+        marker_slices > 0,
+        "no marker range slices in the trace - the probe writer clobbered the marker data"
+    );
+    let marker_instants: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM instant WHERE name = 'clobber_checkpoint'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query marker instants");
+    assert!(marker_instants > 0, "no marker instants in the trace");
+    eprintln!("    {marker_slices} marker slices, {marker_instants} marker instants");
+
+    // --- Check: tracks from both recorders coexist ---
+    eprintln!("  tracks from both recorders...");
+    for track in ["syscalls", "ClobberTrack"] {
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM track WHERE name = ?",
+                [track],
+                |row| row.get(0),
+            )
+            .expect("Failed to query track");
+        assert!(count > 0, "track '{track}' missing from track table");
+    }
+
+    // --- Check: IDs are unique across both recorders ---
+    eprintln!("  id uniqueness...");
+    for table in ["track", "slice", "instant"] {
+        let duplicates: i64 = conn
+            .query_row(
+                &format!(
+                    "SELECT COUNT(*) FROM (SELECT id FROM {table} GROUP BY id HAVING COUNT(*) > 1)"
+                ),
+                [],
+                |row| row.get(0),
+            )
+            .expect("Failed to query duplicate ids");
+        assert_eq!(
+            duplicates, 0,
+            "{table} table has duplicate ids (probe and marker recorders must allocate \
+             from a shared id sequence)"
+        );
+    }
+
+    // --- Check: referential integrity across the merged tables ---
+    eprintln!("  referential integrity...");
+    let orphan_slices: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM slice s LEFT JOIN track t ON s.track_id = t.id \
+             WHERE t.id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query orphan slices");
+    assert_eq!(orphan_slices, 0, "slice rows reference missing track ids");
+    let orphan_args: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM args a LEFT JOIN slice s ON a.slice_id = s.id \
+             WHERE s.id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query orphan args");
+    assert_eq!(orphan_args, 0, "args rows reference missing slice ids");
+    let orphan_instant_args: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM instant_args ia LEFT JOIN instant i \
+             ON ia.instant_id = i.id WHERE i.id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query orphan instant_args");
+    assert_eq!(
+        orphan_instant_args, 0,
+        "instant_args rows reference missing instant ids"
+    );
+
+    // --- Check: thread attribution survives for both recorders' rows ---
+    // Both syscall slices and marker slices/instants carry a utid; every non-null
+    // utid must resolve to a thread row.
+    eprintln!("  utid attribution...");
+    let orphan_utids: i64 = conn
+        .query_row(
+            "SELECT \
+               (SELECT COUNT(*) FROM slice s LEFT JOIN thread t ON s.utid = t.utid \
+                WHERE s.utid IS NOT NULL AND t.utid IS NULL) + \
+               (SELECT COUNT(*) FROM instant i LEFT JOIN thread t ON i.utid = t.utid \
+                WHERE i.utid IS NOT NULL AND t.utid IS NULL)",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query orphan utids");
+    assert_eq!(
+        orphan_utids, 0,
+        "slice/instant rows reference utids missing from the thread table"
+    );
+
+    eprintln!("  All marker+syscall coexistence checks passed");
 }
 
 /// Count rows in a parquet file.


### PR DESCRIPTION
## Problem

Using `--perf-counter` together with `--cpu-frequency` silently loses **all** perf-counter data: the resulting trace contains only the "CPU N frequency" counter tracks and zero perf-counter samples.

Root cause: `SessionRecorder::init_streaming_parquet` gave the perf-counter recorder and the sysinfo (CPU frequency) recorder each their own `StreamingParquetWriter` pointed at the same output directory. Both writers lazily create the same `counter.parquet` / `counter_track.parquet` paths, so whichever finishes last (the sysinfo writer) clobbers the other's file. The two recorders also allocated `counter_track` ids from independent counters starting at 1, so even without the file clobber their track ids would collide in the merged table.

## Fix

- New `SharedCollector` (`src/record/collector.rs`): a cloneable, mutex-guarded handle that lets multiple recorders stream into one underlying collector. Only the last handle to finish finalizes the writer; earlier handles just flush.
- `init_streaming_parquet` now creates a single `StreamingParquetWriter` for counter data and hands a `SharedCollector` clone to both the perf-counter and sysinfo recorders.
- New `CounterTrackIdGenerator` (`src/utid.rs`), shared by both recorders, so counter-track ids stay unique across them.
- Version bump 1.7.3 → 1.7.4 (no schema change).

## Tests

- Unit: `test_shared_collector_counter_round_trip` — two handles writing through one shared writer; all tracks/samples from both survive in the single parquet pair, and an early `finish()` on one handle doesn't close the writer.
- Integration: `tests/perf_counter.rs::test_perf_counter_with_cpu_frequency` (run via `./scripts/run-integration-tests.sh perf_counter`) — records a short trace with both options against a busy workload, converts to DuckDB, and asserts that perf-counter tracks **and** CPU-frequency tracks exist, counter_track ids are unique, and no counter rows are orphaned. Skips on hosts without a usable PMU. Verified the assertions catch the old behavior (a pre-fix trace shows 0 perf-counter tracks).
- Manual: re-ran `systing --perf-counter instructions --perf-counter cpu-cycles --perf-counter ref-cycles --cpu-frequency -- <busy workload>` with the fixed binary; the trace now contains all three perf-counter track families alongside the 64 frequency tracks with no duplicate track ids.
- `cargo fmt --check`, `cargo clippy --all-targets`, full unit test suite pass.

## Note / possible follow-up

The same clobber/id-collision pattern may exist for the `track`/`slice`/`instant`/`args` tables when the probe recorder (which has its own streaming writer) is combined with marker or TPU-op recording (which write those tables through the main writer at generation time). Not addressed here; worth a separate look.