### PR TITLE
Sample CPU stacks in fixed-period mode and record sampling provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.8.2"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.8.2"
+version = "1.9.0"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -153,3 +153,36 @@ record-time import (`src/duckdb.rs`) and `systing-util convert` (which
 previously used positional inserts and would have failed on any added column,
 including v8's `process` columns) now use `INSERT ... BY NAME`, which fills
 missing columns with `NULL`.
+
+---
+
+## Schema Version 10 (systing 1.9.0) — 2026-06-04
+
+Stack sampling moved from the kernel's adaptive frequency mode (nominal 1000 Hz
+on cpu-cycles) to fixed-period mode: the frequency estimator shrinks the period
+toward its floor while a CPU idles, then floods samples the moment the CPU
+wakes, oversampling wakeup paths on mostly-idle CPUs. With a fixed period each
+CPU stack sample represents an exact, constant amount of execution — but
+interpreting it requires knowing the period, and converting cycles to time
+requires CPU frequency data, so both are now recorded.
+
+### Added columns
+- `sysinfo`: added `sample_event VARCHAR` — the perf event that drove CPU stack
+  sampling: `cpu-cycles` (hardware) or `cpu-clock` (software fallback, used
+  with `--sw-event` or when the PMU is unavailable, e.g. most VMs). `NULL` in
+  traces recorded by systing < 1.9.
+- `sysinfo`: added `sample_period BIGINT` — the sampling period in event units:
+  each `stack_sample` row with `stack_event_type = 1` represents
+  `sample_period` cycles (`cpu-cycles`) or nanoseconds (`cpu-clock`) of
+  execution. The period is chosen at startup so sampling runs at ~1000 Hz at
+  the fastest CPU's maximum frequency. `NULL` in traces from systing < 1.9.
+
+### Added tables
+- `cpu_info` — per-CPU static frequency limits from sysfs cpufreq, in kHz:
+  `cpu INTEGER`, `min_freq_khz BIGINT`, `max_freq_khz BIGINT`,
+  `base_freq_khz BIGINT` (sustained non-turbo frequency; only exposed by some
+  drivers, e.g. intel_pstate). One row per CPU with cpufreq data; empty on
+  systems without cpufreq support (typical for VM guests). With cycles-based
+  sampling these bound the cycles-to-time conversion per CPU; with a fixed
+  period, effective frequency is also derivable directly from the trace as
+  `sample_period / Δts` between consecutive samples on a continuously-busy CPU.

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -124,6 +124,16 @@ pub struct TraceSystemInfo {
     /// so CPU-frequency counter tracks are absent from the trace.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpufreq_driver: Option<String>,
+    /// Perf event that drove CPU stack sampling: "cpu-cycles" (hardware) or
+    /// "cpu-clock" (software fallback). `None` for traces from systing < 1.9,
+    /// which sampled cpu-cycles in adaptive frequency mode at a nominal 1kHz.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sample_event: Option<String>,
+    /// Stack sampling period in event units: one CPU stack sample
+    /// (stack_event_type = 1) represents this many cycles ("cpu-cycles") or
+    /// nanoseconds ("cpu-clock") of execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sample_period: Option<i64>,
 }
 
 /// Trace metadata.
@@ -470,7 +480,7 @@ impl AnalyzeDb {
             }
         };
         let sql = format!(
-            "SELECT {}, {}, {}, {}, {}, {}, {} FROM sysinfo ORDER BY 1",
+            "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {} FROM sysinfo ORDER BY 1",
             col("trace_id"),
             col("release"),
             col("machine"),
@@ -478,6 +488,8 @@ impl AnalyzeDb {
             col("sys_vendor"),
             col("product_name"),
             col("cpufreq_driver"),
+            col("sample_event"),
+            col("sample_period"),
         );
 
         let Ok(mut stmt) = self.conn.prepare(&sql) else {
@@ -492,6 +504,8 @@ impl AnalyzeDb {
                 sys_vendor: row.get(4)?,
                 product_name: row.get(5)?,
                 cpufreq_driver: row.get(6)?,
+                sample_event: row.get(7)?,
+                sample_period: row.get(8)?,
             })
         }) else {
             return Vec::new();
@@ -731,9 +745,10 @@ mod tests {
             crate::duckdb::create_schema(&conn).unwrap();
             conn.execute_batch(
                 "INSERT INTO sysinfo (trace_id, sysname, release, version, machine, \
-                 cpufreq_driver, hypervisor, sys_vendor, product_name) \
+                 cpufreq_driver, hypervisor, sys_vendor, product_name, \
+                 sample_event, sample_period) \
                  VALUES ('t1', 'Linux', '6.12.0', '#1 SMP', 'x86_64', \
-                 NULL, 'kvm', 'Amazon EC2', 'm7i.16xlarge')",
+                 NULL, 'kvm', 'Amazon EC2', 'm7i.16xlarge', 'cpu-clock', 1000000)",
             )
             .unwrap();
         }
@@ -753,6 +768,8 @@ mod tests {
             sys.cpufreq_driver, None,
             "NULL cpufreq_driver must come back as None"
         );
+        assert_eq!(sys.sample_event.as_deref(), Some("cpu-clock"));
+        assert_eq!(sys.sample_period, Some(1_000_000));
     }
 
     #[test]
@@ -771,6 +788,8 @@ mod tests {
                  ALTER TABLE sysinfo DROP COLUMN hypervisor; \
                  ALTER TABLE sysinfo DROP COLUMN sys_vendor; \
                  ALTER TABLE sysinfo DROP COLUMN product_name; \
+                 ALTER TABLE sysinfo DROP COLUMN sample_event; \
+                 ALTER TABLE sysinfo DROP COLUMN sample_period; \
                  INSERT INTO sysinfo (trace_id, sysname, release, version, machine) \
                  VALUES ('t1', 'Linux', '5.10.0', '#1 SMP', 'aarch64')",
             )
@@ -788,6 +807,8 @@ mod tests {
         assert_eq!(sys.sys_vendor, None);
         assert_eq!(sys.product_name, None);
         assert_eq!(sys.cpufreq_driver, None);
+        assert_eq!(sys.sample_event, None);
+        assert_eq!(sys.sample_period, None);
     }
 
     #[test]

