### PR TITLE
Skip CPU frequency polling without a cpufreq driver; record platform info in sysinfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,25 +950,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,26 +2677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3367,13 +3328,12 @@ dependencies = [
  "libc",
  "memchr",
  "ntapi",
- "rayon",
  "windows",
 ]
 
 [[package]]
 name = "systing"
-version = "1.7.5"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "systing"
-version = "1.7.5"
+version = "1.8.0"
 edition = "2021"
+# Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
+rust-version = "1.89"
 authors = ["Josef Bacik <josef@toxicpanda.com>"]
 license = "MIT"
 description = "A libbpf based tracer to figure out what an application is doing"
@@ -45,7 +47,11 @@ schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.140"
 syscalls = "0.6"
-sysinfo = "0.33.1"
+# Only the "system" feature is used (CPU frequency polling, kernel version).
+# Default features pull in rayon (via "multithread", which parallelizes the
+# slow /proc/cpuinfo fallback) plus disk/network/component/user code we never
+# call.
+sysinfo = { version = "0.33.1", default-features = false, features = ["system"] }
 tempfile = "3.13"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "io-std"] }
 object = { version = "0.36", default-features = false, features = ["read", "elf"] }

--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -128,3 +128,28 @@ path by walking the live cgroup v2 hierarchy when the trace is written.
 
 Older databases without these columns import cleanly: `cgroup_id` falls back to its
 `0` default and `cgroup_path` to `NULL`.
+
+## Schema Version 9 (systing 1.8.0) — 2026-06-02
+
+Record platform provenance in the `sysinfo` table so a trace identifies what kind
+of machine it was captured on — in particular whether CPU-frequency data could
+exist at all (VM guests have no cpufreq driver, so `--cpu-frequency` is now
+skipped there) and whether the host was virtualized.
+
+### Added columns
+- `sysinfo`: added `cpufreq_driver VARCHAR` — the kernel's cpufreq scaling driver
+  (e.g. `intel_pstate`, `acpi-cpufreq`); `NULL` when the system has no cpufreq
+  support, in which case CPU-frequency counter tracks are absent.
+- `sysinfo`: added `hypervisor VARCHAR` — the hypervisor the trace was captured
+  under, detected via the CPUID hypervisor bit and vendor signature on x86_64
+  (e.g. `kvm`, `xen`, `hyper-v`, `vmware`); `NULL` on bare metal.
+- `sysinfo`: added `sys_vendor VARCHAR` — DMI system vendor (e.g. `Amazon EC2`),
+  `NULL` if DMI is not exposed.
+- `sysinfo`: added `product_name VARCHAR` — DMI product name (e.g.
+  `m7i.16xlarge`), `NULL` if DMI is not exposed.
+
+Older parquet directories without these columns import cleanly: both the
+record-time import (`src/duckdb.rs`) and `systing-util convert` (which
+previously used positional inserts and would have failed on any added column,
+including v8's `process` columns) now use `INSERT ... BY NAME`, which fills
+missing columns with `NULL`.

--- a/src/bin/systing_util.rs
+++ b/src/bin/systing_util.rs
@@ -3410,7 +3410,9 @@ fn run_convert(
             }
         }
 
