### PR TITLE
Refuse to adopt a pre-existing spill directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.9.1"
+version = "1.9.2"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.9.1"
+version = "1.9.2"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -90,11 +90,11 @@ fn create_spill_dir(tmp: &Path) -> Option<PathBuf> {
         SPILL_DIR_SEQ.fetch_add(1, Ordering::Relaxed),
     ));
     use std::os::unix::fs::DirBuilderExt;
-    match std::fs::DirBuilder::new()
-        .recursive(true)
-        .mode(0o700)
-        .create(&spill_dir)
-    {
+    // Non-recursive create: the directory name is predictable, so in a shared
+    // temp dir it could be pre-created by another user with open permissions
+    // (or as a symlink to a directory they control). AlreadyExists then lands
+    // in the spilling-disabled fallback instead of adopting their directory.
+    match std::fs::DirBuilder::new().mode(0o700).create(&spill_dir) {
         Ok(()) => Some(spill_dir),
         Err(e) => {
             eprintln!(


### PR DESCRIPTION
Follow-up to #124 — this commit was pushed to that branch right after the merge, so it missed it.

The analyze-path spill directory name is predictable (pid plus a per-process counter), and it lives in a shared temp dir. With `recursive(true)`, `DirBuilder::create` succeeds on a directory that already exists — so another user could pre-create the path with open permissions, or as a symlink to a directory they control, and spilled trace contents (stack frames, process names, network endpoints) would land there instead of in our owner-only (0700) directory.

Create the directory non-recursively instead: a pre-existing path fails with `AlreadyExists` and drops into the existing safe fallback from #124 — spilling disabled, memory limit still enforced, open still succeeds. The only behavior given up is auto-creating missing `TMPDIR` parent directories, which now also degrades to spilling-disabled rather than creating an arbitrary path.

Version bumped to 1.9.2 (no schema change). Unit tests, clippy, and fmt pass (pre-commit hook).