--- a/src/bin/systing_util.rs
+++ b/src/bin/systing_util.rs
@@ -3481,6 +3481,8 @@ fn run_convert(
     import_table("clock_snapshot", |p| &p.clock_snapshot)?;
     // System info
     import_table("sysinfo", |p| &p.sysinfo)?;
+    // Per-CPU frequency limits
+    import_table("cpu_info", |p| &p.cpu_info)?;
 
     conn.execute_batch("COMMIT")?;
 

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -117,7 +117,7 @@ pub struct TraceImportMapping {
 }
 
 /// Current schema version. See SCHEMA_CHANGES.md for history.
-pub const SCHEMA_VERSION: u32 = 9;
+pub const SCHEMA_VERSION: u32 = 10;
 
 /// All data tables in the DuckDB schema (excludes the `_traces` metadata table).
 pub const DATA_TABLES: &[&str] = &[
@@ -156,6 +156,7 @@ pub const DATA_TABLES: &[&str] = &[
     "memory_alloc",
     "clock_snapshot",
     "sysinfo",
+    "cpu_info",
     "tpu_device",
     "tpu_op",
     "tpu_metric",
@@ -562,7 +563,26 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
             cpufreq_driver VARCHAR,
             hypervisor VARCHAR,
             sys_vendor VARCHAR,
-            product_name VARCHAR
+            product_name VARCHAR,
+            -- Perf event driving stack sampling ('cpu-cycles' or 'cpu-clock')
+            -- and its period in event units (cycles or nanoseconds): one
+            -- stack_sample row with stack_event_type = 1 represents
+            -- sample_period cycles/ns of execution. NULL in traces recorded
+            -- by systing < 1.9.
+            sample_event VARCHAR,
+            sample_period BIGINT
+        );
+
+        -- Per-CPU static frequency limits (kHz) from sysfs cpufreq. Empty on
+        -- systems without cpufreq support (typical for VM guests). With
+        -- cycles-based sampling these convert cycle counts to approximate
+        -- time; per-CPU rows matter on heterogeneous parts (P/E cores).
+        CREATE TABLE IF NOT EXISTS cpu_info (
+            trace_id VARCHAR,
+            cpu INTEGER,
+            min_freq_khz BIGINT,
+            max_freq_khz BIGINT,
+            base_freq_khz BIGINT
         );
 
         -- TPU profiling tables
@@ -753,6 +773,7 @@ fn import_tables(conn: &Connection, paths: &ParquetPaths, trace_id: &str) -> Res
 
     // System info
     import_table("sysinfo", &paths.sysinfo)?;
+    import_table("cpu_info", &paths.cpu_info)?;
 
     // TPU tables
     import_table("tpu_device", &paths.tpu_device)?;
@@ -1147,6 +1168,7 @@ pub fn duckdb_to_parquet(db_path: &Path, output_dir: &Path, trace_id: &str) -> R
 
     // System info
     export_table("sysinfo", &paths.sysinfo)?;
+    export_table("cpu_info", &paths.cpu_info)?;
 
     // TPU tables
     export_table("tpu_device", &paths.tpu_device)?;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -576,7 +576,7 @@ impl SystingMcpServer {
 
     #[tool(
         name = "trace_info",
-        description = "Get metadata about a trace database: database path, trace IDs, time range (in nanoseconds and seconds), per-trace system/platform info (kernel, architecture, hypervisor, DMI vendor/product, cpufreq driver), non-empty tables with row counts, total process count, and the top 25 processes by thread count. Platform fields are omitted when unset: an absent hypervisor means bare metal, and an absent cpufreq_driver means CPU-frequency tracks are absent from the trace - except for traces recorded by systing < 1.8, which omit all four platform fields (meaning unknown, not bare metal). The whole system field is absent when the database has no sysinfo data. Use the query tool to explore the full process list if needed."
+        description = "Get metadata about a trace database: database path, trace IDs, time range (in nanoseconds and seconds), per-trace system/platform info (kernel, architecture, hypervisor, DMI vendor/product, cpufreq driver, stack-sampling event/period), non-empty tables with row counts, total process count, and the top 25 processes by thread count. Platform fields are omitted when unset: an absent hypervisor means bare metal, and an absent cpufreq_driver means CPU-frequency tracks are absent from the trace - except for traces recorded by systing < 1.8, which omit all four platform fields (meaning unknown, not bare metal). sample_event/sample_period (systing >= 1.9) say what one CPU stack sample represents: sample_period cycles for 'cpu-cycles' (so sample density tracks cycles consumed, not wall time; the cpu_info table holds per-CPU min/max/base frequency in kHz for cycles-to-time conversion) or sample_period nanoseconds for 'cpu-clock'; absent means an older trace sampled with the kernel's adaptive frequency mode at a nominal 1000 Hz. The whole system field is absent when the database has no sysinfo data. Use the query tool to explore the full process list if needed."
     )]
     async fn trace_info(
         &self,
@@ -738,6 +738,8 @@ network activity, and performance counters. Traces are stored in DuckDB database
 - process: Process metadata (upid=internal unique ID, pid=Linux PID, name).
 - sched_slice: Scheduling events with durations.
 - counter: Performance counter values over time.
+- cpu_info: Per-CPU static frequency limits in kHz (min/max/base) from sysfs \
+  cpufreq; empty on systems without cpufreq support (typical VMs).
 - network_syscall: Network send/recv syscalls with bytes and buffer metrics.
 - network_packet: Packet-level events (TCP/UDP) with sequence numbers, \
   retransmits, RTT, drops.
@@ -748,6 +750,12 @@ network activity, and performance counters. Traces are stored in DuckDB database
 - utid/upid are internal unique thread/process IDs (not Linux TID/PID). \
   Use thread.tid / process.pid for the Linux IDs.
 - stack_sample.stack_event_type: 0 = uninterruptible-sleep, 1 = CPU sample, 2 = interruptible-sleep.
+- CPU samples are taken in fixed-period mode (systing >= 1.9): each represents \
+  sysinfo.sample_period cycles (sample_event 'cpu-cycles') or nanoseconds \
+  ('cpu-clock'). With cycles, sample density tracks cycles consumed, not wall \
+  time - use sched_slice for time, and cpu_info frequencies (or \
+  sample_period / delta-ts between consecutive samples on a busy CPU) to \
+  convert cycles to approximate time.
 - sched_slice.end_state: 1 = interruptible sleep (S), 2 = uninterruptible sleep (D).
 - Tables are linked by trace_id (for multi-trace databases).
 
@@ -756,8 +764,8 @@ All tools accept an optional `path` parameter pointing to a .duckdb trace databa
 The database is opened automatically on first use and cached for subsequent calls. \
 If `path` is omitted, the most recently accessed database is used.
 1. trace_info \u{2014} Get overview: traces, time range, system/platform \
-   (kernel, hypervisor, machine type, cpufreq driver), tables, processes. \
-   Good first call with a new database path.
+   (kernel, hypervisor, machine type, cpufreq driver, stack-sampling \
+   event/period), tables, processes. Good first call with a new database path.
 2. list_tables \u{2014} See all tables and row counts.
 3. describe_table \u{2014} Get column names and types for a table of interest.
 4. query \u{2014} Run SQL queries. Results are capped at 10,000 rows; \

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -26,13 +26,13 @@ use crate::network_recorder::{drop_reason_str, format_tcp_flags, tcp_state_name}
 use crate::parquet::ParquetPaths;
 use crate::record::RecordCollector;
 use crate::trace::{
-    self, ArgRecord, ClockSnapshotRecord, CounterRecord, CounterTrackRecord, InstantArgRecord,
-    InstantRecord, IrqSliceRecord, MemoryAllocRecord, MemoryFaultRecord, MemoryMapRecord,
-    MemoryRssRecord, NetworkDnsRecord, NetworkInterfaceRecord, NetworkPacketRecord,
-    NetworkPollRecord, NetworkSocketRecord, NetworkSyscallRecord, ProcessExitRecord, ProcessRecord,
-    SchedSliceRecord, SliceRecord, SocketConnectionRecord, SoftirqSliceRecord, StackRecord,
-    StackSampleRecord, SysInfoRecord, ThreadRecord, ThreadStateRecord, TpuDeviceRecord,
-    TpuMetricRecord, TpuOpRecord, TrackRecord, WakeupNewRecord,
+    self, ArgRecord, ClockSnapshotRecord, CounterRecord, CounterTrackRecord, CpuInfoRecord,
+    InstantArgRecord, InstantRecord, IrqSliceRecord, MemoryAllocRecord, MemoryFaultRecord,
+    MemoryMapRecord, MemoryRssRecord, NetworkDnsRecord, NetworkInterfaceRecord,
+    NetworkPacketRecord, NetworkPollRecord, NetworkSocketRecord, NetworkSyscallRecord,
+    ProcessExitRecord, ProcessRecord, SchedSliceRecord, SliceRecord, SocketConnectionRecord,
+    SoftirqSliceRecord, StackRecord, StackSampleRecord, SysInfoRecord, ThreadRecord,
+    ThreadStateRecord, TpuDeviceRecord, TpuMetricRecord, TpuOpRecord, TrackRecord, WakeupNewRecord,
 };
 
 /// Default batch size for streaming writes.
@@ -90,6 +90,7 @@ pub struct StreamingParquetWriter {
     memory_allocs: Vec<MemoryAllocRecord>,
     clock_snapshots: Vec<ClockSnapshotRecord>,
     sysinfo: Option<SysInfoRecord>,
+    cpu_infos: Vec<CpuInfoRecord>,
     tpu_devices: Vec<TpuDeviceRecord>,
     tpu_ops: Vec<TpuOpRecord>,
     tpu_metrics: Vec<TpuMetricRecord>,
@@ -125,6 +126,7 @@ pub struct StreamingParquetWriter {
     memory_alloc_writer: Option<ArrowWriter<File>>,
     clock_snapshot_writer: Option<ArrowWriter<File>>,
     sysinfo_writer: Option<ArrowWriter<File>>,
+    cpu_info_writer: Option<ArrowWriter<File>>,
     tpu_device_writer: Option<ArrowWriter<File>>,
     tpu_op_writer: Option<ArrowWriter<File>>,
     tpu_metric_writer: Option<ArrowWriter<File>>,
@@ -205,6 +207,7 @@ impl StreamingParquetWriter {
             memory_allocs: Vec::new(),
             clock_snapshots: Vec::new(),
             sysinfo: None,
+            cpu_infos: Vec::new(),
             tpu_devices: Vec::new(),
             tpu_ops: Vec::new(),
             tpu_metrics: Vec::new(),
@@ -239,6 +242,7 @@ impl StreamingParquetWriter {
             memory_alloc_writer: None,
             clock_snapshot_writer: None,
             sysinfo_writer: None,
+            cpu_info_writer: None,
             tpu_device_writer: None,
             tpu_op_writer: None,
             tpu_metric_writer: None,
@@ -718,6 +722,26 @@ impl StreamingParquetWriter {
         Ok(())
     }
 
+    // Flush cpu_infos buffer
+    fn flush_cpu_infos(&mut self) -> Result<()> {
+        if self.cpu_infos.is_empty() {
+            return Ok(());
+        }
+
+        let schema = trace::cpu_info_schema();
+        let writer = Self::get_or_create_writer(
+            &mut self.cpu_info_writer,
+            &self.paths.cpu_info,
+            schema.clone(),
+            &self.writer_props,
+        )?;
+
+        let batch = build_cpu_info_batch(&self.cpu_infos, &schema)?;
+        writer.write(&batch)?;
+        self.cpu_infos.clear();
+        Ok(())
+    }
+
     // Flush network_syscalls buffer
     fn flush_network_syscalls(&mut self) -> Result<()> {
         if self.network_syscalls.is_empty() {
@@ -993,6 +1017,7 @@ impl StreamingParquetWriter {
         close_writer!(self.memory_alloc_writer);
         close_writer!(self.clock_snapshot_writer);
         close_writer!(self.sysinfo_writer);
+        close_writer!(self.cpu_info_writer);
         close_writer!(self.tpu_device_writer);
         close_writer!(self.tpu_op_writer);
         close_writer!(self.tpu_metric_writer);
@@ -1033,6 +1058,7 @@ impl Drop for StreamingParquetWriter {
             || self.network_dns_writer.is_some()
             || self.clock_snapshot_writer.is_some()
             || self.sysinfo_writer.is_some()
+            || self.cpu_info_writer.is_some()
             || self.tpu_device_writer.is_some()
             || self.tpu_op_writer.is_some()
             || self.tpu_metric_writer.is_some();
@@ -1362,6 +1388,15 @@ impl RecordCollector for StreamingParquetWriter {
         Ok(())
     }
 
+    fn add_cpu_info(&mut self, record: CpuInfoRecord) -> Result<()> {
+        self.cpu_infos.push(record);
+        self.total_records += 1;
+        if Self::should_flush(&self.cpu_infos, self.batch_size) {
+            self.flush_cpu_infos()?;
+        }
+        Ok(())
+    }
+
     fn flush(&mut self) -> Result<()> {
         self.flush_processes()?;
         self.flush_threads()?;
@@ -1393,6 +1428,7 @@ impl RecordCollector for StreamingParquetWriter {
         self.flush_memory_allocs()?;
         self.flush_clock_snapshots()?;
         self.flush_sysinfo()?;
+        self.flush_cpu_infos()?;
         self.flush_tpu_devices()?;
         self.flush_tpu_ops()?;
         self.flush_tpu_metrics()?;
@@ -2010,6 +2046,8 @@ fn build_sysinfo_batch(record: &SysInfoRecord, schema: &Arc<Schema>) -> Result<R
     let mut hypervisor_builder = StringBuilder::with_capacity(1, 16);
     let mut sys_vendor_builder = StringBuilder::with_capacity(1, 16);
     let mut product_name_builder = StringBuilder::with_capacity(1, 16);
+    let mut sample_event_builder = StringBuilder::with_capacity(1, 16);
+    let mut sample_period_builder = Int64Builder::with_capacity(1);
 
     sysname_builder.append_value(&record.sysname);
     release_builder.append_value(&record.release);
@@ -2019,6 +2057,8 @@ fn build_sysinfo_batch(record: &SysInfoRecord, schema: &Arc<Schema>) -> Result<R
     hypervisor_builder.append_option(record.hypervisor.as_deref());
     sys_vendor_builder.append_option(record.sys_vendor.as_deref());
     product_name_builder.append_option(record.product_name.as_deref());
+    sample_event_builder.append_option(record.sample_event.as_deref());
+    sample_period_builder.append_option(record.sample_period);
 
     Ok(RecordBatch::try_new(
         schema.clone(),
@@ -2031,6 +2071,32 @@ fn build_sysinfo_batch(record: &SysInfoRecord, schema: &Arc<Schema>) -> Result<R
             Arc::new(hypervisor_builder.finish()),
             Arc::new(sys_vendor_builder.finish()),
             Arc::new(product_name_builder.finish()),
+            Arc::new(sample_event_builder.finish()),
+            Arc::new(sample_period_builder.finish()),
+        ],
+    )?)
+}
+
+fn build_cpu_info_batch(records: &[CpuInfoRecord], schema: &Arc<Schema>) -> Result<RecordBatch> {
+    let mut cpu_builder = Int32Builder::with_capacity(records.len());
+    let mut min_freq_builder = Int64Builder::with_capacity(records.len());
+    let mut max_freq_builder = Int64Builder::with_capacity(records.len());
+    let mut base_freq_builder = Int64Builder::with_capacity(records.len());
+
+    for record in records {
+        cpu_builder.append_value(record.cpu);
+        min_freq_builder.append_option(record.min_freq_khz);
+        max_freq_builder.append_option(record.max_freq_khz);
+        base_freq_builder.append_option(record.base_freq_khz);
+    }
+
+    Ok(RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(cpu_builder.finish()),
+            Arc::new(min_freq_builder.finish()),
+            Arc::new(max_freq_builder.finish()),
+            Arc::new(base_freq_builder.finish()),
         ],
     )?)
 }
@@ -2799,6 +2865,8 @@ mod tests {
                 hypervisor: Some("kvm".to_string()),
                 sys_vendor: Some("Amazon EC2".to_string()),
                 product_name: None,
+                sample_event: Some("cpu-cycles".to_string()),
+                sample_period: Some(3_500_000),
             })
             .unwrap();
         writer.finish().unwrap();
@@ -2807,18 +2875,22 @@ mod tests {
         parquet_to_duckdb(dir.path(), &db_path, "test-trace")
             .expect("DuckDB import should succeed");
 
+        type SysInfoRow = (
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            Option<i64>,
+        );
+
         let conn = Connection::open(&db_path).unwrap();
-        let row: (
-            String,
-            String,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-            Option<String>,
-        ) = conn
+        let row: SysInfoRow = conn
             .query_row(
-                "SELECT sysname, machine, cpufreq_driver, hypervisor, sys_vendor, product_name \
-                 FROM sysinfo",
+                "SELECT sysname, machine, cpufreq_driver, hypervisor, sys_vendor, product_name, \
+                 sample_event, sample_period FROM sysinfo",
                 [],
                 |row| {
                     Ok((
@@ -2828,6 +2900,8 @@ mod tests {
                         row.get(3)?,
                         row.get(4)?,
                         row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
                     ))
                 },
             )
@@ -2839,6 +2913,84 @@ mod tests {
         assert_eq!(row.3, Some("kvm".to_string()));
         assert_eq!(row.4, Some("Amazon EC2".to_string()));
         assert_eq!(row.5, None, "absent product_name should round-trip as NULL");
+        assert_eq!(row.6, Some("cpu-cycles".to_string()));
+        assert_eq!(row.7, Some(3_500_000));
+    }
+
+    #[test]
+    fn test_cpu_info_duckdb_round_trip() {
+        use crate::duckdb::parquet_to_duckdb;
+        use duckdb::Connection;
+
+        let dir = TempDir::new().unwrap();
+        let mut writer = StreamingParquetWriter::new(dir.path()).unwrap();
+
+        // A heterogeneous part: cpu 0 is a P-core with a base frequency, cpu 1
+        // is an E-core whose driver exposes no base_frequency.
+        writer
+            .add_cpu_info(CpuInfoRecord {
+                cpu: 0,
+                min_freq_khz: Some(400_000),
+                max_freq_khz: Some(5_000_000),
+                base_freq_khz: Some(3_200_000),
+            })
+            .unwrap();
+        writer
+            .add_cpu_info(CpuInfoRecord {
+                cpu: 1,
+                min_freq_khz: Some(400_000),
+                max_freq_khz: Some(3_800_000),
+                base_freq_khz: None,
+            })
+            .unwrap();
+        writer.finish().unwrap();
+
+        let db_path = dir.path().join("test.duckdb");
+        parquet_to_duckdb(dir.path(), &db_path, "test-trace")
+            .expect("DuckDB import should succeed");
+
+        type CpuInfoRow = (String, i32, Option<i64>, Option<i64>, Option<i64>);
+
+        let conn = Connection::open(&db_path).unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT trace_id, cpu, min_freq_khz, max_freq_khz, base_freq_khz \
+                 FROM cpu_info ORDER BY cpu",
+            )
+            .unwrap();
+        let rows: Vec<CpuInfoRow> = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "test-trace".to_string(),
+                    0,
+                    Some(400_000),
+                    Some(5_000_000),
+                    Some(3_200_000)
+                ),
+                (
+                    "test-trace".to_string(),
+                    1,
+                    Some(400_000),
+                    Some(3_800_000),
+                    None
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/src/parquet_paths.rs
+++ b/src/parquet_paths.rs
@@ -52,6 +52,8 @@ pub struct ParquetPaths {
     pub clock_snapshot: PathBuf,
     // System info table
     pub sysinfo: PathBuf,
+    // Per-CPU frequency limits table
+    pub cpu_info: PathBuf,
     // TPU tables
     pub tpu_device: PathBuf,
     pub tpu_op: PathBuf,
@@ -112,6 +114,8 @@ impl ParquetPaths {
             clock_snapshot: dir.join("clock_snapshot.parquet"),
             // System info table
             sysinfo: dir.join("sysinfo.parquet"),
+            // Per-CPU frequency limits table
+            cpu_info: dir.join("cpu_info.parquet"),
             // TPU tables
             tpu_device: dir.join("tpu_device.parquet"),
             tpu_op: dir.join("tpu_op.parquet"),
@@ -159,6 +163,7 @@ impl ParquetPaths {
             memory_alloc: dir.join(format!("{trace_id}_memory_alloc.parquet")),
             clock_snapshot: dir.join(format!("{trace_id}_clock_snapshot.parquet")),
             sysinfo: dir.join(format!("{trace_id}_sysinfo.parquet")),
+            cpu_info: dir.join(format!("{trace_id}_cpu_info.parquet")),
             // TPU tables
             tpu_device: dir.join(format!("{trace_id}_tpu_device.parquet")),
             tpu_op: dir.join(format!("{trace_id}_tpu_op.parquet")),
@@ -167,7 +172,7 @@ impl ParquetPaths {
     }
 
     /// Returns all paths with their names (single source of truth for path iteration).
-    fn all_paths_with_names(&self) -> [PathEntry<'_>; 38] {
+    fn all_paths_with_names(&self) -> [PathEntry<'_>; 39] {
         [
             PathEntry {
                 path: &self.process,
@@ -309,6 +314,10 @@ impl ParquetPaths {
             PathEntry {
                 path: &self.sysinfo,
                 name: "sysinfo",
+            },
+            PathEntry {
+                path: &self.cpu_info,
+                name: "cpu_info",
             },
             PathEntry {
                 path: &self.tpu_device,

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -228,10 +228,16 @@ impl PerfOpenEvents {
         self.events.values()
     }
 
+    /// Open the configured events. A non-zero `sample_period` makes the events
+    /// sample every `sample_period` occurrences of the event (cycles for
+    /// cpu-cycles, nanoseconds for cpu-clock). Period mode is used instead of
+    /// the kernel's adaptive frequency mode because the frequency estimator
+    /// misbehaves on mostly-idle CPUs: it shrinks the period toward its floor
+    /// while the CPU idles, then floods samples the moment the CPU wakes up.
     pub fn open_events(
         &mut self,
         slots_files: Option<&PerfOpenEvents>,
-        freq: u64,
+        sample_period: u64,
     ) -> Result<(), Error> {
         if !self.events.is_empty() {
             return Ok(());
@@ -244,9 +250,8 @@ impl PerfOpenEvents {
             attr._type = hwevent.event_type;
             attr.size = mem::size_of::<perf_event_attr>() as u32;
             attr.config = hwevent.event_config;
-            if freq > 0 {
-                attr.sample.sample_freq = freq;
-                attr.flags.set_freq(1);
+            if sample_period > 0 {
+                attr.sample.sample_period = sample_period;
             }
             if hwevent.disabled {
                 attr.flags.set_disabled(1);

--- a/src/record/collector.rs
+++ b/src/record/collector.rs
@@ -9,9 +9,9 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use anyhow::Result;
 
 use crate::trace::{
-    ArgRecord, ClockSnapshotRecord, CounterRecord, CounterTrackRecord, ExtractedData,
-    InstantArgRecord, InstantRecord, IrqSliceRecord, MemoryAllocRecord, MemoryFaultRecord,
-    MemoryMapRecord, MemoryRssRecord, NetworkDnsRecord, NetworkInterfaceRecord,
+    ArgRecord, ClockSnapshotRecord, CounterRecord, CounterTrackRecord, CpuInfoRecord,
+    ExtractedData, InstantArgRecord, InstantRecord, IrqSliceRecord, MemoryAllocRecord,
+    MemoryFaultRecord, MemoryMapRecord, MemoryRssRecord, NetworkDnsRecord, NetworkInterfaceRecord,
     NetworkPacketRecord, NetworkPollRecord, NetworkSocketRecord, NetworkSyscallRecord,
     ProcessExitRecord, ProcessRecord, SchedSliceRecord, SliceRecord, SocketConnectionRecord,
     SoftirqSliceRecord, StackRecord, StackSampleRecord, SysInfoRecord, ThreadRecord,
@@ -123,6 +123,9 @@ pub trait RecordCollector {
 
     /// Set the system info record (only one per trace).
     fn set_sysinfo(&mut self, record: SysInfoRecord) -> Result<()>;
+
+    /// Add a per-CPU frequency-limit record (one per CPU with cpufreq data).
+    fn add_cpu_info(&mut self, record: CpuInfoRecord) -> Result<()>;
 
     // TPU profiling records
 
@@ -254,6 +257,7 @@ impl RecordCollector for SharedCollector {
         add_memory_fault(MemoryFaultRecord),
         add_memory_alloc(MemoryAllocRecord),
         set_sysinfo(SysInfoRecord),
+        add_cpu_info(CpuInfoRecord),
         add_tpu_device(TpuDeviceRecord),
         add_tpu_op(TpuOpRecord),
         add_tpu_metric(TpuMetricRecord),
@@ -448,6 +452,11 @@ impl RecordCollector for InMemoryCollector {
 
     fn set_sysinfo(&mut self, record: SysInfoRecord) -> Result<()> {
         self.data.sysinfo = Some(record);
+        Ok(())
+    }
+
+    fn add_cpu_info(&mut self, record: CpuInfoRecord) -> Result<()> {
+        self.data.cpu_infos.push(record);
         Ok(())
     }
 

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::CStr;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::os::unix::io::AsRawFd;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
 
 use anyhow::Result;
 
@@ -42,6 +42,64 @@ pub struct SysInfoEvent {
     pub cpu: u32,
     pub ts: u64,
     pub frequency: i64,
+}
+
+/// The perf event configuration driving CPU stack sampling. Recorded into the
+/// trace's sysinfo row so analysis knows what one stack sample represents:
+/// `period` cycles for "cpu-cycles", `period` nanoseconds for "cpu-clock".
+#[derive(Clone, Debug)]
+pub struct ClockSamplingConfig {
+    /// Perf event name: "cpu-cycles" (hardware) or "cpu-clock" (software
+    /// fallback, used with --sw-event or when the PMU is unavailable).
+    pub event: &'static str,
+    /// Sampling period in event units (cycles or nanoseconds).
+    pub period: u64,
+}
+
+/// Static per-CPU frequency limits from sysfs cpufreq, in kHz (sysfs's native
+/// unit). `base_freq_khz` is the sustained (non-turbo) frequency and is only
+/// exposed by some drivers (e.g. intel_pstate).
+pub struct CpuFreqInfo {
+    pub cpu: u32,
+    pub min_freq_khz: Option<i64>,
+    pub max_freq_khz: Option<i64>,
+    pub base_freq_khz: Option<i64>,
+}
+
+/// Read each CPU's cpufreq limits from sysfs. CPUs without a cpufreq directory
+/// (VM guests, offlined CPUs) are omitted, so the result is empty on systems
+/// with no cpufreq support. Used both to pick the cpu-cycles sample period at
+/// startup and to record per-CPU frequency provenance in the trace, which is
+/// what lets analysis convert cycle-denominated samples into approximate time.
+pub fn cpu_freq_limits() -> Vec<CpuFreqInfo> {
+    let Ok(entries) = fs::read_dir("/sys/devices/system/cpu") else {
+        return Vec::new();
+    };
+    let mut cpus: Vec<CpuFreqInfo> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let name = entry.file_name();
+            let cpu: u32 = name.to_str()?.strip_prefix("cpu")?.parse().ok()?;
+            let cpufreq = entry.path().join("cpufreq");
+            let read_khz = |file: &str| -> Option<i64> {
+                read_sysfs_string(cpufreq.join(file).to_str()?)?
+                    .parse()
+                    .ok()
+            };
+            let info = CpuFreqInfo {
+                cpu,
+                min_freq_khz: read_khz("cpuinfo_min_freq"),
+                max_freq_khz: read_khz("cpuinfo_max_freq"),
+                base_freq_khz: read_khz("base_frequency"),
+            };
+            let has_data = info.min_freq_khz.is_some()
+                || info.max_freq_khz.is_some()
+                || info.base_freq_khz.is_some();
+            has_data.then_some(info)
+        })
+        .collect();
+    cpus.sort_by_key(|c| c.cpu);
+    cpus
 }
 
 pub struct SysinfoRecorder {
@@ -99,6 +157,9 @@ pub struct SessionRecorder {
     kernel_threads: RwLock<HashSet<u32>>,
     /// Shared utid generator for consistent thread IDs across all recorders.
     utid_generator: Arc<UtidGenerator>,
+    /// The perf event/period driving CPU stack sampling, set once perf events
+    /// are opened. Unset until then (or in unit tests that never open them).
+    pub clock_sampling: OnceLock<ClockSamplingConfig>,
 }
 
 pub fn get_clock_value(clock_id: libc::c_int) -> u64 {
@@ -622,6 +683,7 @@ impl SessionRecorder {
             process_cgroups: RwLock::new(HashMap::new()),
             kernel_threads: RwLock::new(HashSet::new()),
             utid_generator,
+            clock_sampling: OnceLock::new(),
         }
     }
 
@@ -1084,6 +1146,7 @@ impl SessionRecorder {
 
         // Write system info (utsname + platform provenance)
         if let Some(utsname) = get_system_utsname() {
+            let clock_sampling = self.clock_sampling.get();
             writer.set_sysinfo(crate::trace::SysInfoRecord {
                 sysname: utsname.sysname().to_string(),
                 release: utsname.release().to_string(),
@@ -1093,6 +1156,20 @@ impl SessionRecorder {
                 hypervisor: detect_hypervisor(),
                 sys_vendor: dmi_sys_vendor(),
                 product_name: dmi_product_name(),
+                sample_event: clock_sampling.map(|c| c.event.to_string()),
+                sample_period: clock_sampling.map(|c| c.period as i64),
+            })?;
+        }
+
+        // Write per-CPU frequency limits so cycle-denominated stack samples
+        // can be converted to approximate time during analysis. Empty (no
+        // rows) on systems without cpufreq support.
+        for cpu in cpu_freq_limits() {
+            writer.add_cpu_info(crate::trace::CpuInfoRecord {
+                cpu: cpu.cpu as i32,
+                min_freq_khz: cpu.min_freq_khz,
+                max_freq_khz: cpu.max_freq_khz,
+                base_freq_khz: cpu.base_freq_khz,
             })?;
         }
 
@@ -1494,6 +1571,7 @@ mod tests {
             kernel_threads: RwLock::new(HashSet::new()),
             utid_generator,
             tpu_metrics_recorder: None,
+            clock_sampling: OnceLock::new(),
         }
     }
 

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -26,7 +26,9 @@ use crate::perf::{PerfCounters, PerfHwEvent, PerfOpenEvents};
 use crate::perf_recorder::PerfCounterRecorder;
 use crate::ringbuf::RingBuffer;
 use crate::sched::SchedEventRecorder;
-use crate::session_recorder::{get_clock_value, SessionRecorder, SysInfoEvent};
+use crate::session_recorder::{
+    get_clock_value, ClockSamplingConfig, SessionRecorder, SysInfoEvent,
+};
 use crate::stack_recorder::StackRecorder;
 
 // Library imports for shared functionality
@@ -42,8 +44,20 @@ use libbpf_rs::{
 
 use plain::Plain;
 
-/// Sample period for perf clock events (1ms = 1000 samples/sec)
-const PERF_CLOCK_SAMPLE_PERIOD: u64 = 1000;
+/// Target stack-sampling rate for the perf clock event, in samples per second
+/// per CPU. The clock event runs in period mode (see `PerfOpenEvents::
+/// open_events`), so this target is hit exactly for the cpu-clock software
+/// event and at max CPU frequency for the cpu-cycles hardware event; a
+/// throttled CPU samples proportionally slower.
+const PERF_CLOCK_TARGET_FREQ_HZ: u64 = 1000;
+
+/// Sample period for the cpu-clock software clock event, which counts
+/// nanoseconds: 1ms between samples = PERF_CLOCK_TARGET_FREQ_HZ.
+const SW_CLOCK_SAMPLE_PERIOD_NS: u64 = 1_000_000_000 / PERF_CLOCK_TARGET_FREQ_HZ;
+
+/// Fallback cpu-cycles sample period when no CPU frequency information is
+/// available from sysfs: assume a 3 GHz part, sampling at ~1kHz.
+const DEFAULT_CYCLES_SAMPLE_PERIOD: u64 = 3_000_000_000 / PERF_CLOCK_TARGET_FREQ_HZ;
 
 /// Memory lock limit for BPF programs (128 MiB)
 const MEMLOCK_RLIMIT_BYTES: u64 = 128 << 20;
@@ -2187,20 +2201,45 @@ fn configure_bpf_skeleton(
     Ok(())
 }
 
+/// Pick the cpu-cycles sample period that yields PERF_CLOCK_TARGET_FREQ_HZ
+/// samples/sec at the fastest CPU's maximum frequency. Using the max across
+/// CPUs (rather than per-CPU periods) keeps the period uniform so every sample
+/// in the trace represents the same number of cycles; slower or throttled CPUs
+/// simply sample at a proportionally lower rate.
+fn cycles_sample_period() -> u64 {
+    let max_khz = crate::session_recorder::cpu_freq_limits()
+        .into_iter()
+        .filter_map(|c| c.max_freq_khz)
+        .max();
+    match max_khz {
+        Some(khz) if khz > 0 => (khz as u64 * 1000) / PERF_CLOCK_TARGET_FREQ_HZ,
+        _ => DEFAULT_CYCLES_SAMPLE_PERIOD,
+    }
+}
+
 fn setup_perf_events(
     skel: &mut SystingSystemSkel,
     opts: &Config,
     counters: &PerfCounters,
     perf_counter_names: &[String],
     num_cpus: u32,
-) -> Result<(Vec<libbpf_rs::Link>, Vec<PerfOpenEvents>)> {
+) -> Result<(
+    Vec<libbpf_rs::Link>,
+    Vec<PerfOpenEvents>,
+    ClockSamplingConfig,
+)> {
     use crate::perf;
 
     let mut perf_links = Vec::new();
     let mut event_files_vec = Vec::new();
 
+    let sw_clock_sampling = ClockSamplingConfig {
+        event: "cpu-clock",
+        period: SW_CLOCK_SAMPLE_PERIOD_NS,
+    };
+
     // Set up clock perf events with automatic VM detection and fallback
-    let clock_files = {
+    let (clock_files, clock_sampling) = {
         let mut clock_files = PerfOpenEvents::default();
         let mut clock_event = PerfHwEvent {
             name: "clock".to_string(),
@@ -2218,11 +2257,19 @@ fn setup_perf_events(
             need_slots: false,
             cpus: (0..num_cpus).collect(),
         };
+        let mut clock_sampling = if opts.sw_event {
+            sw_clock_sampling.clone()
+        } else {
+            ClockSamplingConfig {
+                event: "cpu-cycles",
+                period: cycles_sample_period(),
+            }
+        };
 
         clock_files.add_hw_event(clock_event.clone())?;
 
         // Try to open the events, handle VM detection
-        if let Err(e) = clock_files.open_events(None, PERF_CLOCK_SAMPLE_PERIOD) {
+        if let Err(e) = clock_files.open_events(None, clock_sampling.period) {
             // Check if this is a VM-related error (ErrorKind::NotFound)
             if e.kind() == std::io::ErrorKind::NotFound && !opts.sw_event {
                 // Detected VM environment, automatically retry with software events
@@ -2231,18 +2278,19 @@ fn setup_perf_events(
                 // Modify the event to use software events
                 clock_event.event_type = perf::PERF_TYPE_SOFTWARE;
                 clock_event.event_config = perf::PERF_COUNT_SW_CPU_CLOCK;
+                clock_sampling = sw_clock_sampling;
 
                 // Recreate clock_files with the modified event
                 clock_files = PerfOpenEvents::default();
                 clock_files.add_hw_event(clock_event)?;
-                clock_files.open_events(None, PERF_CLOCK_SAMPLE_PERIOD)?;
+                clock_files.open_events(None, clock_sampling.period)?;
             } else {
                 // Not a VM error or already using software events, propagate the error
                 return Err(e.into());
             }
         }
 
-        clock_files
+        (clock_files, clock_sampling)
     };
 
     // Attach clock events to BPF program
@@ -2315,7 +2363,7 @@ fn setup_perf_events(
         event_files_vec.push(slots_files);
     }
 
-    Ok((perf_links, event_files_vec))
+    Ok((perf_links, event_files_vec, clock_sampling))
 }
 
 /// Returns PIDs to attach probes to with their resolved library paths.
@@ -3298,8 +3346,14 @@ pub fn systing(
         )?;
 
         // Set up perf events (clock events and counter events)
-        let (_perf_links, _events_files) =
+        let (_perf_links, _events_files, clock_sampling) =
             setup_perf_events(&mut skel, &opts, &counters, &perf_counter_names, num_cpus)?;
+
+        // Record which event/period drives stack sampling so the trace's
+        // sysinfo row documents what each stack sample represents. Perf
+        // events are opened once per recording session, so the set cannot
+        // race or repeat.
+        let _ = recorder.clock_sampling.set(clock_sampling);
 
         skel.attach().with_context(|| {
             "Failed to attach BPF programs to tracepoints. Check if tracepoints are enabled."

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -491,6 +491,32 @@ pub struct SysInfoRecord {
     pub sys_vendor: Option<String>,
     /// DMI product name (e.g. "m7i.16xlarge"), if exposed.
     pub product_name: Option<String>,
+    /// Perf event driving CPU stack sampling: "cpu-cycles" (hardware) or
+    /// "cpu-clock" (software fallback). `None` in traces from systing < 1.9
+    /// (which sampled cycles in adaptive frequency mode at a nominal 1000 Hz).
+    pub sample_event: Option<String>,
+    /// Stack sampling period in event units: each `stack_sample` row with
+    /// `stack_event_type` = 1 represents this many cycles ("cpu-cycles") or
+    /// nanoseconds ("cpu-clock") of execution. `None` in traces from
+    /// systing < 1.9.
+    pub sample_period: Option<i64>,
+}
+
+/// Per-CPU static frequency limits from sysfs cpufreq, in kHz.
+///
+/// One row per CPU that exposes cpufreq data; the table is empty on systems
+/// without cpufreq support (typical for VM guests). With cycles-based stack
+/// sampling (`sysinfo.sample_event` = "cpu-cycles") these bound the
+/// cycles-to-time conversion for each CPU; per-CPU rows matter on
+/// heterogeneous parts (P/E cores) where limits differ between CPUs.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CpuInfoRecord {
+    pub cpu: i32,
+    pub min_freq_khz: Option<i64>,
+    pub max_freq_khz: Option<i64>,
+    /// Sustained (non-turbo) frequency; only exposed by some drivers
+    /// (e.g. intel_pstate's `base_frequency`).
+    pub base_freq_khz: Option<i64>,
 }
 
 /// Container for all extracted trace data.
@@ -584,6 +610,7 @@ pub struct ExtractedData {
     pub memory_allocs: Vec<MemoryAllocRecord>,
     pub clock_snapshots: Vec<ClockSnapshotRecord>,
     pub sysinfo: Option<SysInfoRecord>,
+    pub cpu_infos: Vec<CpuInfoRecord>,
     pub tpu_devices: Vec<TpuDeviceRecord>,
     pub tpu_ops: Vec<TpuOpRecord>,
     pub tpu_metrics: Vec<TpuMetricRecord>,

--- a/src/trace/schema.rs
+++ b/src/trace/schema.rs
@@ -240,6 +240,21 @@ pub fn sysinfo_schema() -> Arc<Schema> {
         Field::new("hypervisor", DataType::Utf8, true),
         Field::new("sys_vendor", DataType::Utf8, true),
         Field::new("product_name", DataType::Utf8, true),
+        Field::new("sample_event", DataType::Utf8, true),
+        Field::new("sample_period", DataType::Int64, true),
+    ]))
+}
+
+/// Schema for cpu_info.parquet
+///
+/// Per-CPU static frequency limits (kHz) from sysfs cpufreq. Empty on systems
+/// without cpufreq support.
+pub fn cpu_info_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("cpu", DataType::Int32, false),
+        Field::new("min_freq_khz", DataType::Int64, true),
+        Field::new("max_freq_khz", DataType::Int64, true),
+        Field::new("base_freq_khz", DataType::Int64, true),
     ]))
 }
 


### PR DESCRIPTION
## Problem

The stack-sampling clock event (`PERF_COUNT_HW_CPU_CYCLES`) was opened in the kernel's adaptive **frequency mode** at 1000 Hz. On mostly-idle CPUs the frequency estimator shrinks the period toward its floor while the CPU idles (cycles barely accrue in idle), then floods samples the instant the CPU wakes. Wakeup paths get massively oversampled, giving a false picture of where CPU time goes.

Measured on an idle 64-CPU machine over 5 seconds (real-task samples only, idle pid excluded):

| | samples | sub-100µs same-CPU gaps |
|---|---|---|
| frequency mode (before) | 34,626 | 4.2% |
| period mode (after) | 2,264 | 0% |

Sub-100µs gaps are impossible under honest 1 kHz pacing — they are the storm.

## Fix

Open the clock event in fixed **period mode**:
- cpu-cycles period = (max `cpuinfo_max_freq` across CPUs) / 1000 Hz target, so ~1 kHz at full speed and proportionally slower when throttled. Falls back to 3M cycles when no cpufreq data exists.
- The `--sw-event` / VM-fallback cpu-clock path uses a fixed 1 ms period — identical cadence to before.
- A traced busy loop samples at ~1041 Hz with gaps tightly clustered at 0.95–0.97 ms.

## Recording provenance (schema v10, version 1.9.0)

A fixed cycles period means sample density tracks **cycles consumed**, not wall time, so the trace now records what analysis needs:

- `sysinfo.sample_event` (`cpu-cycles`/`cpu-clock`, reflecting any VM fallback) and `sysinfo.sample_period` (cycles or ns): one CPU stack sample represents exactly `sample_period` event units.
- New `cpu_info` table: per-CPU `min_freq_khz`/`max_freq_khz`/`base_freq_khz` from sysfs cpufreq, for cycles-to-time conversion (per-CPU rows so P/E-core parts are represented; empty on hosts without cpufreq).
- `trace_info` (analyze + MCP) reports the sampling config; MCP instructions document the interpretation, including deriving effective frequency as `sample_period / Δts` between consecutive samples on a busy CPU.

Old databases keep working: the analyze query substitutes NULL for missing columns, imports use `INSERT ... BY NAME`, and exports skip the missing table.

## Known trade-off

The same perf event drives perf-counter reads and memory hiwater sampling, so those also go quiet on idle CPUs; a counter delta accumulated across an idle gap lands on the first post-idle sample.

## Testing

- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo test` (347+ tests) clean
- Full integration suite passes (31 tests)
- New round-trip tests for the sysinfo columns and `cpu_info` table (including heterogeneous P/E-core NULL handling); pre-v9 migration test extended
- E2E traces on a KVM guest with vPMU verify `sample_event='cpu-cycles'`, fallback period 3,000,000, empty `cpu_info` (no cpufreq), schema version 10
- Adversarial code review completed; all findings addressed (notably: `systing-util` parquet-merge now imports `cpu_info`)