### PR TITLE
pystacks: move symbol interning off the BPF probe path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.9.2"
+version = "1.9.3"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/pystacks/bpf/include/py_structs.h
+++ b/src/pystacks/bpf/include/py_structs.h
@@ -36,9 +36,10 @@ struct read_file_name {
   uintptr_t fault_addr; // != 0 if fault
 };
 
-// IMPORTANT: pystacks_symbol struct is used as the key to the 'symbols' bpf
-// map. Be careful about adding fields as any increase cardinality can degrade
-// symbol quality.
+// IMPORTANT: pystacks_symbol is the input to the 64-bit content hash that
+// becomes the symbol ID (see get_py_symbol_id). Be careful about adding
+// fields as any increased cardinality can degrade symbol quality, and the
+// struct size must stay a multiple of 8 bytes for the word-at-a-time hash.
 //
 // pystacks_symbol file names and qualified names are normally read directly
 // from bpf_py_probe.bpf.c in get_names(). If a page fault occurs when trying to
@@ -49,6 +50,7 @@ struct pystacks_symbol {
   struct read_file_name filename;
   struct read_qualified_name qualname;
   pid_t fault_pid; // != 0 if fault
+  int32_t pad_; // explicit padding: hashed, so it must be deterministic
 };
 
 struct pystacks_message {
@@ -75,6 +77,19 @@ struct pystacks_line_table {
   uint32_t length;
   uintptr_t addr;
   pid_t pid;
+  int32_t pad_; // explicit padding so the ringbuf record has no uninit bytes
+};
+
+/*
+ * Sent BPF -> userspace through the pysym ringbuf the first time a symbol
+ * hash misses the pystacks_symbols gate map. Userspace resolves it (page
+ * fault recovery, line table read) and then inserts symbol_id into
+ * pystacks_symbols, which stops further emission of this symbol.
+ */
+struct pystacks_symbol_record {
+  symbol_id_t symbol_id;
+  struct pystacks_symbol sym;
+  struct pystacks_line_table linetable;
 };
 
 #endif

--- a/src/pystacks/bpf/include/stack_walker.h
+++ b/src/pystacks/bpf/include/stack_walker.h
@@ -38,11 +38,18 @@ struct stack_walker_opts {
 };
 
 // @lint-ignore-every CLANGTIDY modernize-use-using
-typedef uint32_t symbol_id_t;
+//
+// Symbol IDs are 64-bit content hashes (FNV-style, over struct pystacks_symbol)
+// computed in BPF. A content-derived ID means every CPU independently arrives
+// at the same ID for the same symbol, so the probe never needs a shared
+// counter or a BPF-map insert to allocate one (see get_py_symbol_id in
+// pystacks.bpf.c for why probe-context map updates are forbidden).
+typedef uint64_t symbol_id_t;
 
 struct stack_walker_frame {
   symbol_id_t symbol_id;
   int32_t inst_idx;
+  int32_t pad_;
 };
 
 #ifdef __cplusplus

--- a/src/pystacks/bpf/pystacks.bpf.c
+++ b/src/pystacks/bpf/pystacks.bpf.c
@@ -64,19 +64,80 @@ struct {
 #define BPF_LIB_CO_ITERABLE_COROUTINE 0x0100
 #define BPF_LIB_CO_STATICALLY_COMPILED 0x4000000
 
+/*
+ * LOCKING RULE FOR THIS FILE: pystacks runs from probe contexts where IRQs
+ * are hard-off (sched_switch fires under the runqueue lock; the perf-event
+ * sampler runs in NMI context). bpf_map_update_elem on a HASH map takes a
+ * per-bucket raw spinlock; on a large guest under contention those waiters
+ * fall into the paravirt qspinlock slow path, where kvm_wait executes HLT
+ * with IF=0 and depends on the hypervisor's PV kick to ever wake up. AWS
+ * Nitro does not deliver that kick to an IF=0 halt, so a contended map
+ * update from these probes permanently halts the vCPU and wedges the node
+ * (rq lock never released). Therefore BPF code here may only do lock-free
+ * map *lookups* on shared hash maps; all inserts are done by userspace from
+ * process context (IF=1 waiters fall back to safe_halt and are woken by the
+ * timer tick even without a kick). Per-CPU array maps and ringbuf
+ * reserve/submit (short, low-duty-cycle critical section, NMI-safe trylock)
+ * are the only other map operations allowed on the probe paths.
+ */
+
+#define PYSYM_GATE_MAP_SIZE 65536
+#define PYSYM_CACHE_SLOTS 1024
+/* Minimum interval between re-emissions of the same un-interned symbol from
+ * one CPU. Bounds duplicate ringbuf traffic during warm-up while still
+ * guaranteeing eventual interning if a record is dropped. */
+#define PYSYM_REEMIT_NS (1ULL * 1000 * 1000 * 1000)
+
+/*
+ * Interned-symbol gate. Key is the 64-bit content hash of the symbol
+ * (== symbol_id), value is unused. BPF only ever does lock-free lookups
+ * here; userspace inserts an entry once it has consumed and resolved the
+ * corresponding pystacks_symbol_record, which stops further emission of
+ * that symbol. See the locking rule above for why BPF must never update it.
+ */
 struct {
   __uint(type, BPF_MAP_TYPE_HASH);
-  __uint(max_entries, BPF_LIB_DEFAULT_MAP_SIZE);
-  __type(key, struct pystacks_symbol);
-  __type(value, symbol_id_t);
+  __uint(max_entries, PYSYM_GATE_MAP_SIZE);
+  __type(key, symbol_id_t);
+  __type(value, uint8_t);
 } pystacks_symbols SEC(".maps");
 
+/*
+ * Carries pystacks_symbol_record from probe context to userspace. A single
+ * (un-sharded) ringbuf is fine here: emission is rate-limited to at most one
+ * record per CPU per un-interned symbol per PYSYM_REEMIT_NS, so the reserve
+ * spinlock's duty cycle is far too low to push waiters into the paravirt
+ * halt path even on very wide machines. ~470-byte records; 4MiB buffers ~8k
+ * in-flight symbols, and drops are recovered via PYSYM_REEMIT_NS.
+ * Shrunk to one page at open time when pystacks is disabled.
+ */
 struct {
-  __uint(type, BPF_MAP_TYPE_HASH);
-  __uint(max_entries, BPF_LIB_DEFAULT_MAP_SIZE);
-  __type(key, symbol_id_t);
-  __type(value, struct pystacks_line_table);
-} pystacks_linetables SEC(".maps");
+  __uint(type, BPF_MAP_TYPE_RINGBUF);
+  __uint(max_entries, 4 * 1024 * 1024 /* 4MiB */);
+} ringbuf_pysym_events SEC(".maps");
+
+/*
+ * Per-CPU emission rate limiter, direct-mapped by the low bits of the
+ * symbol id; each slot holds the timestamp of the last emission attempt
+ * that claimed it. A slot in cooldown suppresses emission for *any* symbol
+ * mapping to it, which hard-caps each CPU at PYSYM_CACHE_SLOTS ringbuf
+ * reserve attempts per PYSYM_REEMIT_NS no matter how many distinct
+ * un-interned symbols are in flight (deliberately slot-based, not id-based:
+ * an id-based check would let two aliasing symbols evict each other's claim
+ * and degenerate to per-frame reserve attempts on the shared ringbuf lock).
+ * A suppressed symbol is retried on its next *sighting*: another CPU with a
+ * free slot emits it, or this slot's cooldown expires and a later miss
+ * re-emits. Symbols that recur are therefore eventually interned; a one-shot
+ * frame (e.g. module-level import code seen exactly once) that loses the
+ * slot race on every CPU that saw it, or whose record is dropped by a full
+ * ringbuf, stays unresolved — an accepted trade for the hard cap.
+ */
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __uint(max_entries, PYSYM_CACHE_SLOTS);
+  __type(key, u32);
+  __type(value, uint64_t);
+} pystacks_emitted_cache SEC(".maps");
 
 struct {
   __uint(type, BPF_MAP_TYPE_HASH);
@@ -120,8 +181,6 @@ static __always_inline struct sample_state_t* get_state() {
     return 0; /* should never happen */       \
   }
 
-static symbol_id_t next_symbol_id = 1;
-
 static __always_inline void read_shadow_frame_data(
     void* shadow_frame,
     const OffsetConfig* const offsets,
@@ -153,30 +212,77 @@ static __always_inline void read_shadow_frame_data(
                       (uintptr_t)offsets->PyShadowFrame_PtrMask);
 }
 
-static symbol_id_t get_py_symbol_id(struct pystacks_symbol* const sym) {
-  symbol_id_t* id = bpf_map_lookup_elem(&pystacks_symbols, sym);
-  if (id) {
-    return *id;
-  } else {
-    symbol_id_t new_id = next_symbol_id;
-    __sync_fetch_and_add(&next_symbol_id, 1);
-    int error =
-        bpf_map_update_elem(&pystacks_symbols, sym, &new_id, BPF_NOEXIST);
-    if (!error) {
-      return new_id;
-    }
-    if (error == -EEXIST) {
-      // Another thread updated the map already with the same stack.
-      // It should exist now.
-      id = bpf_map_lookup_elem(&pystacks_symbols, sym);
-      if (!id) {
-        // This shouldn't happen (fingers crossed).
-        return 0;
-      }
-      return *id;
-    }
-    return 0;
+/*
+ * 64-bit FNV-style hash over the whole pystacks_symbol, folding 8 bytes per
+ * round (NOT byte-wise FNV-1a — mixing is coarser, but collision odds at
+ * realistic symbol counts are still negligible, ~1e-8 at 100k symbols).
+ * get_names() zeroes the struct before filling it, so unused bytes
+ * (including the explicit padding) hash deterministically. The result is
+ * the symbol ID: content-derived, so every CPU computes the same ID
+ * independently and no shared counter or map insert is needed from probe
+ * context.
+ */
+static symbol_id_t hash_symbol(const struct pystacks_symbol* const sym) {
+  _Static_assert(
+      sizeof(struct pystacks_symbol) % sizeof(uint64_t) == 0,
+      "pystacks_symbol must be a multiple of 8 bytes for the word hash");
+  const uint64_t* words = (const uint64_t*)sym;
+  uint64_t hash = 0xcbf29ce484222325ULL;
+  for (uint32_t i = 0; i < sizeof(struct pystacks_symbol) / sizeof(uint64_t);
+       i++) {
+    hash ^= words[i];
+    hash *= 0x100000001b3ULL;
   }
+  /* 0 is reserved as "no symbol" by userspace consumers. */
+  return hash ? hash : 1;
+}
+
+/*
+ * Send {id, symbol, line table} to userspace for interning, rate-limited by
+ * the per-CPU emitted cache. The cache slot is claimed *before* the reserve
+ * so that a full ringbuf backs us off for PYSYM_REEMIT_NS instead of
+ * hammering the shared reserve spinlock on every frame.
+ */
+static __noinline void emit_symbol_record(
+    symbol_id_t id,
+    const struct pystacks_symbol* const sym,
+    const struct pystacks_line_table* const linetable) {
+  u32 slot = (u32)(id & (PYSYM_CACHE_SLOTS - 1));
+  uint64_t* last_emit = bpf_map_lookup_elem(&pystacks_emitted_cache, &slot);
+  u64 now = bpf_ktime_get_ns();
+
+  /* Fail closed: emitting without rate limiting is the failure class this
+   * file exists to prevent. The lookup can only miss if the cache map was
+   * shrunk (pystacks disabled), where this path should be dead code anyway. */
+  if (!last_emit)
+    return;
+  if (now - *last_emit < PYSYM_REEMIT_NS)
+    return;
+  *last_emit = now;
+
+  /* In NMI context (perf-event sampler) reserve degrades to a trylock and
+   * may fail; the record is re-emitted after PYSYM_REEMIT_NS. */
+  struct pystacks_symbol_record* rec =
+      bpf_ringbuf_reserve(&ringbuf_pysym_events, sizeof(*rec), 0);
+  if (!rec)
+    return;
+
+  rec->symbol_id = id;
+  rec->sym = *sym;
+  rec->linetable = *linetable;
+  bpf_ringbuf_submit(rec, 0);
+}
+
+static symbol_id_t get_py_symbol_id(struct sample_state_t* const state) {
+  symbol_id_t id = hash_symbol(&state->sym);
+
+  /* Lock-free lookup; see the locking rule above the map definitions for
+   * why this path must never bpf_map_update_elem a shared hash map. */
+  if (bpf_map_lookup_elem(&pystacks_symbols, &id))
+    return id;
+
+  emit_symbol_record(id, &state->sym, &state->linetable);
+  return id;
 }
 
 static __always_inline void* get_gen_ptr(
@@ -603,7 +709,7 @@ add_symbol_to_buffer(struct pystacks_message* const py_msg) {
     return 0; /* should never happen */
   }
 
-  const symbol_id_t symbol_id = get_py_symbol_id(&state->sym);
+  const symbol_id_t symbol_id = get_py_symbol_id(state);
 
   uint64_t max_len = pystacks_prog_cfg.stack_max_len;
   uint64_t max_offset = BPF_LIB_MAX_STACK_DEPTH;
@@ -612,14 +718,14 @@ add_symbol_to_buffer(struct pystacks_message* const py_msg) {
   if (st_len >= 0 && st_len < max_len && st_len < max_offset) {
     py_msg->buffer[st_len].symbol_id = symbol_id;
     py_msg->buffer[st_len].inst_idx = state->lasti;
+    py_msg->buffer[st_len].pad_ = 0;
     py_msg->header.len += sizeof(struct stack_walker_frame);
     ++st_len;
   }
 
-  if (pystacks_prog_cfg.enable_py_src_lines) {
-    bpf_map_update_elem(
-        &pystacks_linetables, &symbol_id, &state->linetable, BPF_NOEXIST);
-  }
+  /* Line tables ride in the pystacks_symbol_record emitted by
+   * get_py_symbol_id; updating a shared hash map from here is forbidden
+   * (see the locking rule above the map definitions). */
   py_msg->stack_len = st_len;
   return st_len;
 }

--- a/src/pystacks/bpf_maps.rs
+++ b/src/pystacks/bpf_maps.rs
@@ -21,8 +21,13 @@ use std::os::fd::{AsFd, AsRawFd};
 
 /// Holds BPF map file descriptors and BSS access for pystacks.
 pub struct PystacksMaps {
+    /// The interned-symbol gate map (key: u64 symbol id, value: u8).
+    /// BPF only does lock-free lookups on it; userspace inserts entries
+    /// here once a symbol record has been resolved, which stops BPF from
+    /// re-emitting that symbol. This split exists because a hash-map
+    /// update from the sched_switch/perf probes (IRQs off) can deadlock
+    /// the CPU on hypervisors that drop PV spinlock kicks (AWS Nitro).
     pub symbols_fd: i32,
-    pub linetables_fd: i32,
     pub pid_config_fd: i32,
     pub targeted_pids_fd: i32,
     bss_fd: i32,
@@ -33,7 +38,6 @@ impl PystacksMaps {
     /// Initialize map FDs from the loaded BPF object.
     pub fn new(bpf_object: &Object) -> Option<Self> {
         let symbols_fd = get_map_fd(bpf_object, "pystacks_symbols")?;
-        let linetables_fd = get_map_fd(bpf_object, "pystacks_linetables")?;
         let pid_config_fd = get_map_fd(bpf_object, "pystacks_pid_config")?;
         let targeted_pids_fd = get_map_fd(bpf_object, "targeted_pids")?;
 
@@ -42,12 +46,27 @@ impl PystacksMaps {
 
         Some(Self {
             symbols_fd,
-            linetables_fd,
             pid_config_fd,
             targeted_pids_fd,
             bss_fd,
             bss_size,
         })
+    }
+
+    /// Mark a symbol ID as interned in the BPF gate map so BPF stops
+    /// emitting records for it. Runs in process context (IRQs on), which is
+    /// the only context where contended hash-map bucket locks are safe on
+    /// all hypervisors.
+    pub fn mark_symbol_interned(&self, symbol_id: u64) -> bool {
+        let val: u8 = 1;
+        unsafe {
+            libbpf_rs::libbpf_sys::bpf_map_update_elem(
+                self.symbols_fd,
+                &symbol_id as *const u64 as *const std::ffi::c_void,
+                &val as *const u8 as *const std::ffi::c_void,
+                0, // BPF_ANY
+            ) == 0
+        }
     }
 
     /// Add a PID to the targeted_pids BPF map.

--- a/src/pystacks/stack_walker.rs
+++ b/src/pystacks/stack_walker.rs
@@ -1,11 +1,11 @@
 use crate::systing_core::types::{pystacks_message, stack_event};
 use libbpf_rs::Object;
 use std::hash::{Hash, Hasher};
-use std::time::Instant;
 
 use {
     crate::pystacks::bpf_maps::PystacksMaps, crate::pystacks::discovery,
-    crate::pystacks::symbols::SymbolResolver, crate::pystacks::types::StackWalkerFrame, std::fmt,
+    crate::pystacks::symbols::SymbolResolver, crate::pystacks::types::PystacksSymbolRecord,
+    crate::pystacks::types::StackWalkerFrame, std::fmt,
 };
 
 #[derive(Debug, Clone)]
@@ -32,6 +32,7 @@ impl From<&crate::systing_core::types::stack_walker_frame> for StackWalkerFrame 
         StackWalkerFrame {
             symbol_id: frame.symbol_id,
             inst_idx: frame.inst_idx,
+            pad_: 0,
         }
     }
 }
@@ -62,9 +63,6 @@ const DEBUG_SAMPLE_LOG_LIMIT: u64 = 10;
 pub struct StackWalkerRun {
     resolver: Option<SymbolResolver>,
     maps: Option<PystacksMaps>,
-    // Symbol loading rate limiting
-    last_symbol_load: std::cell::Cell<Option<Instant>>,
-    symbol_load_interval: std::time::Duration,
     // Debug mode flag (atomic for thread safety with Sync impl)
     debug: std::sync::atomic::AtomicBool,
     // Counters for debug statistics (atomic for thread safety with Sync impl)
@@ -73,6 +71,9 @@ pub struct StackWalkerRun {
     symbols_loaded_count: std::sync::atomic::AtomicU64,
     frames_symbolized: std::sync::atomic::AtomicU64,
     frames_unknown: std::sync::atomic::AtomicU64,
+    /// Failed inserts into the BPF gate map (warned once, see
+    /// `ingest_symbol_record`).
+    gate_insert_failures: std::sync::atomic::AtomicU64,
 }
 
 impl StackWalkerRun {
@@ -83,16 +84,13 @@ impl StackWalkerRun {
         StackWalkerRun {
             resolver: None,
             maps: None,
-            last_symbol_load: std::cell::Cell::new(None),
-            // Load symbols at most once per 500ms (2 Hz) to catch dying processes
-            // while minimizing overhead on long traces
-            symbol_load_interval: std::time::Duration::from_millis(500),
             debug: AtomicBool::new(false),
             events_with_pystack: AtomicU64::new(0),
             events_without_pystack: AtomicU64::new(0),
             symbols_loaded_count: AtomicU64::new(0),
             frames_symbolized: AtomicU64::new(0),
             frames_unknown: AtomicU64::new(0),
+            gate_insert_failures: AtomicU64::new(0),
         }
     }
 
@@ -153,11 +151,7 @@ impl StackWalkerRun {
         }
 
         // Create symbol resolver
-        self.resolver = Some(SymbolResolver::new(
-            maps.symbols_fd,
-            maps.linetables_fd,
-            &process_info,
-        ));
+        self.resolver = Some(SymbolResolver::new(&process_info));
 
         self.maps = Some(maps);
 
@@ -189,6 +183,10 @@ impl StackWalkerRun {
                 self.frames_unknown.load(Ordering::Relaxed),
                 self.initialized()
             );
+            let gate_failures = self.gate_insert_failures.load(Ordering::Relaxed);
+            if gate_failures > 0 {
+                eprintln!("[pystacks debug] gate map insert failures: {gate_failures}");
+            }
         }
     }
 
@@ -206,9 +204,49 @@ impl StackWalkerRun {
         }
     }
 
-    fn load_symbols(&self) {
-        if let Some(resolver) = &self.resolver {
-            resolver.load_symbols();
+    /// Ingest a symbol record emitted by BPF through the pysym ringbuf.
+    ///
+    /// Resolves and caches the symbol, then marks its ID as interned in the
+    /// BPF gate map so BPF stops re-emitting it. The gate update happens
+    /// here, from process context — BPF must never insert into the gate map
+    /// from its probes (IRQs-off hash-map updates can wedge the CPU on
+    /// hypervisors that drop PV spinlock kicks; see pystacks.bpf.c).
+    pub fn ingest_symbol_record(&self, record: &PystacksSymbolRecord) {
+        use std::sync::atomic::Ordering;
+
+        let Some(resolver) = &self.resolver else {
+            return;
+        };
+
+        if resolver.ingest_record(record) {
+            if let Some(maps) = &self.maps {
+                if !maps.mark_symbol_interned(record.symbol_id) {
+                    // Likely the gate map is full. Symbolization stays
+                    // correct (the userspace cache above is authoritative),
+                    // but BPF will keep re-emitting this symbol at the
+                    // rate-limited cadence for the rest of the trace.
+                    let count = self.gate_insert_failures.fetch_add(1, Ordering::Relaxed) + 1;
+                    if count == 1 {
+                        eprintln!(
+                            "[pystacks] Warning: failed to mark symbol {:#x} as interned \
+                             (gate map full?); BPF will keep re-emitting un-interned symbols",
+                            record.symbol_id
+                        );
+                    }
+                }
+            }
+
+            if self.is_debug() {
+                let count = self.symbols_loaded_count.fetch_add(1, Ordering::Relaxed) + 1;
+                if count <= DEBUG_SAMPLE_LOG_LIMIT {
+                    eprintln!(
+                        "[pystacks debug] Interned symbol #{} (id {:#x}, {} total)",
+                        count,
+                        record.symbol_id,
+                        resolver.symbol_count()
+                    );
+                }
+            }
         }
     }
 
@@ -270,39 +308,6 @@ impl StackWalkerRun {
             .iter()
             .map(|frame| PyAddr { addr: frame.into() })
             .collect()
-    }
-
-    pub fn load_pystack_symbols(&self, event: &stack_event) {
-        use std::sync::atomic::Ordering;
-
-        if !self.initialized() {
-            if self.is_debug() && self.events_with_pystack.load(Ordering::Relaxed) == 1 {
-                eprintln!("[pystacks debug] load_pystack_symbols: not initialized!");
-            }
-            return;
-        }
-
-        if event.py_msg_buffer.stack_len == 0 {
-            return;
-        }
-
-        let now = Instant::now();
-        let should_load = match self.last_symbol_load.get() {
-            None => true,
-            Some(last_load) => now.duration_since(last_load) >= self.symbol_load_interval,
-        };
-
-        if should_load {
-            if self.is_debug() {
-                let count = self.symbols_loaded_count.fetch_add(1, Ordering::Relaxed) + 1;
-                if count <= DEBUG_SAMPLE_LOG_LIMIT {
-                    eprintln!("[pystacks debug] Loading symbols (load #{})", count);
-                }
-            }
-
-            self.load_symbols();
-            self.last_symbol_load.set(Some(now));
-        }
     }
 
     pub fn init_pystacks(&mut self, pids: &[u32], bpf_object: &Object, debug: bool) {

--- a/src/pystacks/symbols.rs
+++ b/src/pystacks/symbols.rs
@@ -1,8 +1,13 @@
 /// Symbol resolution for Python stack frames.
 ///
-/// Replaces the core symbol lookup logic from pystacks.cpp.
-/// Reads symbols from BPF maps, constructs function names, and resolves
-/// source file/line information using line tables.
+/// Symbols arrive as `PystacksSymbolRecord`s through the pysym ringbuf: BPF
+/// emits a record the first time a symbol's content hash misses the
+/// `pystacks_symbols` gate map, and `ingest_record` resolves it here (page
+/// fault recovery, line table read) and caches it by symbol ID. The caller
+/// then inserts the ID into the gate map (from process context) so BPF stops
+/// emitting that symbol. BPF never inserts into shared hash maps itself
+/// because its probes run with IRQs off, where a contended map bucket lock
+/// can permanently halt the vCPU on hypervisors that drop PV spinlock kicks.
 use super::discovery::PyProcessInfo;
 use super::linetable::PyLineTable;
 use super::process;
@@ -17,23 +22,15 @@ struct PySymbol {
     linetable: Option<PyLineTable>,
 }
 
-/// Manages symbol resolution from BPF maps.
+/// Manages symbol resolution from BPF symbol records.
 pub struct SymbolResolver {
     symbols: RwLock<HashMap<SymbolIdT, PySymbol>>,
     /// Map of PID -> version info for line table construction.
     pid_versions: RwLock<HashMap<i32, (i32, i32)>>,
-    /// FD for the pystacks_symbols BPF map.
-    symbols_fd: i32,
-    /// FD for the pystacks_linetables BPF map.
-    linetables_fd: i32,
 }
 
 impl SymbolResolver {
-    pub fn new(
-        symbols_fd: i32,
-        linetables_fd: i32,
-        process_info: &HashMap<i32, PyProcessInfo>,
-    ) -> Self {
+    pub fn new(process_info: &HashMap<i32, PyProcessInfo>) -> Self {
         let pid_versions = process_info
             .iter()
             .map(|(&pid, info)| (pid, (info.version_major, info.version_minor)))
@@ -42,8 +39,6 @@ impl SymbolResolver {
         Self {
             symbols: RwLock::new(HashMap::new()),
             pid_versions: RwLock::new(pid_versions),
-            symbols_fd,
-            linetables_fd,
         }
     }
 
@@ -54,131 +49,72 @@ impl SymbolResolver {
             .insert(pid, (major, minor));
     }
 
-    /// Load symbols from BPF maps.
-    /// Iterates the pystacks_symbols BPF hash map and caches resolved symbols.
-    pub fn load_symbols(&self) {
-        let mut new_symbols = 0usize;
-        let mut missing_linetables = 0usize;
+    /// Number of symbols currently cached.
+    pub fn symbol_count(&self) -> usize {
+        self.symbols.read().unwrap().len()
+    }
 
-        // Iterate over all elements in the symbols BPF hash map.
-        // bpf_map_get_next_key with NULL key returns the first key.
-        let mut prev_key: Option<PystacksSymbol> = None;
-        let mut next_key = PystacksSymbol::default();
+    /// Ingest one symbol record emitted by BPF.
+    ///
+    /// Returns true if the symbol is cached after this call (newly resolved
+    /// or already known); the caller should then mark the ID as interned in
+    /// the BPF gate map. Returns false if resolution failed (e.g. the
+    /// faulted qualname could not be read back); the ID is left out of the
+    /// gate map so BPF re-emits it (rate-limited) and we retry — the page
+    /// may be resident on a later attempt.
+    pub fn ingest_record(&self, record: &PystacksSymbolRecord) -> bool {
+        let id = record.symbol_id;
+        if id == 0 {
+            // 0 is reserved as "no symbol".
+            return false;
+        }
 
-        loop {
-            let prev_ptr = match &prev_key {
-                Some(k) => k as *const PystacksSymbol as *const std::ffi::c_void,
-                None => std::ptr::null(),
-            };
+        if self.symbols.read().unwrap().contains_key(&id) {
+            return true;
+        }
 
-            let ret = unsafe {
-                libbpf_rs::libbpf_sys::bpf_map_get_next_key(
-                    self.symbols_fd,
-                    prev_ptr,
-                    &mut next_key as *mut PystacksSymbol as *mut std::ffi::c_void,
-                )
-            };
+        let mut sym = record.sym.clone();
 
-            if ret != 0 {
-                break; // No more keys
-            }
-
-            // Look up the symbol_id value for this key
-            let mut id: SymbolIdT = 0;
-            let ret = unsafe {
-                libbpf_rs::libbpf_sys::bpf_map_lookup_elem(
-                    self.symbols_fd,
-                    &next_key as *const PystacksSymbol as *const std::ffi::c_void,
-                    &mut id as *mut SymbolIdT as *mut std::ffi::c_void,
-                )
-            };
-
-            if ret != 0 {
-                prev_key = Some(next_key.clone());
-                continue;
-            }
-
-            // Skip if already cached
+        // Handle page fault recovery for qualname
+        if sym.qualname.fault_addr != 0 && sym.fault_pid != 0 {
+            let mut buf = [0u8; BPF_LIB_PYSTACKS_QUAL_NAME_LEN];
+            if process::read_process_memory(sym.fault_pid, sym.qualname.fault_addr, &mut buf)
+                .is_ok()
             {
-                let symbols = self.symbols.read().unwrap();
-                if symbols.contains_key(&id) {
-                    prev_key = Some(next_key.clone());
-                    continue;
-                }
+                sym.qualname.value = buf;
+            } else {
+                return false; // Can't recover qualname yet; retry on re-emit
             }
+        }
 
-            // Handle page fault recovery for qualname
-            let mut sym = next_key.clone();
-            if sym.qualname.fault_addr != 0 && sym.fault_pid != 0 {
-                let mut buf = [0u8; BPF_LIB_PYSTACKS_QUAL_NAME_LEN];
-                if process::read_process_memory(sym.fault_pid, sym.qualname.fault_addr, &mut buf)
-                    .is_ok()
-                {
-                    sym.qualname.value = buf;
-                } else {
-                    prev_key = Some(next_key.clone());
-                    continue; // Can't recover qualname
-                }
-            }
+        // Handle page fault recovery for filename
+        if sym.filename.fault_addr != 0 && sym.fault_pid != 0 {
+            let mut buf = [0u8; BPF_LIB_PYSTACKS_FILE_NAME_LEN];
+            let _ = process::read_process_memory(sym.fault_pid, sym.filename.fault_addr, &mut buf)
+                .map(|_| {
+                    sym.filename.value = buf;
+                });
+            // Continue even if filename recovery fails - qualname is more important
+        }
 
-            // Handle page fault recovery for filename
-            if sym.filename.fault_addr != 0 && sym.fault_pid != 0 {
-                let mut buf = [0u8; BPF_LIB_PYSTACKS_FILE_NAME_LEN];
-                let _ =
-                    process::read_process_memory(sym.fault_pid, sym.filename.fault_addr, &mut buf)
-                        .map(|_| {
-                            sym.filename.value = buf;
-                        });
-                // Continue even if filename recovery fails - qualname is more important
-            }
+        let funcname = get_symbol_name(&sym);
+        let filename = cstring_from_bytes(&sym.filename.value);
+        let linetable = self.load_line_table(&record.linetable);
 
-            // Build the symbol
-            let funcname = get_symbol_name(&sym);
-            let filename = cstring_from_bytes(&sym.filename.value);
-
-            // Try to load line table
-            let linetable = self.load_line_table(id);
-            if linetable.is_none() {
-                missing_linetables += 1;
-            }
-
-            let py_symbol = PySymbol {
+        self.symbols.write().unwrap().insert(
+            id,
+            PySymbol {
                 funcname,
                 filename,
                 linetable,
-            };
-
-            {
-                let mut symbols = self.symbols.write().unwrap();
-                symbols.insert(id, py_symbol);
-            }
-            new_symbols += 1;
-
-            prev_key = Some(next_key.clone());
-        }
-
-        if new_symbols > 0 {
-            let total = self.symbols.read().unwrap().len();
-            eprintln!(
-                "[pystacks] Added {} Python symbols ({} total, {} missing linetables)",
-                new_symbols, total, missing_linetables
-            );
-        }
+            },
+        );
+        true
     }
 
-    /// Load a line table from BPF map for a given symbol ID.
-    fn load_line_table(&self, id: SymbolIdT) -> Option<PyLineTable> {
-        let mut lt = PystacksLineTable::default();
-
-        let ret = unsafe {
-            libbpf_rs::libbpf_sys::bpf_map_lookup_elem(
-                self.linetables_fd,
-                &id as *const SymbolIdT as *const std::ffi::c_void,
-                &mut lt as *mut PystacksLineTable as *mut std::ffi::c_void,
-            )
-        };
-
-        if ret != 0 || lt.addr == 0 || lt.length == 0 || lt.first_line == 0 || lt.pid == 0 {
+    /// Build a line table from the data carried in a symbol record.
+    fn load_line_table(&self, lt: &PystacksLineTable) -> Option<PyLineTable> {
+        if lt.addr == 0 || lt.length == 0 || lt.first_line == 0 || lt.pid == 0 {
             return None;
         }
 
@@ -403,5 +339,37 @@ mod tests {
         sym.qualname.value[128..128 + func_name.len()].copy_from_slice(func_name);
 
         assert_eq!(get_symbol_name(&sym), "MyClass.my_method");
+    }
+
+    #[test]
+    fn test_ingest_record_caches_symbol() {
+        let resolver = SymbolResolver::new(&HashMap::new());
+        let mut record = PystacksSymbolRecord {
+            symbol_id: 0xdeadbeefcafef00d,
+            ..Default::default()
+        };
+        let name = b"my_func";
+        record.sym.qualname.value[..name.len()].copy_from_slice(name);
+
+        assert!(resolver.ingest_record(&record));
+        assert_eq!(resolver.symbol_count(), 1);
+        // Duplicate ingestion is a no-op but still reports cached.
+        assert!(resolver.ingest_record(&record));
+        assert_eq!(resolver.symbol_count(), 1);
+
+        let frame = StackWalkerFrame {
+            symbol_id: 0xdeadbeefcafef00d,
+            inst_idx: -1,
+            pad_: 0,
+        };
+        assert_eq!(resolver.symbolize_function(&frame), "my_func");
+    }
+
+    #[test]
+    fn test_ingest_record_rejects_zero_id() {
+        let resolver = SymbolResolver::new(&HashMap::new());
+        let record = PystacksSymbolRecord::default();
+        assert!(!resolver.ingest_record(&record));
+        assert_eq!(resolver.symbol_count(), 0);
     }
 }

--- a/src/pystacks/types.rs
+++ b/src/pystacks/types.rs
@@ -12,15 +12,19 @@ pub const BPF_LIB_PYSTACKS_QUAL_NAME_LEN: usize =
 pub const BPF_LIB_MAX_STACK_DEPTH: usize = 127;
 pub const BPF_LIB_DEFAULT_MAP_SIZE: usize = 1024;
 
-pub type SymbolIdT = u32;
+/// Symbol IDs are 64-bit content hashes computed in BPF (FNV-style, over the
+/// `pystacks_symbol` struct), so the same symbol gets the same ID on every
+/// CPU without any shared counter or probe-context map insert.
+pub type SymbolIdT = u64;
 
 /// Matches `struct stack_walker_frame` from stack_walker.h.
-/// 8 bytes: symbol_id (u32) + inst_idx (i32).
+/// 16 bytes: symbol_id (u64) + inst_idx (i32) + explicit padding.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash)]
 pub struct StackWalkerFrame {
     pub symbol_id: SymbolIdT,
     pub inst_idx: i32,
+    pub pad_: i32,
 }
 
 /// Matches `struct read_file_name` from python/include/structs.h.
@@ -60,13 +64,15 @@ impl Default for ReadQualifiedName {
 }
 
 /// Matches `struct pystacks_symbol` from python/include/structs.h.
-/// Used as the key in the `pystacks_symbols` BPF map.
+/// Hashed in BPF to produce the symbol ID and shipped to userspace inside
+/// `PystacksSymbolRecord`.
 #[repr(C)]
 #[derive(Clone, Default)]
 pub struct PystacksSymbol {
     pub filename: ReadFileName,
     pub qualname: ReadQualifiedName,
     pub fault_pid: i32,
+    pub pad_: i32,
 }
 
 /// Matches `struct pystacks_line_table` from python/include/structs.h.
@@ -77,7 +83,24 @@ pub struct PystacksLineTable {
     pub length: u32,
     pub addr: usize,
     pub pid: i32,
+    pub pad_: i32,
 }
+
+/// Matches `struct pystacks_symbol_record` from python/include/py_structs.h.
+/// Emitted by BPF through the pysym ringbuf the first time a symbol hash
+/// misses the `pystacks_symbols` gate map.
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct PystacksSymbolRecord {
+    pub symbol_id: SymbolIdT,
+    pub sym: PystacksSymbol,
+    pub linetable: PystacksLineTable,
+}
+
+// SAFETY: repr(C) with explicit padding fields; any byte pattern is a valid
+// value (raw byte buffers and integers only). Required so the ringbuf
+// consumer can deserialize records with plain::copy_from_bytes.
+unsafe impl plain::Plain for PystacksSymbolRecord {}
 
 /// Matches `OffsetConfig` from python/include/OffsetConfig.h.
 /// Contains field offsets for Python runtime structures.
@@ -231,8 +254,8 @@ pub struct BpfLibBinaryId {
 // Size assertions to validate struct layout matches C definitions.
 // These are compile-time checks - any mismatch is a build error.
 const _: () = {
-    assert!(std::mem::size_of::<StackWalkerFrame>() == 8);
-    assert!(std::mem::align_of::<StackWalkerFrame>() == 4);
+    assert!(std::mem::size_of::<StackWalkerFrame>() == 16);
+    assert!(std::mem::align_of::<StackWalkerFrame>() == 8);
 
     // ReadFileName: 192 bytes + padding + usize
     assert!(std::mem::size_of::<ReadFileName>() == BPF_LIB_PYSTACKS_FILE_NAME_LEN + 8);
@@ -240,16 +263,19 @@ const _: () = {
     // ReadQualifiedName: 224 bytes + usize
     assert!(std::mem::size_of::<ReadQualifiedName>() == BPF_LIB_PYSTACKS_QUAL_NAME_LEN + 8);
 
-    // PystacksLineTable: u32 + u32 + usize + i32 + padding
-    // On 64-bit: 4 + 4 + 8 + 4 + 4(pad) = 24
+    // PystacksLineTable: u32 + u32 + usize + i32 + explicit pad
+    // On 64-bit: 4 + 4 + 8 + 4 + 4 = 24
     assert!(std::mem::size_of::<PystacksLineTable>() == 24);
 
     // OffsetConfig: 51 usize fields + 3 i32 fields
     // On 64-bit: 51*8 + 3*4 + 4(pad) = 408 + 12 + 4 = 424
     assert!(std::mem::size_of::<OffsetConfig>() == 424);
 
-    // PystacksSymbol: ReadFileName(200) + ReadQualifiedName(232) + i32(4) + padding(4) = 440
+    // PystacksSymbol: ReadFileName(200) + ReadQualifiedName(232) + i32(4) + explicit pad(4) = 440
     assert!(std::mem::size_of::<PystacksSymbol>() == 440);
+
+    // PystacksSymbolRecord: u64(8) + PystacksSymbol(440) + PystacksLineTable(24) = 472
+    assert!(std::mem::size_of::<PystacksSymbolRecord>() == 472);
 
     // PyPidData: OffsetConfig(424) + bool(1) + padding(7) + 5*usize(40) = 472
     assert!(std::mem::size_of::<PyPidData>() == 472);
@@ -264,8 +290,13 @@ mod tests {
 
     #[test]
     fn test_stack_walker_frame_size() {
-        assert_eq!(std::mem::size_of::<StackWalkerFrame>(), 8);
-        assert_eq!(std::mem::align_of::<StackWalkerFrame>(), 4);
+        assert_eq!(std::mem::size_of::<StackWalkerFrame>(), 16);
+        assert_eq!(std::mem::align_of::<StackWalkerFrame>(), 8);
+    }
+
+    #[test]
+    fn test_pystacks_symbol_record_size() {
+        assert_eq!(std::mem::size_of::<PystacksSymbolRecord>(), 472);
     }
 
     #[test]

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -157,7 +157,7 @@ impl StackSpill {
 
     /// Record format (little-endian):
     /// id: i64, tgid: i32, klen: u16, ulen: u16, pylen: u16,
-    /// then klen+ulen u64 addresses and pylen (u32 symbol_id, i32 inst_idx).
+    /// then klen+ulen u64 addresses and pylen (u64 symbol_id, i32 inst_idx).
     ///
     /// Called from the ringbuf consumer path, but only once per *unique* stack
     /// and buffered through page cache, so it does not normally block event
@@ -409,7 +409,9 @@ fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32,
     let ulen = u16::from_le_bytes(hdr[14..16].try_into().unwrap()) as usize;
     let pylen = u16::from_le_bytes(hdr[16..18].try_into().unwrap()) as usize;
 
-    let mut addrs = vec![0u8; (klen + ulen) * 8 + pylen * 8];
+    // Python frames serialize as 12 bytes: u64 symbol_id + i32 inst_idx.
+    const PY_FRAME_BYTES: usize = 12;
+    let mut addrs = vec![0u8; (klen + ulen) * 8 + pylen * PY_FRAME_BYTES];
     reader
         .read_exact(&mut addrs)
         .context("reading stack spill record body")?;
@@ -425,12 +427,13 @@ fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32,
     };
     let kernel_stack = read_u64s(klen, &mut off);
     let user_stack = read_u64s(ulen, &mut off);
-    let py_stack = addrs[off..off + pylen * 8]
-        .chunks_exact(8)
+    let py_stack = addrs[off..off + pylen * PY_FRAME_BYTES]
+        .chunks_exact(PY_FRAME_BYTES)
         .map(|c| PyAddr {
             addr: crate::pystacks::types::StackWalkerFrame {
-                symbol_id: u32::from_le_bytes(c[0..4].try_into().unwrap()),
-                inst_idx: i32::from_le_bytes(c[4..8].try_into().unwrap()),
+                symbol_id: u64::from_le_bytes(c[0..8].try_into().unwrap()),
+                inst_idx: i32::from_le_bytes(c[8..12].try_into().unwrap()),
+                pad_: 0,
             },
         })
         .collect();
@@ -1061,8 +1064,9 @@ mod tests {
 
         let py = vec![PyAddr {
             addr: crate::pystacks::types::StackWalkerFrame {
-                symbol_id: 7,
+                symbol_id: 0xdeadbeef_cafef00d,
                 inst_idx: -1,
+                pad_: 0,
             },
         }];
         let stacks = [

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -801,11 +801,6 @@ pub trait SystingEvent {
     fn prev_task_info(&self) -> Option<&task_info> {
         None
     }
-    /// Returns true if this event contains Python stack data that needs symbol loading.
-    /// Default is false; only stack_event overrides this.
-    fn has_pystack(&self) -> bool {
-        false
-    }
 }
 
 impl SystingEvent for task_event {
@@ -832,9 +827,6 @@ impl SystingEvent for stack_event {
     }
     fn next_task_info(&self) -> Option<&task_info> {
         Some(&self.task)
-    }
-    fn has_pystack(&self) -> bool {
-        self.py_msg_buffer.stack_len > 0
     }
 }
 
@@ -963,7 +955,6 @@ fn consume_loop<T, N>(
     rx: Receiver<N>,
     stop_tx: Sender<()>,
     task_info_tx: Sender<task_info>,
-    pystack_symbol_tx: Option<Sender<N>>,
 ) where
     T: SystingRecordEvent<N>,
     N: Plain + SystingEvent + Copy,
@@ -992,15 +983,6 @@ fn consume_loop<T, N>(
                     let _ = task_info_tx.send(*task_info);
                 }
             }
-
-            // Send event to pystack symbol loading thread only if it has Python stack data
-            // This avoids waking up the symbol loader thread for events without Python stacks
-            if let Some(ref tx) = pystack_symbol_tx {
-                if event.has_pystack() {
-                    tx.send(*event)
-                        .expect("Failed to send event to pystack symbol loader thread");
-                }
-            }
         }
 
         let mut rec = recorder.lock().unwrap();
@@ -1024,6 +1006,10 @@ struct RecorderChannels {
     memory_rx: Receiver<memory_event>,
     marker_rx: Receiver<marker_event>,
     exec_event_rx: Option<Receiver<exec_event>>,
+    /// Python symbol records emitted by BPF on first sight of a symbol;
+    /// consumed by the pystack_symbol_loader thread, which interns them and
+    /// updates the BPF gate map. Present only when pystacks is enabled.
+    pysym_rx: Option<Receiver<crate::pystacks::types::PystacksSymbolRecord>>,
 }
 
 fn spawn_recorder_threads(
@@ -1033,7 +1019,6 @@ fn spawn_recorder_threads(
     stop_tx: &Sender<()>,
     perf_counter_names: &[String],
     task_info_tx: &Sender<task_info>,
-    pystack_symbol_tx: &Option<Sender<stack_event>>,
 ) -> Result<Vec<thread::JoinHandle<i32>>> {
     let RecorderChannels {
         event_rx,
@@ -1064,7 +1049,6 @@ fn spawn_recorder_threads(
                         event_rx,
                         my_stop_tx,
                         my_task_tx,
-                        None,
                     );
                     0
                 })?,
@@ -1076,7 +1060,6 @@ fn spawn_recorder_threads(
         let session_recorder = recorder.clone();
         let my_stop_tx = stop_tx.clone();
         let my_task_tx = task_info_tx.clone();
-        let my_pystack_tx = pystack_symbol_tx.clone();
         threads.push(
             thread::Builder::new()
                 .name("stack_recorder".to_string())
@@ -1086,7 +1069,6 @@ fn spawn_recorder_threads(
                         stack_rx,
                         my_stop_tx,
                         my_task_tx,
-                        my_pystack_tx,
                     );
                     0
                 })?,
@@ -1107,7 +1089,6 @@ fn spawn_recorder_threads(
                         probe_rx,
                         my_stop_tx,
                         my_task_tx,
-                        None,
                     );
                     0
                 })?,
@@ -1128,7 +1109,6 @@ fn spawn_recorder_threads(
                         network_rx,
                         my_stop_tx,
                         my_task_tx,
-                        None,
                     );
                     0
                 })?,
@@ -1210,7 +1190,6 @@ fn spawn_recorder_threads(
                         cache_rx,
                         my_stop_tx,
                         my_task_tx,
-                        None,
                     );
                     0
                 })?,
@@ -1233,7 +1212,6 @@ fn spawn_recorder_threads(
                         memory_rx,
                         my_stop_tx,
                         my_task_tx,
-                        None,
                     );
                     0
                 })?,
@@ -1256,7 +1234,6 @@ fn spawn_recorder_threads(
                         marker_rx,
                         my_stop_tx,
                         my_task_tx,
-                        None,
                     );
                     0
                 })?,
@@ -1889,12 +1866,24 @@ fn setup_ringbuffers<'a>(
         }
     }
 
+    let mut pysym_rx = None;
     if collect_pystacks {
         for map in object.maps() {
             if map.name().to_str().unwrap() == "ringbuf_exec_events" {
                 let ring = create_ring::<exec_event>(&map, exec_tx.clone())?;
                 rings.push(("ringbuf_exec_events".to_string(), ring));
                 has_exec_ringbuf = true;
+                break;
+            }
+        }
+
+        for map in object.maps() {
+            if map.name().to_str().unwrap() == "ringbuf_pysym_events" {
+                let (pysym_tx, rx) = sync_channel(CHANNEL_CAPACITY);
+                let ring =
+                    create_ring::<crate::pystacks::types::PystacksSymbolRecord>(&map, pysym_tx)?;
+                rings.push(("ringbuf_pysym_events".to_string(), ring));
+                pysym_rx = Some(rx);
                 break;
             }
         }
@@ -1932,6 +1921,7 @@ fn setup_ringbuffers<'a>(
         epoll_rx,
         marker_rx,
         exec_event_rx,
+        pysym_rx,
     };
 
     Ok((rings, channels))
@@ -2167,6 +2157,19 @@ fn configure_bpf_skeleton(
         if unreachable_slot {
             map.set_max_entries(page_size)
                 .with_context(|| format!("Failed to shrink unreachable ringbuf slot '{name}'"))?;
+        }
+        // The pysym maps are referenced by always-loaded programs (the
+        // sched_switch pystacks path is rodata-gated via
+        // tool_config.collect_pystacks, not autoload-gated), so they can't be
+        // autocreate=false; shrink them when pystacks is off instead.
+        if !collect_pystacks {
+            if name == "ringbuf_pysym_events" {
+                map.set_max_entries(page_size)
+                    .with_context(|| format!("Failed to shrink '{name}'"))?;
+            } else if name == "pystacks_symbols" || name == "pystacks_emitted_cache" {
+                map.set_max_entries(1)
+                    .with_context(|| format!("Failed to shrink '{name}'"))?;
+            }
         }
     }
 
@@ -2918,7 +2921,6 @@ struct ThreadHandles {
     exec_handler_thread: Option<thread::JoinHandle<()>>,
     tpu_metrics_thread: Option<thread::JoinHandle<i32>>,
     task_info_tx: Sender<task_info>,
-    pystack_symbol_tx: Sender<stack_event>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3037,7 +3039,6 @@ fn run_tracing_loop(
     }
     // Drop senders to allow background threads to exit
     drop(handles.task_info_tx);
-    drop(handles.pystack_symbol_tx);
     handles
         .discovery_thread
         .join()
@@ -3311,8 +3312,10 @@ pub fn systing(
         }
 
         let (rings, mut channels) = setup_ringbuffers(&skel, &opts, collect_pystacks)?;
-        // Take exec_event_rx out before channels is moved into spawn_recorder_threads
+        // Take exec_event_rx/pysym_rx out before channels is moved into
+        // spawn_recorder_threads
         let exec_event_rx = channels.exec_event_rx.take();
+        let pysym_rx = channels.pysym_rx.take();
 
         // Create shutdown signal for receiver threads
         let shutdown_signal = Arc::new(AtomicBool::new(false));
@@ -3331,9 +3334,6 @@ pub fn systing(
                 0
             })?;
 
-        // Create channel for Python symbol loading
-        let (pystack_symbol_tx, pystack_symbol_rx) = channel();
-
         // Spawn all recorder threads
         let recv_threads = spawn_recorder_threads(
             &recorder,
@@ -3342,7 +3342,6 @@ pub fn systing(
             &stop_tx,
             &perf_counter_names,
             &task_info_tx,
-            &Some(pystack_symbol_tx.clone()),
         )?;
 
         // Set up perf events (clock events and counter events)
@@ -3441,11 +3440,21 @@ pub fn systing(
             );
         }
 
+        // Consume symbol records emitted by BPF the first time it sees a
+        // Python symbol: resolve + cache the symbol, then insert it into the
+        // BPF gate map from this (process-context) thread. BPF itself never
+        // inserts into the gate map because its probes run with IRQs off,
+        // where a contended hash-map bucket lock can permanently halt the
+        // vCPU on hypervisors that drop PV spinlock kicks (AWS Nitro).
+        // The channel senders live in the ringbuf callbacks, so this thread
+        // exits once the ringbuf threads are joined and the rings dropped.
         let symbol_thread = thread::Builder::new()
             .name("pystack_symbol_loader".to_string())
             .spawn(move || {
-                while let Ok(event) = pystack_symbol_rx.recv() {
-                    psr.load_pystack_symbols(&event);
+                if let Some(rx) = pysym_rx {
+                    while let Ok(record) = rx.recv() {
+                        psr.ingest_symbol_record(&record);
+                    }
                 }
                 0
             })?;
@@ -3639,7 +3648,6 @@ pub fn systing(
             symbol_loader_thread: symbol_thread,
             exec_handler_thread,
             task_info_tx,
-            pystack_symbol_tx,
             tpu_metrics_thread,
         };
 


### PR DESCRIPTION
## What this does

Fixes hard node lockups caused by pystacks updating shared BPF hash maps from probe context. After this change, the BPF probe paths perform only lock-free hash-map lookups, per-CPU array writes, and rate-limited ringbuf reserves; all shared hash-map inserts move to userspace.

## Why now

With Python stack collection enabled, sched_switch-driven pystacks walks were wedging large AWS instances (p5/trn2 class, 192 vCPUs) within minutes of trace start. The probe runs with the runqueue lock held and IRQs off; per-frame `bpf_map_update_elem` calls contended the hash bucket raw spinlocks hard enough to push waiters into the paravirt qspinlock slow path, where `kvm_wait` HLTs with IF=0. Nitro never delivers the PV unhalt kick to an IF=0 halt, so the vCPU halts permanently while holding the rq lock and the node hard-locks. Reducing contention is not sufficient — the trace-start warm-up burst alone (all CPUs missing on the same hot symbols simultaneously) exceeds the spin threshold — so probe-context inserts had to be removed entirely.

## What changed

- **Symbol IDs are 64-bit content hashes** computed in BPF (`symbol_id_t` u32 → u64). Every CPU derives the same ID independently; the shared atomic counter and insert-to-allocate-an-ID pattern are gone.
- **`pystacks_symbols` is now a lookup-only gate map.** BPF checks it lock-free; only userspace inserts (process context, where contended PV waiters use `safe_halt` and recover via timer tick).
- **On gate miss, BPF emits `{id, symbol, linetable}`** through a new `ringbuf_pysym_events` ringbuf, rate-limited by a per-CPU slot-based cooldown that hard-caps reserve attempts at 1024/s/CPU under any workload (fails closed if the cache lookup misses). NMI-context reserves use the kernel's trylock path.
- **Userspace interns**: a consumer thread resolves records (existing page-fault recovery), caches them, and marks the ID interned in the gate map, stopping re-emission. The `pystacks_linetables` map and the 500ms full-map polling are deleted.
- Frames always carry the hash, so stacks recorded before interning completes still symbolize correctly at trace save.
- When pystacks is disabled, the new maps are shrunk at open time; the probe references are rodata-gated and verifier-pruned.
- Stack spill file format: Python frames are now 12 bytes (u64 id + i32 inst_idx). Per-run temp file, no compatibility impact. No DB schema change; patch bump to 1.9.3.

## How we know it works

- Unit tests: 352/352. Integration tests (as root): trace_validation 31/31 (all pystacks variants, Python 3.8–3.13, multiprocessing, threads, sleep stacks), memory_recorder 5/5, network_throughput, perf_counter, analyze_commands all pass.
- Manual run against a live Python 3.12 workload: 8,098 stack events produced exactly 5 interning operations (one per unique symbol vs. per-frame map updates before), zero unknown frames, per-instruction source lines intact in the DuckDB output.
- Adversarial review (BPF concurrency, C/Rust layout, shutdown ordering, rate limiter) completed; all findings addressed: fail-closed rate limiter, once-logged warning when the gate map fills, and accurate documentation of the delivery guarantee (recurring symbols always intern; a one-shot frame whose every emission is suppressed or dropped stays unresolved — accepted trade for the hard cap).

## After merge

Python stack collection can be re-enabled on the affected fleets. The hypervisor-side issue (PV kick not resuming IF=0 halts) remains worth pursuing with AWS independently; this change removes the only kernel context in which systing could trigger it.