### PR TITLE
pystacks: cache per-binary ELF parses during process discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.9.2"
+version = "1.9.3"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.9.2"
+version = "1.9.3"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/pystacks/discovery.rs
+++ b/src/pystacks/discovery.rs
@@ -8,7 +8,86 @@ use super::types::{BpfLibBinaryId, PyPidData, BPF_LIB_DEFAULT_FIELD_OFFSET};
 use object::{Object, ObjectSymbol};
 use std::collections::HashMap;
 use std::fs;
+use std::io::Read;
+use std::os::unix::fs::MetadataExt;
 use std::path::Path;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Instant;
+
+/// ELF-derived facts about a Python runtime binary. These depend only on the
+/// file contents, never on the process mapping it, so they are cached by
+/// (st_dev, st_ino) — a node running N forked workers of the same interpreter
+/// would otherwise read and symbol-scan the same multi-hundred-MB binary N
+/// times, which can take seconds per process.
+#[derive(Debug)]
+struct ElfPyInfo {
+    py_runtime_addr: usize,
+    version: (i32, i32, i32),
+    is_dynamic: bool,
+}
+
+/// Per-binary ELF parse results keyed by (st_dev, st_ino, st_size). `None`
+/// records a binary that is not a Python runtime — rejections cost a full
+/// ELF parse too, so they're worth remembering. I/O failures are never
+/// cached: a transient read error (ESTALE, a /proc/pid/root path vanishing
+/// when the process exits mid-check) must not blacklist an interpreter for
+/// the rest of the session.
+type ElfCache = HashMap<(u64, u64, u64), Option<Arc<ElfPyInfo>>>;
+
+static ELF_CACHE: LazyLock<Mutex<ElfCache>> = LazyLock::new(Default::default);
+
+/// Parse the ELF at `file_path` for Python runtime facts, going through the
+/// (st_dev, st_ino, st_size) cache. Returns `None` when the file is
+/// unreadable or is not a Python runtime.
+fn elf_py_info(file_path: &str) -> Option<Arc<ElfPyInfo>> {
+    // Open first and stat through the handle so the cache key describes the
+    // file we actually read. The inode is pinned while any process maps the
+    // binary, but a cache entry can outlive every mapper; st_size in the key
+    // guards against a freed (dev, ino) being reused by a different file
+    // later in the session.
+    //
+    // Known limit: the version fallback in detect_python_version keys off
+    // the basename, so hardlinks to one inode under different names share
+    // whichever result was cached first.
+    let mut file = fs::File::open(file_path).ok()?;
+    let meta = file.metadata().ok()?;
+    let key = (meta.dev(), meta.ino(), meta.len());
+    if let Some(cached) = ELF_CACHE.lock().unwrap().get(&key) {
+        return cached.clone();
+    }
+    // Read and parse outside the lock; two threads racing on the same binary
+    // produce identical results, so last-write-wins is fine.
+    let mut data = Vec::new();
+    file.read_to_end(&mut data).ok()?;
+    let parsed = parse_elf_py_info(file_path, &data);
+    ELF_CACHE.lock().unwrap().insert(key, parsed.clone());
+    parsed
+}
+
+/// Rejections costing at least this long are logged: a large non-Python
+/// embedder pays the same full read and symbol scans as an accept, and the
+/// log line makes the negative-cache benefit attributable.
+const SLOW_REJECT_SECS: f64 = 0.5;
+
+fn parse_elf_py_info(file_path: &str, data: &[u8]) -> Option<Arc<ElfPyInfo>> {
+    let start = Instant::now();
+    let result = object::File::parse(data).ok().and_then(|elf| {
+        let py_runtime_addr = find_symbol_address(&elf, "_PyRuntime")?;
+        let version = detect_python_version(&elf, file_path)?;
+        Some(Arc::new(ElfPyInfo {
+            py_runtime_addr,
+            version,
+            is_dynamic: elf.kind() == object::ObjectKind::Dynamic,
+        }))
+    });
+    let elapsed = start.elapsed().as_secs_f64();
+    if result.is_some() {
+        eprintln!("[pystacks] Parsed Python runtime ELF {file_path} in {elapsed:.2}s");
+    } else if elapsed >= SLOW_REJECT_SECS {
+        eprintln!("[pystacks] Rejected non-Python ELF {file_path} in {elapsed:.2}s");
+    }
+    result
+}
 
 /// Kernel MKDEV macro: (major << 20) | minor
 fn kmkdev(major: u32, minor: u32) -> u64 {
@@ -29,6 +108,7 @@ pub struct PyProcessInfo {
 /// Discover Python processes from a list of PIDs.
 /// Returns a map of PID -> PyProcessInfo for all Python processes found.
 pub fn discover_python_processes(pids: &[i32]) -> HashMap<i32, PyProcessInfo> {
+    let start = Instant::now();
     let mut results = HashMap::new();
 
     for &pid in pids {
@@ -39,9 +119,10 @@ pub fn discover_python_processes(pids: &[i32]) -> HashMap<i32, PyProcessInfo> {
 
     if !results.is_empty() {
         eprintln!(
-            "[pystacks] Discovered {} Python processes out of {} examined",
+            "[pystacks] Discovered {} Python processes out of {} examined in {:.2}s",
             results.len(),
-            pids.len()
+            pids.len(),
+            start.elapsed().as_secs_f64()
         );
     }
 
@@ -111,20 +192,16 @@ fn try_python_module(
     maps: &[MemoryMapping],
     is_exe: bool,
 ) -> Option<PyProcessInfo> {
-    // Read the ELF file
+    // ELF facts come from the per-binary cache — forked workers of the same
+    // interpreter share one parse instead of re-reading the binary per PID.
     let file_path = resolve_proc_path(pid, module_path);
-    let data = fs::read(&file_path).ok()?;
-    let elf = object::File::parse(&*data).ok()?;
+    let elf_info = elf_py_info(&file_path)?;
 
-    let is_pie = elf.kind() == object::ObjectKind::Dynamic && is_exe;
-    let is_shared = elf.kind() == object::ObjectKind::Dynamic && !is_exe;
+    let is_pie = elf_info.is_dynamic && is_exe;
+    let is_shared = elf_info.is_dynamic && !is_exe;
 
-    // Find _PyRuntime symbol
-    let py_runtime_addr = find_symbol_address(&elf, "_PyRuntime")?;
-
-    // Try to determine Python version
-    let version = detect_python_version(&elf, module_path);
-    let (major, minor, micro) = version?;
+    let py_runtime_addr = elf_info.py_runtime_addr;
+    let (major, minor, micro) = elf_info.version;
 
     // Get offset config for this version
     let offsets = offsets::for_version(major, minor)?;
@@ -250,7 +327,9 @@ fn find_symbol_address(elf: &object::File, name: &str) -> Option<usize> {
 }
 
 /// Detect the Python version from an ELF file.
-/// Tries _PySys_ImplCacheTag first, then falls back to filename pattern.
+/// Tries _PySys_ImplCacheTag first, then falls back to filename pattern
+/// (the resolved on-disk path has the same basename as the mapped module,
+/// so the pattern match is unaffected by /proc/pid/root resolution).
 fn detect_python_version(elf: &object::File, module_path: &str) -> Option<(i32, i32, i32)> {
     // Try to find version from _PySys_ImplCacheTag symbol value
     if let Some(version_str) = read_impl_cache_tag(elf) {
@@ -433,6 +512,53 @@ mod tests {
     #[test]
     fn test_kmkdev() {
         assert_eq!(kmkdev(8, 1), (8 << 20) | 1);
+    }
+
+    #[test]
+    fn test_elf_py_info_caches_negative_results() {
+        // Our own test binary is a valid ELF with no _PyRuntime symbol: it
+        // must be rejected, and the rejection must be cached by (dev, ino)
+        // so re-checking (e.g. N workers of one non-Python embedder) skips
+        // the ELF re-parse.
+        let exe = std::env::current_exe().unwrap();
+        let exe_str = exe.to_string_lossy();
+        assert!(elf_py_info(&exe_str).is_none());
+
+        let meta = fs::metadata(&*exe_str).unwrap();
+        let cached = ELF_CACHE
+            .lock()
+            .unwrap()
+            .get(&(meta.dev(), meta.ino(), meta.len()))
+            .cloned();
+        assert!(matches!(cached, Some(None)), "negative result not cached");
+
+        // Second lookup serves from cache (same answer).
+        assert!(elf_py_info(&exe_str).is_none());
+    }
+
+    #[test]
+    fn test_elf_py_info_unreadable_path() {
+        assert!(elf_py_info("/nonexistent/definitely-not-a-file").is_none());
+    }
+
+    #[test]
+    fn test_elf_py_info_io_failure_not_cached() {
+        // Opening a directory succeeds but reading it fails (EISDIR) — a
+        // stand-in for transient I/O failures like ESTALE or a /proc path
+        // vanishing mid-read. Those must not be cached as negatives, or one
+        // transient error would blacklist the inode for the whole session.
+        let dir = tempfile::tempdir().unwrap();
+        let dir_str = dir.path().to_string_lossy();
+        assert!(elf_py_info(&dir_str).is_none());
+
+        let meta = fs::metadata(dir.path()).unwrap();
+        assert!(
+            !ELF_CACHE
+                .lock()
+                .unwrap()
+                .contains_key(&(meta.dev(), meta.ino(), meta.len())),
+            "I/O failure must not be cached"
+        );
     }
 
     #[test]

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -1098,6 +1098,14 @@ impl SessionRecorder {
         output_dir: &Path,
         tpu_recorder: Option<crate::tpu::recorder::TpuRecorder>,
     ) -> Result<()> {
+        // Per-stage elapsed lines below let fleet log pipelines attribute
+        // stop-phase cost without relying on collector timestamp granularity.
+        let gen_start = std::time::Instant::now();
+        let mut stage_start = gen_start;
+        let stage_done = |label: &str, start: &mut std::time::Instant| {
+            eprintln!("{} in {:.2}s", label, start.elapsed().as_secs_f64());
+            *start = std::time::Instant::now();
+        };
         eprintln!("Generating Parquet trace to {output_dir:?}...");
 
         // Get the end timestamp for flushing streaming data
@@ -1114,6 +1122,7 @@ impl SessionRecorder {
         let mut writer: Box<dyn RecordCollector + Send> = collector_opt.ok_or_else(|| {
             anyhow::anyhow!("streaming collector must be initialized before generating trace")
         })?;
+        stage_done("Flushed scheduler trace records", &mut stage_start);
 
         // Step 2: Generate clock snapshot records
         eprintln!("Writing clock snapshot...");
@@ -1252,6 +1261,7 @@ impl SessionRecorder {
         // Step 4: Generate network interface metadata
         eprintln!("Writing network interface metadata...");
         self.write_network_interface_records(&mut *writer)?;
+        stage_done("Wrote metadata records", &mut stage_start);
 
         // Step 5: Flush streaming records from all recorders
         // Scheduler trace records were already written via streaming above.
@@ -1268,24 +1278,29 @@ impl SessionRecorder {
             }
             writer = memory.finish(writer)?;
         }
+        stage_done("Flushed memory trace records", &mut stage_start);
 
         eprintln!("Flushing stack samples and symbolizing stacks...");
         writer = self.stack_recorder.lock().unwrap().finish(writer)?;
+        stage_done("Flushed and symbolized stack samples", &mut stage_start);
 
         eprintln!("Flushing network trace records...");
         if let Some(network_collector) = self.network_recorder.lock().unwrap().finish()? {
             network_collector.finish_boxed()?;
         }
+        stage_done("Flushed network trace records", &mut stage_start);
 
         eprintln!("Flushing perf counter records from streaming...");
         if let Some(perf_collector) = self.perf_counter_recorder.lock().unwrap().finish()? {
             perf_collector.finish_boxed()?;
         }
+        stage_done("Flushed perf counter records", &mut stage_start);
 
         eprintln!("Flushing sysinfo records from streaming...");
         if let Some(sysinfo_collector) = self.sysinfo_recorder.lock().unwrap().finish()? {
             sysinfo_collector.finish_boxed()?;
         }
+        stage_done("Flushed sysinfo records", &mut stage_start);
 
         // The probe recorder (trace-events/syscalls) and the marker recorder both
         // emit track/slice/instant/args rows, which map to the same parquet files.
@@ -1315,10 +1330,12 @@ impl SessionRecorder {
             }
         }
         track_writer.finish_boxed()?;
+        stage_done("Flushed probe trace records", &mut stage_start);
 
         // Write TPU profiling records (if any were captured). TPU device/op IDs are
         // only referenced within the tpu_* tables, which nothing else writes, so
         // write_records assigns them internally.
+        let has_tpu = tpu_recorder.is_some() || self.tpu_metrics_recorder.is_some();
         if let Some(tpu) = tpu_recorder {
             eprintln!("Writing TPU profiling records...");
             tpu.write_records(&mut *writer)?;
@@ -1330,13 +1347,20 @@ impl SessionRecorder {
                 collector.finish_boxed()?;
             }
         }
+        if has_tpu {
+            stage_done("Wrote TPU records", &mut stage_start);
+        }
 
         // Step 6: Finish writing and close all files
         eprintln!("Finishing Parquet trace...");
         // Flush and properly close all Parquet writers
         writer.finish_boxed()?;
+        stage_done("Finished Parquet writers", &mut stage_start);
 
-        eprintln!("Parquet trace generation complete.");
+        eprintln!(
+            "Parquet trace generation complete in {:.2}s.",
+            gen_start.elapsed().as_secs_f64()
+        );
         Ok(())
     }
 }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -3719,8 +3719,13 @@ pub fn systing(
                     "Converting to Perfetto format: {}...",
                     opts.output.display()
                 );
+                let convert_start = std::time::Instant::now();
                 parquet_to_perfetto::convert(&opts.output_dir, &opts.output)?;
-                println!("Successfully wrote {}", opts.output.display());
+                println!(
+                    "Successfully wrote {} in {:.2}s",
+                    opts.output.display(),
+                    convert_start.elapsed().as_secs_f64()
+                );
             }
             Some("duckdb") => {
                 // Generate trace_id from output directory name
@@ -3731,8 +3736,13 @@ pub fn systing(
                     .unwrap_or_else(|| "trace".to_string());
 
                 println!("Generating DuckDB database: {}...", opts.output.display());
+                let convert_start = std::time::Instant::now();
                 systing_duckdb::parquet_to_duckdb(&opts.output_dir, &opts.output, &trace_id)?;
-                println!("Successfully wrote {}", opts.output.display());
+                println!(
+                    "Successfully wrote {} in {:.2}s",
+                    opts.output.display(),
+                    convert_start.elapsed().as_secs_f64()
+                );
             }
             Some(ext) => {
                 bail!(


### PR DESCRIPTION
## Problem

Process discovery parses the full Python binary (`fs::read` + ELF parse + two symbol-table scans) once per PID, serially, before recording starts. On hosts running many forked workers of one interpreter the same binary is re-read and re-parsed for every worker — observed ~3s per process, so 63 workers delayed recording start by ~170s.

## Change

- Cache ELF-derived facts (`_PyRuntime` address, version, object kind) keyed by `(st_dev, st_ino, st_size)`, so each distinct binary is parsed once per session. Negative results are cached too, since rejecting a non-Python module also costs a full parse. I/O failures are never cached — a transient read error (ESTALE, a `/proc/pid/root` path vanishing when the process exits mid-check) must not blacklist an interpreter for the rest of the session. The file is opened once and stat'd through the handle, so the cache key describes the file actually read. Per-PID work (maps parsing, base-address computation, GIL address reads) is unchanged.
- Print elapsed time for: total discovery, each per-binary ELF parse (and slow ≥0.5s rejections), every parquet flush stage (scheduler/metadata/memory/stacks/network/perf/sysinfo/probe/TPU/finish), and the DuckDB/Perfetto conversion, so slow phases are attributable from timestamped logs. Stage times sum to the printed total.
- Patch version bump 1.9.2 → 1.9.3 (no schema change).

## Testing

- New unit tests: negative-result caching via the test binary's own ELF, unreadable-path handling, and a regression test that I/O failures (EISDIR stand-in) are not cached.
- `cargo test`: 390 passed. `cargo clippy --all-targets`: clean. `cargo fmt --check`: clean.
- Integration suite (`./scripts/run-integration-tests.sh`): 31 passed, including all pystacks discovery paths (exec, fork, fork+exec, multiprocessing, Python 3.8–3.13).