-        // Import files that already have trace_id
+        // Import files that already have trace_id. BY NAME so parquet files
+        // written by older systing versions (with fewer columns) import
+        // cleanly - missing columns become NULL.
         if !with_trace_id.is_empty() {
             let paths_list = with_trace_id
                 .iter()
@@ -3418,7 +3420,7 @@ fn run_convert(
                 .collect::<Vec<_>>()
                 .join(", ");
             conn.execute_batch(&format!(
-                "INSERT INTO {table_name} SELECT * FROM read_parquet([{paths_list}])"
+                "INSERT INTO {table_name} BY NAME SELECT * FROM read_parquet([{paths_list}])"
             ))?;
         }
 
@@ -3427,7 +3429,7 @@ fn run_convert(
             let escaped_path = path.replace('\'', "''");
             let escaped_trace_id = trace_id.replace('\'', "''");
             conn.execute_batch(&format!(
-                "INSERT INTO {table_name} SELECT '{escaped_trace_id}' as trace_id, * FROM read_parquet('{escaped_path}')"
+                "INSERT INTO {table_name} BY NAME SELECT '{escaped_trace_id}' as trace_id, * FROM read_parquet('{escaped_path}')"
             ))?;
         }
 

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -116,7 +116,7 @@ pub struct TraceImportMapping {
 }
 
 /// Current schema version. See SCHEMA_CHANGES.md for history.
-pub const SCHEMA_VERSION: u32 = 8;
+pub const SCHEMA_VERSION: u32 = 9;
 
 /// All data tables in the DuckDB schema (excludes the `_traces` metadata table).
 pub const DATA_TABLES: &[&str] = &[
@@ -557,7 +557,11 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
             sysname VARCHAR,
             release VARCHAR,
             version VARCHAR,
-            machine VARCHAR
+            machine VARCHAR,
+            cpufreq_driver VARCHAR,
+            hypervisor VARCHAR,
+            sys_vendor VARCHAR,
+            product_name VARCHAR
         );
 
         -- TPU profiling tables

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -2000,11 +2000,19 @@ fn build_sysinfo_batch(record: &SysInfoRecord, schema: &Arc<Schema>) -> Result<R
     let mut release_builder = StringBuilder::with_capacity(1, record.release.len());
     let mut version_builder = StringBuilder::with_capacity(1, record.version.len());
     let mut machine_builder = StringBuilder::with_capacity(1, record.machine.len());
+    let mut cpufreq_driver_builder = StringBuilder::with_capacity(1, 16);
+    let mut hypervisor_builder = StringBuilder::with_capacity(1, 16);
+    let mut sys_vendor_builder = StringBuilder::with_capacity(1, 16);
+    let mut product_name_builder = StringBuilder::with_capacity(1, 16);
 
     sysname_builder.append_value(&record.sysname);
     release_builder.append_value(&record.release);
     version_builder.append_value(&record.version);
     machine_builder.append_value(&record.machine);
+    cpufreq_driver_builder.append_option(record.cpufreq_driver.as_deref());
+    hypervisor_builder.append_option(record.hypervisor.as_deref());
+    sys_vendor_builder.append_option(record.sys_vendor.as_deref());
+    product_name_builder.append_option(record.product_name.as_deref());
 
     Ok(RecordBatch::try_new(
         schema.clone(),
@@ -2013,6 +2021,10 @@ fn build_sysinfo_batch(record: &SysInfoRecord, schema: &Arc<Schema>) -> Result<R
             Arc::new(release_builder.finish()),
             Arc::new(version_builder.finish()),
             Arc::new(machine_builder.finish()),
+            Arc::new(cpufreq_driver_builder.finish()),
+            Arc::new(hypervisor_builder.finish()),
+            Arc::new(sys_vendor_builder.finish()),
+            Arc::new(product_name_builder.finish()),
         ],
     )?)
 }
