### PR TITLE
Bound analysis-side DuckDB resources by the cgroup limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -36,8 +36,75 @@ use duckdb::Connection;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use query::{duckdb_value_to_json, duckdb_value_to_string};
+
+/// Distinguishes the spill directories of databases opened by one process:
+/// DuckDB names temp files by block id, which is only unique per instance, so
+/// instances sharing a temp_directory could clobber each other's spills.
+static SPILL_DIR_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Best-effort removal of spill directories left behind by dead processes.
+/// DuckDB only cleans its temp files up on graceful shutdown, so an OOM-killed
+/// or SIGKILLed process leaves its whole spill directory behind; reclaim it
+/// once the owning pid is gone. Directories whose embedded pid is alive (or
+/// reused) are skipped — a stale dir then just waits for a later sweep.
+fn sweep_stale_spill_dirs(tmp: &Path) {
+    let Ok(entries) = std::fs::read_dir(tmp) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(rest) = name
+            .to_str()
+            .and_then(|n| n.strip_prefix("systing-analyze-spill-"))
+        else {
+            continue;
+        };
+        let Some(pid) = rest.split('-').next().and_then(|p| p.parse::<u32>().ok()) else {
+            continue;
+        };
+        if pid != std::process::id() && !Path::new(&format!("/proc/{pid}")).exists() {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+/// Create a per-instance spill directory under `tmp`, owner-only (0700): left
+/// to DuckDB it would be created lazily with umask-default permissions, and
+/// spill files contain trace contents (stack frames, process names, network
+/// endpoints) that should not be world-readable on multi-user hosts.
+///
+/// Returns `None` if the directory cannot be created — some container
+/// environments have no writable temp dir at all. The caller then disables
+/// spilling entirely rather than inheriting DuckDB's default location (a
+/// lazily-created, umask-permission `.tmp` directory next to the database),
+/// which would quietly drop the owner-only protection. Without spilling, an
+/// oversized aggregation gets a query error at the memory limit, which still
+/// beats the OOM killer.
+fn create_spill_dir(tmp: &Path) -> Option<PathBuf> {
+    let spill_dir = tmp.join(format!(
+        "systing-analyze-spill-{}-{}",
+        std::process::id(),
+        SPILL_DIR_SEQ.fetch_add(1, Ordering::Relaxed),
+    ));
+    use std::os::unix::fs::DirBuilderExt;
+    match std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(&spill_dir)
+    {
+        Ok(()) => Some(spill_dir),
+        Err(e) => {
+            eprintln!(
+                "duckdb: cannot create spill dir {}: {e}; spilling disabled",
+                spill_dir.display()
+            );
+            None
+        }
+    }
+}
 
 /// Maximum number of rows returned by a query.
 pub const MAX_QUERY_ROWS: usize = 10_000;
@@ -183,16 +250,48 @@ impl AnalyzeDb {
             bail!("Database not found: {}", path.display());
         }
 
+        // DuckDB sizes its buffer pool and thread pool from the host (80% of
+        // physical RAM, one thread per CPU), not the cgroup, so analyzing a
+        // large trace from a small container on a big node gets the whole
+        // container OOM-killed mid-aggregation. Bound both from the cgroup
+        // limit — 50% rather than the import path's 75%, because an analysis
+        // container typically also hosts whatever is driving the MCP server —
+        // and point spills at the system temp dir so oversized aggregations
+        // hit disk instead of the OOM killer. Note temp_dir() honors TMPDIR;
+        // if /tmp is a tmpfs (whose pages are charged to the same cgroup,
+        // defeating the spill), point TMPDIR at a disk-backed directory.
+        let (mem_limit_mib, threads) = crate::duckdb::duckdb_resource_limits(50, 512);
+        let tmp = std::env::temp_dir();
+        sweep_stale_spill_dirs(&tmp);
+        let mut config = duckdb::Config::default().threads(threads as i64)?;
+        // temp_directory must be set before enable_external_access(false):
+        // DuckDB refuses to modify it once external access is disabled, even
+        // on a Config that has not opened a database yet. An empty value
+        // disables spilling, so the unwritable-temp-dir fallback never lands
+        // spill files in DuckDB's umask-permission default location.
+        config = match create_spill_dir(&tmp) {
+            Some(spill_dir) => config.with("temp_directory", spill_dir.to_string_lossy())?,
+            None => config.with("temp_directory", "")?,
+        };
+        if let Some(m) = mem_limit_mib {
+            config = config.max_memory(&format!("{m}MiB"))?;
+            eprintln!("duckdb: memory_limit={m}MiB threads={threads}");
+        } else {
+            eprintln!("duckdb: threads={threads} (no cgroup memory limit detected)");
+        }
+
         // Disable external access (reading/writing files, ATTACH, loading
         // extensions) so SQL run against an untrusted trace database -- e.g.
         // queries an AI assistant was prompt-injected into running via the MCP
         // server -- cannot touch anything outside the trace database. DuckDB
         // refuses to re-enable this setting while the database is running, so
-        // it cannot be undone with a SET statement.
-        let mut config = duckdb::Config::default().enable_external_access(false)?;
+        // it cannot be undone with a SET statement; it also locks
+        // temp_directory, so injected SQL cannot redirect spills either.
+        config = config.enable_external_access(false)?;
         if read_only {
             config = config.access_mode(duckdb::AccessMode::ReadOnly)?;
         }
+
         let conn = Connection::open_with_flags(path, config)?;
 
         Ok(Self {
@@ -732,6 +831,104 @@ mod tests {
                     .contains("Cannot change enable_external_access"),
                 "unexpected error: {set_err}"
             );
+        }
+    }
+
+    #[test]
+    fn test_create_spill_dir_unwritable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+        let base = tempfile::tempdir().unwrap();
+        let ro = base.path().join("ro");
+        std::fs::create_dir(&ro).unwrap();
+        std::fs::set_permissions(&ro, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        // Root ignores directory write bits, so the failure path can only be
+        // exercised as an unprivileged user; probe instead of checking uid.
+        if std::fs::write(ro.join("probe"), b"").is_err() {
+            assert!(create_spill_dir(&ro).is_none());
+        }
+
+        // Restore write permission so TempDir cleanup succeeds.
+        std::fs::set_permissions(&ro, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        // The fallback feeds '' to DuckDB to disable spilling; make sure that
+        // is accepted at config time and sticks.
+        let conn = Connection::open_in_memory_with_flags(
+            duckdb::Config::default()
+                .with("temp_directory", "")
+                .unwrap(),
+        )
+        .unwrap();
+        let temp_directory: String = conn
+            .query_row("SELECT current_setting('temp_directory')", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(temp_directory, "");
+    }
+
+    #[test]
+    fn test_open_bounds_duckdb_resources() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.duckdb");
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1);")
+                .unwrap();
+        }
+
+        let setting = |db: &AnalyzeDb, name: &str| -> String {
+            let result = db
+                .query(&format!("SELECT current_setting('{name}')"))
+                .unwrap();
+            match &result.rows[0][0] {
+                serde_json::Value::String(s) => s.clone(),
+                v => v.to_string(),
+            }
+        };
+
+        // A spill dir left behind by a dead process (this pid is above the
+        // kernel's PID_MAX_LIMIT, so it cannot be alive) is swept on open.
+        let stale = std::env::temp_dir().join("systing-analyze-spill-4294967294-0");
+        std::fs::create_dir_all(&stale).unwrap();
+
+        for read_only in [true, false] {
+            let db = AnalyzeDb::open(&db_path, read_only).unwrap();
+
+            // Spills are redirected away from the database's directory into a
+            // per-instance directory under the system temp dir, pre-created
+            // owner-only since spill files contain trace contents.
+            let temp_directory = setting(&db, "temp_directory");
+            assert!(
+                temp_directory.contains("systing-analyze-spill-"),
+                "unexpected temp_directory: {temp_directory}"
+            );
+            let mode = std::fs::metadata(&temp_directory).unwrap().permissions();
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(mode.mode() & 0o777, 0o700);
+
+            assert!(!stale.exists(), "stale spill dir not swept");
+
+            // Threads are capped, not one per host CPU.
+            let threads: u64 = setting(&db, "threads").parse().unwrap();
+            assert!(threads >= 2, "threads clamped below floor: {threads}");
+            assert!(threads <= 32 || crate::duckdb::detect_cgroup_memory_limit().is_some());
+
+            // Inside a cgroup the memory limit comes from the cgroup, not
+            // from 80% of host RAM. Compare against a reference connection
+            // configured with the same value so the test doesn't depend on
+            // how DuckDB formats the setting for display.
+            if let Some(cgroup_bytes) = crate::duckdb::detect_cgroup_memory_limit() {
+                let expected_mib = (cgroup_bytes / 2 / (1024 * 1024)).max(512);
+                let reference = Connection::open_in_memory_with_flags(
+                    duckdb::Config::default()
+                        .max_memory(&format!("{expected_mib}MiB"))
+                        .unwrap(),
+                )
+                .unwrap();
+                let expected: String = reference
+                    .query_row("SELECT current_setting('memory_limit')", [], |r| r.get(0))
+                    .unwrap();
+                assert_eq!(setting(&db, "memory_limit"), expected);
+            }
         }
     }
 

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -62,6 +62,36 @@ pub(crate) fn detect_cgroup_memory_limit() -> Option<u64> {
     None
 }
 
+/// Compute a `(memory_limit in MiB, threads)` budget for a DuckDB instance
+/// from the cgroup memory limit.
+///
+/// `mem_fraction_pct` is the share of the cgroup granted to DuckDB's buffer
+/// pool — the remainder is headroom for everything else in the container.
+/// `min_mib` is a floor so tiny containers still get a working instance.
+/// Returns `None` for the memory limit when no cgroup limit is detected.
+///
+/// Threads are capped at one per ~512 MiB of memory budget: a parallel scan
+/// keeps roughly a row-group's worth of state live per thread, so an 18 GiB
+/// budget (a 24 GiB container at 75%) tops out around 36 threads instead of
+/// one per host CPU. Without a
+/// cgroup limit we still cap at 32 — unbounded thread counts were the
+/// observed OOM trigger.
+pub(crate) fn duckdb_resource_limits(mem_fraction_pct: u64, min_mib: u64) -> (Option<u64>, u64) {
+    const MIB: u64 = 1024 * 1024;
+
+    let mem_limit_mib = detect_cgroup_memory_limit()
+        .map(|bytes| (bytes * mem_fraction_pct / 100 / MIB).max(min_mib));
+
+    let num_cpus = std::thread::available_parallelism()
+        .map(|n| n.get() as u64)
+        .unwrap_or(4);
+    let threads = match mem_limit_mib {
+        Some(m) => num_cpus.clamp(2, (m / 512).max(2)),
+        None => num_cpus.clamp(2, 32),
+    };
+    (mem_limit_mib, threads)
+}
+
 /// Configure a DuckDB connection for bulk parquet import/export under a memory
 /// budget.
 ///
@@ -71,24 +101,10 @@ pub(crate) fn detect_cgroup_memory_limit() -> Option<u64> {
 /// without reorder buffering, and points `temp_directory` at `spill_dir` so
 /// DuckDB can spill instead of OOMing if it still hits the cap.
 fn configure_for_bulk_io(conn: &Connection, spill_dir: &Path) -> Result<()> {
-    const MIB: u64 = 1024 * 1024;
-
     // Leave 25% of the container for everything that is not DuckDB's buffer
     // pool (our own heap, resident BPF maps, kernel page cache pressure),
     // clamped to at least 1 GiB so tiny containers still get a working import.
-    let mem_limit_mib = detect_cgroup_memory_limit().map(|bytes| (bytes * 3 / 4 / MIB).max(1024));
-
-    let num_cpus = std::thread::available_parallelism()
-        .map(|n| n.get() as u64)
-        .unwrap_or(4);
-    // Parallel parquet scan + insert keeps roughly a row-group's worth of state
-    // live per thread; budget ~512 MiB/thread so a 24 GiB container tops out
-    // around 36 threads instead of 200+. Without a cgroup limit we still cap at
-    // 32 — unbounded thread counts were the observed OOM trigger.
-    let threads = match mem_limit_mib {
-        Some(m) => num_cpus.clamp(2, (m / 512).max(2)),
-        None => num_cpus.clamp(2, 32),
-    };
+    let (mem_limit_mib, threads) = duckdb_resource_limits(75, 1024);
 
     let escaped_spill = spill_dir.to_string_lossy().replace('\'', "''");
     let mut pragmas = format!(


### PR DESCRIPTION
## What this does

`AnalyzeDb::open` (used by both the `systing-analyze` CLI and the MCP server) opened DuckDB with read-only mode and the external-access lockdown, but no `memory_limit`, `threads` cap, or `temp_directory`. DuckDB's defaults for those are cgroup-unaware: 80% of physical host RAM and one thread per CPU. Inside a memory-limited container on a large host, DuckDB believes it has hundreds of GiB and dozens of threads, and a single flamegraph or sched_stats aggregation over a multi-million-row `stack_sample` table blows through the container's limit — the kernel OOM-killer takes out the analysis process mid-query. The import path already bounds this in `configure_for_bulk_io`; this applies the same treatment to the analyze path.

## What changed

- Extracted the cgroup budget math into `duckdb_resource_limits(mem_fraction_pct, min_mib)`. The import path's behavior is unchanged (75% of the cgroup, 1 GiB floor — `bytes*75/100` is bit-identical to the old `bytes*3/4`).
- `AnalyzeDb::open` now sets, via `duckdb::Config` before open:
  - `max_memory` = 50% of the cgroup limit (lower than the import path's 75% because the analysis container typically also hosts the MCP client driving the server), 512 MiB floor;
  - `threads` capped at one per ~512 MiB of budget (32 when no cgroup limit is detectable);
  - `temp_directory` = a per-instance, owner-only (0700) spill directory under the system temp dir, so oversized aggregations spill to disk instead of OOMing. `temp_dir()` honors `TMPDIR` for hosts where `/tmp` is tmpfs (tmpfs pages are charged to the same cgroup, which would defeat the spill).
- Ordering subtlety: the external-access lockdown freezes `temp_directory` even on a `Config` that hasn't opened a database yet, so it must be set before `enable_external_access(false)`. The lockdown then also prevents injected SQL from redirecting spills. Documented in a comment.
- Spill dirs are per-instance (pid + counter) because DuckDB names temp files by block id, which is only unique per DuckDB instance. Stale dirs left by OOM-killed/SIGKILLed processes are swept on open once the owning pid is gone.
- Graceful degradation when no writable temp dir exists (common in locked-down containers): spill-dir creation failure disables spilling outright (`temp_directory = ''`) instead of falling back to DuckDB's umask-permission default next to the database. Open still succeeds, the memory limit still holds, and an oversized aggregation gets a clean query error instead of the OOM killer.
- Version bump 1.9.0 → 1.9.1 (no schema change).

## How it was verified

- New regression test `test_open_bounds_duckdb_resources` asserts, for both read-only and read-write opens: the spill dir is applied and is 0700, threads are capped, stale spill dirs are swept, and — when a cgroup limit is detectable — `memory_limit` equals exactly half of it (compared via a reference connection so the test doesn't depend on DuckDB's display formatting). On the dev host this exercises the real cgroup branch (~220 GiB limit → 110 GiB applied).
- New test `test_create_spill_dir_unwritable_parent` covers the unwritable-temp-dir path and pins down that DuckDB accepts the empty `temp_directory` (spilling disabled) at config time.
- Full unit suite (349 tests), clippy, fmt, and the 31-test integration suite all pass.