@@ -2761,6 +2773,66 @@ mod tests {
         assert_eq!(device_id, 0);
         assert_eq!(metric_name, "test.metric");
         assert!((value - 42.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_sysinfo_duckdb_round_trip() {
+        use crate::duckdb::parquet_to_duckdb;
+        use duckdb::Connection;
+
+        let dir = TempDir::new().unwrap();
+        let mut writer = StreamingParquetWriter::new(dir.path()).unwrap();
+
+        writer
+            .set_sysinfo(SysInfoRecord {
+                sysname: "Linux".to_string(),
+                release: "6.12.0".to_string(),
+                version: "#1 SMP".to_string(),
+                machine: "x86_64".to_string(),
+                cpufreq_driver: Some("intel_pstate".to_string()),
+                hypervisor: Some("kvm".to_string()),
+                sys_vendor: Some("Amazon EC2".to_string()),
+                product_name: None,
+            })
+            .unwrap();
+        writer.finish().unwrap();
+
+        let db_path = dir.path().join("test.duckdb");
+        parquet_to_duckdb(dir.path(), &db_path, "test-trace")
+            .expect("DuckDB import should succeed");
+
+        let conn = Connection::open(&db_path).unwrap();
+        let row: (
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conn
+            .query_row(
+                "SELECT sysname, machine, cpufreq_driver, hypervisor, sys_vendor, product_name \
+                 FROM sysinfo",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .unwrap();
+
+        assert_eq!(row.0, "Linux");
+        assert_eq!(row.1, "x86_64");
+        assert_eq!(row.2, Some("intel_pstate".to_string()));
+        assert_eq!(row.3, Some("kvm".to_string()));
+        assert_eq!(row.4, Some("Amazon EC2".to_string()));
+        assert_eq!(row.5, None, "absent product_name should round-trip as NULL");
     }
 
     #[test]

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -144,6 +144,121 @@ pub fn get_system_utsname() -> Option<Utsname> {
     Some(utsname)
 }
 
+/// Read a small sysfs/procfs file into a trimmed string. Returns `None` if the
+/// file is missing, unreadable, or empty. Trims NUL bytes as well as
+/// whitespace, since device-tree properties are NUL-terminated.
+fn read_sysfs_string(path: &str) -> Option<String> {
+    let contents = fs::read_to_string(path).ok()?;
+    let trimmed = contents.trim_matches(|c: char| c.is_whitespace() || c == '\0');
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Returns the kernel's cpufreq scaling driver name (e.g. "intel_pstate",
+/// "acpi-cpufreq"), or `None` if the system has no cpufreq support at all.
+///
+/// VM guests typically have no cpufreq driver: the guest has no real frequency
+/// to report, so `--cpu-frequency` polling there only yields a constant nominal
+/// value (and the sysinfo crate's fallback path - a full /proc/cpuinfo parse
+/// per CPU per poll - is expensive). Callers use this both to gate the poller
+/// and to record frequency-data provenance in the trace.
+///
+/// Probes the policy directories rather than a per-CPU path: per-CPU `cpufreq`
+/// symlinks disappear when a CPU is offlined (possible for any CPU on arm64),
+/// while `policyN` directories track the driver itself. Note the `cpufreq`
+/// directory can exist and be empty on systems with no driver.
+pub fn cpufreq_scaling_driver() -> Option<String> {
+    fs::read_dir("/sys/devices/system/cpu/cpufreq")
+        .ok()?
+        .flatten()
+        .filter(|e| e.file_name().to_string_lossy().starts_with("policy"))
+        .find_map(|e| read_sysfs_string(e.path().join("scaling_driver").to_str()?))
+}
+
+/// Detect whether we are running under a hypervisor and, if so, identify it.
+///
+/// On x86_64 this checks the CPUID hypervisor-present bit (leaf 1, ECX bit 31)
+/// and reads the vendor signature from leaf 0x40000000 - the canonical,
+/// unforgeable-by-DMI way to tell a VM from bare metal (cloud "metal" instances
+/// report a vendor like "Amazon EC2" in DMI but do not set the hypervisor bit).
+/// Returns a normalized name ("kvm", "xen", ...) or the raw signature for
+/// unrecognized hypervisors. Returns `None` on bare metal.
+///
+/// Caveats: this records the hypervisor *interface* the guest sees - a KVM
+/// guest with Hyper-V enlightenments advertises "Microsoft Hv" at leaf
+/// 0x40000000 (the KVM signature moves to 0x40000100) and is reported as
+/// "hyper-v" here. On non-x86_64 the check is device-tree based and
+/// best-effort: ACPI-booted guests (most cloud aarch64) have no
+/// /proc/device-tree, so `None` there does not reliably mean bare metal.
+pub fn detect_hypervisor() -> Option<String> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        // CPUID is unprivileged and always available on x86_64.
+        let leaf1 = std::arch::x86_64::__cpuid(1);
+        if leaf1.ecx & (1 << 31) == 0 {
+            return None;
+        }
+        // Leaf 0x40000000 is defined whenever the hypervisor bit is set, and
+        // returns the vendor signature in EBX/ECX/EDX.
+        let hv = std::arch::x86_64::__cpuid(0x4000_0000);
+        let mut sig_bytes = [0u8; 12];
+        sig_bytes[0..4].copy_from_slice(&hv.ebx.to_le_bytes());
+        sig_bytes[4..8].copy_from_slice(&hv.ecx.to_le_bytes());
+        sig_bytes[8..12].copy_from_slice(&hv.edx.to_le_bytes());
+        let sig = String::from_utf8_lossy(&sig_bytes)
+            .trim_matches(['\0', ' '])
+            .to_string();
+        let name = match sig.as_str() {
+            s if s.starts_with("KVM") => "kvm",
+            s if s.starts_with("VMware") => "vmware",
+            s if s.starts_with("XenVMM") => "xen",
+            "Microsoft Hv" => "hyper-v",
+            s if s.starts_with("TCG") => "qemu-tcg",
+            s if s.starts_with("bhyve") => "bhyve",
+            s if s.starts_with("VBox") => "virtualbox",
+            s if s.starts_with("ACRN") => "acrn",
+            // Pass unrecognized signatures through so they stay identifiable,
+            // but only if they are printable - garbage CPUID output (or the
+            // U+FFFD characters from_utf8_lossy substitutes for invalid bytes)
+            // should not land in the database verbatim.
+            other
+                if !other.is_empty() && other.chars().all(|c| c.is_ascii_graphic() || c == ' ') =>
+            {
+                other
+            }
+            _ => "unknown",
+        };
+        Some(name.to_string())
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        // Best effort on other architectures: device-tree-booted ARM guests
+        // under KVM/Xen expose a hypervisor node whose `compatible` property
+        // names the hypervisor (e.g. "linux,kvm", "xen,xen").
+        if Path::new("/proc/device-tree/hypervisor").exists() {
+            Some(
+                read_sysfs_string("/proc/device-tree/hypervisor/compatible")
+                    .unwrap_or_else(|| "unknown".to_string()),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+/// DMI system vendor (e.g. "Amazon EC2", "Dell Inc."), if exposed.
+pub fn dmi_sys_vendor() -> Option<String> {
+    read_sysfs_string("/sys/class/dmi/id/sys_vendor")
+}
+
+/// DMI product name (e.g. "m7i.16xlarge", "PowerEdge R750"), if exposed.
+pub fn dmi_product_name() -> Option<String> {
+    read_sysfs_string("/sys/class/dmi/id/product_name")
+}
+
 /// Track name for network interface metadata in Perfetto traces.
 pub const NETWORK_INTERFACES_TRACK_NAME: &str = "Network Interfaces";
 
@@ -961,13 +1076,17 @@ impl SessionRecorder {
         }
         drop(clock_snapshot);
 
-        // Write system info (utsname)
+        // Write system info (utsname + platform provenance)
         if let Some(utsname) = get_system_utsname() {
             writer.set_sysinfo(crate::trace::SysInfoRecord {
                 sysname: utsname.sysname().to_string(),
                 release: utsname.release().to_string(),
                 version: utsname.version().to_string(),
                 machine: utsname.machine().to_string(),
+                cpufreq_driver: cpufreq_scaling_driver(),
+                hypervisor: detect_hypervisor(),
+                sys_vendor: dmi_sys_vendor(),
+                product_name: dmi_product_name(),
             })?;
         }
 
@@ -1692,6 +1811,59 @@ mod tests {
 
         // On Linux, sysname should be "Linux"
         assert_eq!(utsname.sysname(), "Linux");
+    }
+
+    #[test]
+    fn test_cpufreq_scaling_driver_matches_sysfs() {
+        // The helper must agree with the sysfs layout it probes: Some(non-empty)
+        // exactly when at least one policy directory has a scaling_driver file.
+        // (The cpufreq directory itself can exist and be empty on systems with
+        // no driver, so directory existence alone is not the oracle.)
+        let any_policy_driver = std::fs::read_dir("/sys/devices/system/cpu/cpufreq")
+            .map(|entries| {
+                entries.flatten().any(|e| {
+                    e.file_name().to_string_lossy().starts_with("policy")
+                        && e.path().join("scaling_driver").exists()
+                })
+            })
+            .unwrap_or(false);
+        let driver = cpufreq_scaling_driver();
+        assert_eq!(driver.is_some(), any_policy_driver);
+        if let Some(d) = driver {
+            assert!(!d.is_empty());
+            assert!(!d.contains('\n'));
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_detect_hypervisor_matches_cpuinfo_flag() {
+        // /proc/cpuinfo's "hypervisor" flag mirrors CPUID.1:ECX bit 31, the
+        // same bit detect_hypervisor() checks - the two must agree.
+        let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").unwrap();
+        let flag_set = cpuinfo
+            .lines()
+            .find(|l| l.starts_with("flags"))
+            .is_some_and(|l| l.split_whitespace().any(|f| f == "hypervisor"));
+        assert_eq!(detect_hypervisor().is_some(), flag_set);
+    }
+
+    #[test]
+    fn test_dmi_helpers_match_sysfs() {
+        // Compare against a direct read of the sysfs files (an independent
+        // oracle) rather than re-calling the helper's own code path.
+        for (helper, path) in [
+            (
+                dmi_sys_vendor as fn() -> Option<String>,
+                "/sys/class/dmi/id/sys_vendor",
+            ),
+            (dmi_product_name, "/sys/class/dmi/id/product_name"),
+        ] {
+            let expected = std::fs::read_to_string(path)
+                .map(|s| !s.trim().is_empty())
+                .unwrap_or(false);
+            assert_eq!(helper().is_some(), expected, "{path}");
+        }
     }
 
     #[test]

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -3433,43 +3433,54 @@ pub fn systing(
             })?);
         }
 
-        // Start the sysinfo recorder if it's enabled
+        // Start the sysinfo recorder if it's enabled. Skip it when the kernel
+        // has no cpufreq driver (typical for VM guests): there is no real
+        // frequency to read, so polling would only record a constant nominal
+        // value - and the sysinfo crate's fallback path re-parses the whole
+        // /proc/cpuinfo per CPU per poll, which is expensive on large machines.
         let mut sysinfo_thread = None;
         if opts.cpu_frequency {
-            let shutdown_clone = shutdown_signal.clone();
-            let sysinfo_recorder = recorder.clone();
-            sysinfo_thread = Some(
-                thread::Builder::new()
-                    .name("sysinfo_recorder".to_string())
-                    .spawn(move || {
-                        let mut sys = sysinfo::System::new_with_specifics(
-                            sysinfo::RefreshKind::nothing()
-                                .with_cpu(sysinfo::CpuRefreshKind::nothing().with_frequency()),
-                        );
+            if crate::session_recorder::cpufreq_scaling_driver().is_none() {
+                eprintln!(
+                    "Warning: --cpu-frequency requested but this system has no cpufreq \
+                     scaling driver (common in VMs); skipping CPU frequency collection"
+                );
+            } else {
+                let shutdown_clone = shutdown_signal.clone();
+                let sysinfo_recorder = recorder.clone();
+                sysinfo_thread = Some(
+                    thread::Builder::new()
+                        .name("sysinfo_recorder".to_string())
+                        .spawn(move || {
+                            let mut sys = sysinfo::System::new_with_specifics(
+                                sysinfo::RefreshKind::nothing()
+                                    .with_cpu(sysinfo::CpuRefreshKind::nothing().with_frequency()),
+                            );
 
-                        loop {
-                            if shutdown_clone.load(Ordering::Relaxed) {
-                                break;
-                            }
-                            sys.refresh_cpu_frequency();
-                            let ts = get_clock_value(libc::CLOCK_BOOTTIME);
-                            {
-                                let mut recorder =
-                                    sysinfo_recorder.sysinfo_recorder.lock().unwrap();
-                                for (i, cpu) in sys.cpus().iter().enumerate() {
-                                    let event = SysInfoEvent {
-                                        ts,
-                                        cpu: i as u32,
-                                        frequency: cpu.frequency() as i64,
-                                    };
-                                    recorder.record_event(event);
+                            loop {
+                                if shutdown_clone.load(Ordering::Relaxed) {
+                                    break;
                                 }
+                                sys.refresh_cpu_frequency();
+                                let ts = get_clock_value(libc::CLOCK_BOOTTIME);
+                                {
+                                    let mut recorder =
+                                        sysinfo_recorder.sysinfo_recorder.lock().unwrap();
+                                    for (i, cpu) in sys.cpus().iter().enumerate() {
+                                        let event = SysInfoEvent {
+                                            ts,
+                                            cpu: i as u32,
+                                            frequency: cpu.frequency() as i64,
+                                        };
+                                        recorder.record_event(event);
+                                    }
+                                }
+                                thread::sleep(Duration::from_millis(SYSINFO_REFRESH_INTERVAL_MS));
                             }
-                            thread::sleep(Duration::from_millis(SYSINFO_REFRESH_INTERVAL_MS));
-                        }
-                        0
-                    })?,
-            );
+                            0
+                        })?,
+                );
+            }
         }
 
         // Start TPU profiling thread if enabled.

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -471,13 +471,26 @@ pub struct ClockSnapshotRecord {
     pub is_primary: bool,
 }
 
-/// System info record - kernel version and machine information.
+/// System info record - kernel version, machine, and platform information.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SysInfoRecord {
     pub sysname: String,
     pub release: String,
     pub version: String,
     pub machine: String,
+    /// cpufreq scaling driver name (e.g. "intel_pstate"); `None` when the
+    /// kernel has no cpufreq support (typical for VM guests), in which case
+    /// CPU-frequency counter data is absent or meaningless.
+    pub cpufreq_driver: Option<String>,
+    /// Hypervisor the trace was captured under (e.g. "kvm"). `None` means no
+    /// hypervisor was detected; on x86_64 (CPUID-based) that reliably means
+    /// bare metal, on other architectures the check is best-effort and `None`
+    /// may just mean detection was unavailable.
+    pub hypervisor: Option<String>,
+    /// DMI system vendor (e.g. "Amazon EC2"), if exposed.
+    pub sys_vendor: Option<String>,
+    /// DMI product name (e.g. "m7i.16xlarge"), if exposed.
+    pub product_name: Option<String>,
 }
 
 /// Container for all extracted trace data.

--- a/src/trace/schema.rs
+++ b/src/trace/schema.rs
@@ -236,6 +236,10 @@ pub fn sysinfo_schema() -> Arc<Schema> {
         Field::new("release", DataType::Utf8, false),
         Field::new("version", DataType::Utf8, false),
         Field::new("machine", DataType::Utf8, false),
+        Field::new("cpufreq_driver", DataType::Utf8, true),
+        Field::new("hypervisor", DataType::Utf8, true),
+        Field::new("sys_vendor", DataType::Utf8, true),
+        Field::new("product_name", DataType::Utf8, true),
     ]))
 }
 

--- a/tests/perf_counter.rs
+++ b/tests/perf_counter.rs
@@ -144,8 +144,14 @@ fn test_perf_counter_with_cpu_frequency() {
         eprintln!("    {tracks} tracks, {samples} samples, max delta {max_value}");
     }
 
-    // --- Check: CPU-frequency tracks are also present ---
+    // --- Check: CPU-frequency tracks match cpufreq availability ---
+    // Frequency polling is skipped when the kernel has no cpufreq scaling
+    // driver (typical for VM guests), so frequency tracks must exist exactly
+    // when the driver does. On hosts without one, the rest of this test still
+    // validates that requesting --cpu-frequency does not clobber the
+    // perf-counter data.
     eprintln!("  cpu-frequency tracks...");
+    let cpufreq_available = systing::session_recorder::cpufreq_scaling_driver().is_some();
     let (freq_tracks, freq_samples): (i64, i64) = conn
         .query_row(
             "SELECT COUNT(DISTINCT ct.id), COUNT(c.ts)
@@ -156,15 +162,23 @@ fn test_perf_counter_with_cpu_frequency() {
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .expect("Failed to query frequency tracks");
-    assert!(
-        freq_tracks > 0,
-        "[cpu-frequency] no 'CPU <n> frequency' tracks in counter_track"
-    );
-    assert!(
-        freq_samples > 0,
-        "[cpu-frequency] no frequency samples recorded"
-    );
-    eprintln!("    {freq_tracks} tracks, {freq_samples} samples");
+    if cpufreq_available {
+        assert!(
+            freq_tracks > 0,
+            "[cpu-frequency] cpufreq driver present but no 'CPU <n> frequency' tracks"
+        );
+        assert!(
+            freq_samples > 0,
+            "[cpu-frequency] no frequency samples recorded"
+        );
+        eprintln!("    {freq_tracks} tracks, {freq_samples} samples");
+    } else {
+        assert_eq!(
+            freq_tracks, 0,
+            "[cpu-frequency] no cpufreq driver, yet frequency tracks were recorded"
+        );
+        eprintln!("    no cpufreq driver on this host; frequency collection skipped");
+    }
 
     // --- Check: counter_track IDs are unique across both recorders ---
     eprintln!("  counter_track id uniqueness...");


### PR DESCRIPTION
## Problem

`--cpu-frequency` burns ~0.55 cores of system time on VM guests for zero information. The sysinfo crate reads `scaling_cur_freq` first, but VM guests have **no cpufreq driver at all**, so every poll falls back to reading and parsing the **entire** `/proc/cpuinfo` once **per CPU** (64 full reads × 10 Hz on a 64-CPU guest) — and the only value that path ever yields there is the constant nominal MHz. Verified the same fallback exists in sysinfo master, so a dependency upgrade doesn't help.

Measured (15s capture, 64-vCPU guest, 8 busy workloads): sys time **14.4s → 2.1s** with this change; perf-counter data identical.

## Changes

- **Gate the poller**: when `--cpu-frequency` is requested but the kernel has no cpufreq scaling driver, warn and skip frequency collection. Detection probes `/sys/devices/system/cpu/cpufreq/policy*/scaling_driver` (not a per-CPU path, so offlined CPUs can't cause a false negative; the `cpufreq` dir can exist empty, which is handled).
- **Trim the sysinfo dependency** to `features = ["system"]`: drops rayon (only used to parallelize the slow cpuinfo fallback) and disk/network/component/user code we never call. `cargo tree -i rayon` is now empty.
- **Record platform provenance in the `sysinfo` table** so traces are self-describing about the capture host:
  - `cpufreq_driver` — scaling driver name; NULL exactly when frequency tracks are absent
  - `hypervisor` — CPUID-based (hypervisor bit + leaf 0x40000000 vendor signature → "kvm", "xen", "hyper-v", ...); NULL on bare metal. CPUID is the right signal — DMI can't distinguish a cloud VM from a cloud metal instance (both say "Amazon EC2")
  - `sys_vendor` / `product_name` — DMI identity (e.g. "Amazon EC2" / "m7i.16xlarge")
- **Schema bookkeeping**: `SCHEMA_VERSION` 8 → 9, `SCHEMA_CHANGES.md` entry, version 1.7.5 → **1.8.0** (minor, per policy). `rust-version = "1.89"` declared (floor for safe `__cpuid`).
- **`systing-util convert` back-compat fix** (review finding): its parquet imports were positional and failed on *any* added column (already broken for v8's `process` columns). Switched to `INSERT ... BY NAME`; verified a v1.7.3-era parquet directory now converts cleanly with NULLs for the new columns.

## Validation

- This host (m7i.16xlarge KVM guest): warning printed, 0 frequency tracks, perf counters intact, sysinfo row = `(…, x86_64, NULL, "kvm", "Amazon EC2", "m7i.16xlarge")`, schema_version 9
- 376/376 unit tests (6 new: sysinfo round-trip incl. NULLs, generator/helper tests with independent oracles)
- Integration: `perf_counter` ✓ (frequency assertions now conditional on driver presence — still asserts tracks exist *iff* the driver does, and the #118 no-clobber regression check runs unconditionally), `test_e2e_validation_suite` ✓ (full record→parquet→DuckDB→Perfetto with schema v9)
- Old-format convert: v1.7.3 parquet dir → new DB via `systing-util convert` ✓
- Reviewed; all feedback addressed (policy-based probe, signature sanitization + VBox/ACRN, Hyper-V-enlightenments caveat documented, device-tree `compatible` read on non-x86_64, BY NAME fix, MSRV)