### PR TITLE
Add --stream: write parquet over vsock/unix/tcp instead of disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90eeab0aa92f3f9b4e87f258c72b139c207d251f9cbc1080a0086b86a8870dd3"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "windows-sys 0.59.0",
 ]
 
@@ -1971,15 +1971,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8306b516a70a129cb6afed17c1e51e162d35aadfcc6339364addcebe32de90"
 dependencies = [
  "cc",
- "nix",
+ "nix 0.29.0",
  "pkg-config",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libduckdb-sys"
@@ -2094,6 +2094,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2149,19 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3408,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",
@@ -3425,7 +3447,7 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libc",
- "nix",
+ "nix 0.29.0",
  "object",
  "parquet",
  "perfetto_protos",
@@ -3449,6 +3471,7 @@ dependencies = [
  "tonic-reflection",
  "tracing",
  "tracing-subscriber",
+ "vsock",
 ]
 
 [[package]]
@@ -3949,6 +3972,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsock"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
+dependencies = [
+ "libc",
+ "nix 0.31.3",
+]
 
 [[package]]
 name = "vsprintf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.10.0"
+version = "1.10.1"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"
@@ -53,6 +53,7 @@ syscalls = "0.6"
 # call.
 sysinfo = { version = "0.33.1", default-features = false, features = ["system"] }
 tempfile = "3.13"
+vsock = "0.5"
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "io-std"] }
 object = { version = "0.36", default-features = false, features = ["read", "elf"] }
 tracing = "0.1"

--- a/STREAMING.md
+++ b/STREAMING.md
@@ -1,0 +1,77 @@
+# Streaming output (`--stream`)
+
+`--stream <URI>` makes systing write each parquet table to a socket connection
+instead of the local filesystem. This is intended for running systing inside a
+guest VM (or other constrained environment) and shipping the trace out to a
+host-side receiver that assembles parquet files and imports them into DuckDB.
+
+## URI schemes
+
+| URI                      | Transport | Notes |
+|--------------------------|-----------|-------|
+| `vsock://CID:PORT`       | AF_VSOCK  | Guest → host. From inside a guest, the host is **CID 2**. |
+| `unix:///path/to.sock`   | AF_UNIX   | Local stream socket. |
+| `tcp://host:port`        | TCP       | **Unauthenticated.** Trusted networks only. |
+
+`--stream` is mutually exclusive with `--output` and `--parquet-only`. No local
+parquet directory or DuckDB file is produced; the receiver owns conversion.
+
+## Wire protocol
+
+One connection per parquet table, opened lazily on the first row-group flush
+for that table (≈20–30 connections over a trace lifetime). Each connection
+carries:
+
+```
+systing/<SCHEMA_VERSION> <table_name>\n
+<raw parquet bytes ...>
+```
+
+The first line is ASCII; everything after the `\n` is the unmodified parquet
+file (PAR1 magic, row groups, footer, PAR1). `SCHEMA_VERSION` is the integer
+from `src/duckdb.rs`; `table_name` is the DuckDB table / parquet file stem
+(`sched_slice`, `stack_sample`, …) and is always one of the names in
+`systing::stream::TABLE_NAMES`.
+
+The connection is closed after the parquet footer is written. A receiver can
+treat the body as opaque: strip the header line, write the rest to
+`<table>.parquet`, and run the existing parquet → DuckDB import.
+
+Multiple writer instances may emit the same table (e.g. `process` rows come
+from several recorders), so a receiver should suffix duplicates
+(`process.1.parquet`, …); DuckDB's `read_parquet('dir/process*.parquet')`
+handles this.
+
+## Reference receiver
+
+```sh
+# Host (or wherever the listener lives):
+systing-util receive unix:///tmp/systing.sock --output-dir ./traces
+
+# Guest / sender:
+sudo systing --duration 10 --stream unix:///tmp/systing.sock
+```
+
+For vsock from a KVM/QEMU guest, the host listens with
+`systing-util receive vsock://any:5000 -o ./traces` (`any` =
+`VMADDR_CID_ANY`; `host` and `local` are also accepted) and the guest dials
+`--stream vsock://2:5000` (or `vsock://host:5000`). With Firecracker /
+Cloud Hypervisor's vhost-user-vsock backend the host side is exposed as a
+unix socket, so the receiver uses `unix://` instead.
+
+The receiver validates the header against `TABLE_NAMES` and rejects anything
+else, so a hostile peer cannot influence the output path. TCP listeners refuse
+to bind on `0.0.0.0` / `[::]` without `--insecure-tcp-bind-any`.
+
+`systing-util receive` is a reference implementation: it spawns one thread per
+connection without bound and has no graceful-shutdown handling, so Ctrl-C
+during an active trace can leave a half-written `.parquet` file. A production
+host-side daemon should bound concurrency and drain in-flight connections on
+SIGINT.
+
+## Spill files
+
+Stack and memory recorders spill interner state to disk during recording. In
+stream mode this goes to a private (mode 0700) `systing-spill-*` directory
+under `$TMPDIR`, removed when the trace ends. No trace data is left on the
+guest.

--- a/src/bin/systing_util.rs
+++ b/src/bin/systing_util.rs
@@ -108,6 +108,27 @@ enum Commands {
         #[arg(long)]
         addr: Option<String>,
     },
+    /// Receive a streamed trace from `systing --stream` and write parquet files.
+    ///
+    /// Listens on a vsock/unix/tcp socket. Each accepted connection carries one
+    /// table: an ASCII header line `systing/<ver> <table>` followed by raw
+    /// parquet bytes. Streams are written to `<output_dir>/<table>.parquet`
+    /// (or `<table>.<n>.parquet` if multiple writer instances emit the same
+    /// table) and can then be imported with `systing-util convert`.
+    Receive {
+        /// Listen URI: vsock://CID:PORT | unix:///path/to.sock | tcp://host:port.
+        /// tcp is unauthenticated; for trusted networks only.
+        #[arg(value_name = "URI")]
+        listen: systing::stream::StreamTarget,
+
+        /// Directory to write received parquet files into.
+        #[arg(short, long)]
+        output_dir: PathBuf,
+
+        /// Allow binding a TCP listener on 0.0.0.0 / [::].
+        #[arg(long)]
+        insecure_tcp_bind_any: bool,
+    },
 }
 
 /// Information about a trace being processed
@@ -3753,6 +3774,11 @@ fn main() -> Result<()> {
             json,
         } => run_validate(path, verbose, json),
         Commands::DumpTpuProto { addr } => run_dump_tpu_proto(addr),
+        Commands::Receive {
+            listen,
+            output_dir,
+            insecure_tcp_bind_any,
+        } => systing::stream::receive::run(listen, output_dir, insecure_tcp_bind_any),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod ringbuf;
 pub mod sched;
 pub mod session_recorder;
 pub mod stack_recorder;
+pub mod stream;
 pub mod systing_core;
 pub mod tpu;
 pub mod trace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::FmtSubscriber;
 
+use systing::stream::StreamTarget;
 use systing::traced_command;
 use systing::{get_available_recorders, systing, Config};
 
@@ -142,6 +143,12 @@ struct Command {
     #[arg(long)]
     parquet_only: bool,
 
+    /// Stream parquet over a socket instead of writing to disk.
+    /// URI: vsock://CID:PORT | unix:///path/to.sock | tcp://host:port
+    /// (tcp is unauthenticated; trusted networks only).
+    #[arg(long, value_name = "URI", conflicts_with_all = ["output", "parquet_only"])]
+    stream: Option<StreamTarget>,
+
     /// Command to run and trace. Everything after -- is treated as the command.
     /// Only the command and its children/threads will be traced.
     /// Example: systing -- python3 myscript.py
@@ -194,6 +201,7 @@ impl From<Command> for Config {
             output_dir: cmd.output_dir,
             output: cmd.output,
             parquet_only: cmd.parquet_only,
+            stream: cmd.stream,
             run_command: if cmd.run_command.is_empty() {
                 None
             } else {

--- a/src/parquet/mod.rs
+++ b/src/parquet/mod.rs
@@ -3,8 +3,10 @@
 //! This module provides functionality for reading and writing trace data
 //! in Parquet format.
 
+pub mod sink;
 pub mod writer;
 
 // Re-export ParquetPaths from the crate root for backwards compatibility
 pub use crate::ParquetPaths;
+pub use sink::ParquetSink;
 pub use writer::StreamingParquetWriter;

--- a/src/parquet/sink.rs
+++ b/src/parquet/sink.rs
@@ -1,0 +1,88 @@
+//! Output sink abstraction for the streaming parquet writer.
+//!
+//! `ParquetSink` is what `StreamingParquetWriter` opens per-table writers
+//! against: either a local directory of `<table>.parquet` files (the default)
+//! or a socket endpoint when `--stream` is in use. Either way the writer gets
+//! back a `Box<dyn Write + Send>`, which is all `ArrowWriter` needs.
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use tempfile::TempDir;
+
+use crate::stream::StreamTarget;
+
+/// Where parquet table data goes.
+#[derive(Debug, Clone)]
+pub enum ParquetSink {
+    /// One `<table>.parquet` file per table under this directory.
+    Directory(PathBuf),
+    /// One socket connection per table, header-tagged. The `tmp` directory is
+    /// a private (mode 0700) scratch area for stack/memory interner spill
+    /// files; it is removed when the last clone of this sink drops.
+    Stream {
+        target: StreamTarget,
+        tmp: Arc<TempDir>,
+    },
+}
+
+impl ParquetSink {
+    /// Create a directory sink, creating the directory if it doesn't exist.
+    pub fn directory(dir: &Path) -> Result<Self> {
+        if !dir.exists() {
+            fs::create_dir_all(dir)
+                .with_context(|| format!("Failed to create output directory: {}", dir.display()))?;
+        } else if !dir.is_dir() {
+            bail!(
+                "Output path exists but is not a directory: {}",
+                dir.display()
+            );
+        }
+        Ok(Self::Directory(dir.to_path_buf()))
+    }
+
+    /// Create a stream sink with a private spill directory.
+    pub fn stream(target: StreamTarget) -> Result<Self> {
+        let tmp = tempfile::Builder::new()
+            .prefix("systing-spill-")
+            .tempdir()
+            .context("creating spill tempdir for stream sink")?;
+        Ok(Self::Stream {
+            target,
+            tmp: Arc::new(tmp),
+        })
+    }
+
+    /// Open the writer for a single table.
+    pub fn open(&self, table: &str) -> Result<Box<dyn Write + Send>> {
+        match self {
+            Self::Directory(dir) => {
+                let path = dir.join(format!("{table}.parquet"));
+                let file = File::create(&path)
+                    .with_context(|| format!("Failed to create file: {}", path.display()))?;
+                Ok(Box::new(file))
+            }
+            Self::Stream { target, .. } => target.connect(table),
+        }
+    }
+
+    /// Directory for stack/memory interner spill files.
+    pub fn spill_dir(&self) -> &Path {
+        match self {
+            Self::Directory(d) => d,
+            Self::Stream { tmp, .. } => tmp.path(),
+        }
+    }
+}
+
+impl std::fmt::Display for ParquetSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Directory(d) => write!(f, "{}", d.display()),
+            Self::Stream { target, .. } => write!(f, "{target}"),
+        }
+    }
+}

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -8,8 +8,8 @@
 //! `StreamingParquetWriter` is NOT thread-safe. Use from a single thread or wrap
 //! in appropriate synchronization primitives.
 
-use std::fs::{self, File};
-use std::path::{Path, PathBuf};
+use std::io::Write;
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -24,7 +24,7 @@ use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::schema::types::ColumnPath;
 
 use crate::network_recorder::{drop_reason_str, format_tcp_flags, tcp_state_name};
-use crate::parquet::ParquetPaths;
+use crate::parquet::ParquetSink;
 use crate::record::RecordCollector;
 use crate::trace::{
     self, ArgRecord, ClockSnapshotRecord, CounterRecord, CounterTrackRecord, CpuInfoRecord,
@@ -82,6 +82,11 @@ fn build_writer_properties() -> WriterProperties {
     builder.build()
 }
 
+/// Per-table parquet writer. `ArrowWriter` only needs `Write + Send` (no
+/// `Seek`), so the underlying sink can be a `File` or a socket — see
+/// [`ParquetSink`].
+type TableWriter = ArrowWriter<Box<dyn Write + Send>>;
+
 /// A streaming Parquet writer that implements `RecordCollector`.
 ///
 /// Records are buffered in memory and flushed to Parquet files when the
@@ -92,8 +97,7 @@ fn build_writer_properties() -> WriterProperties {
 ///
 /// This type is NOT thread-safe. Use from a single thread.
 pub struct StreamingParquetWriter {
-    output_dir: PathBuf,
-    paths: ParquetPaths,
+    sink: ParquetSink,
     batch_size: usize,
     writer_props: WriterProperties,
 
@@ -134,76 +138,76 @@ pub struct StreamingParquetWriter {
     tpu_metrics: Vec<TpuMetricRecord>,
 
     // Persistent writers (created lazily on first flush, kept alive until finish)
-    process_writer: Option<ArrowWriter<File>>,
-    thread_writer: Option<ArrowWriter<File>>,
-    sched_slice_writer: Option<ArrowWriter<File>>,
-    thread_state_writer: Option<ArrowWriter<File>>,
-    irq_slice_writer: Option<ArrowWriter<File>>,
-    softirq_slice_writer: Option<ArrowWriter<File>>,
-    wakeup_new_writer: Option<ArrowWriter<File>>,
-    process_exit_writer: Option<ArrowWriter<File>>,
-    counter_writer: Option<ArrowWriter<File>>,
-    counter_track_writer: Option<ArrowWriter<File>>,
-    slice_writer: Option<ArrowWriter<File>>,
-    track_writer: Option<ArrowWriter<File>>,
-    instant_writer: Option<ArrowWriter<File>>,
-    args_writer: Option<ArrowWriter<File>>,
-    instant_args_writer: Option<ArrowWriter<File>>,
-    stack_writer: Option<ArrowWriter<File>>,
-    stack_sample_writer: Option<ArrowWriter<File>>,
-    network_interface_writer: Option<ArrowWriter<File>>,
-    socket_connection_writer: Option<ArrowWriter<File>>,
-    network_syscall_writer: Option<ArrowWriter<File>>,
-    network_packet_writer: Option<ArrowWriter<File>>,
-    network_socket_writer: Option<ArrowWriter<File>>,
-    network_poll_writer: Option<ArrowWriter<File>>,
-    network_dns_writer: Option<ArrowWriter<File>>,
-    memory_rss_writer: Option<ArrowWriter<File>>,
-    memory_map_writer: Option<ArrowWriter<File>>,
-    memory_fault_writer: Option<ArrowWriter<File>>,
-    memory_alloc_writer: Option<ArrowWriter<File>>,
-    clock_snapshot_writer: Option<ArrowWriter<File>>,
-    sysinfo_writer: Option<ArrowWriter<File>>,
-    cpu_info_writer: Option<ArrowWriter<File>>,
-    tpu_device_writer: Option<ArrowWriter<File>>,
-    tpu_op_writer: Option<ArrowWriter<File>>,
-    tpu_metric_writer: Option<ArrowWriter<File>>,
+    process_writer: Option<TableWriter>,
+    thread_writer: Option<TableWriter>,
+    sched_slice_writer: Option<TableWriter>,
+    thread_state_writer: Option<TableWriter>,
+    irq_slice_writer: Option<TableWriter>,
+    softirq_slice_writer: Option<TableWriter>,
+    wakeup_new_writer: Option<TableWriter>,
+    process_exit_writer: Option<TableWriter>,
+    counter_writer: Option<TableWriter>,
+    counter_track_writer: Option<TableWriter>,
+    slice_writer: Option<TableWriter>,
+    track_writer: Option<TableWriter>,
+    instant_writer: Option<TableWriter>,
+    args_writer: Option<TableWriter>,
+    instant_args_writer: Option<TableWriter>,
+    stack_writer: Option<TableWriter>,
+    stack_sample_writer: Option<TableWriter>,
+    network_interface_writer: Option<TableWriter>,
+    socket_connection_writer: Option<TableWriter>,
+    network_syscall_writer: Option<TableWriter>,
+    network_packet_writer: Option<TableWriter>,
+    network_socket_writer: Option<TableWriter>,
+    network_poll_writer: Option<TableWriter>,
+    network_dns_writer: Option<TableWriter>,
+    memory_rss_writer: Option<TableWriter>,
+    memory_map_writer: Option<TableWriter>,
+    memory_fault_writer: Option<TableWriter>,
+    memory_alloc_writer: Option<TableWriter>,
+    clock_snapshot_writer: Option<TableWriter>,
+    sysinfo_writer: Option<TableWriter>,
+    cpu_info_writer: Option<TableWriter>,
+    tpu_device_writer: Option<TableWriter>,
+    tpu_op_writer: Option<TableWriter>,
+    tpu_metric_writer: Option<TableWriter>,
 
     // Track counts for statistics
     total_records: usize,
 }
 
 impl StreamingParquetWriter {
-    /// Create a new streaming Parquet writer.
+    /// Create a new streaming Parquet writer that writes to a directory.
     ///
     /// The output directory will be created if it doesn't exist.
     pub fn new(output_dir: &Path) -> Result<Self> {
-        Self::with_batch_size(output_dir, DEFAULT_BATCH_SIZE)
+        Ok(Self::with_sink(
+            ParquetSink::directory(output_dir)?,
+            DEFAULT_BATCH_SIZE,
+        ))
     }
 
     /// Create a new streaming Parquet writer with a custom batch size.
     pub fn with_batch_size(output_dir: &Path, batch_size: usize) -> Result<Self> {
-        // Create the output directory if it doesn't exist
-        if !output_dir.exists() {
-            fs::create_dir_all(output_dir).with_context(|| {
-                format!(
-                    "Failed to create output directory: {}",
-                    output_dir.display()
-                )
-            })?;
-        } else if !output_dir.is_dir() {
-            anyhow::bail!(
-                "Output path exists but is not a directory: {}",
-                output_dir.display()
-            );
-        }
+        Ok(Self::with_sink(
+            ParquetSink::directory(output_dir)?,
+            batch_size,
+        ))
+    }
 
-        let paths = ParquetPaths::new(output_dir);
+    /// Create a new streaming Parquet writer over an arbitrary sink, with the
+    /// default batch size.
+    pub fn for_sink(sink: ParquetSink) -> Self {
+        Self::with_sink(sink, DEFAULT_BATCH_SIZE)
+    }
+
+    /// Create a new streaming Parquet writer over an arbitrary sink.
+    pub fn with_sink(sink: ParquetSink, batch_size: usize) -> Self {
         let writer_props = build_writer_properties();
 
-        Ok(Self {
-            output_dir: output_dir.to_path_buf(),
-            paths,
+        Self {
+            sink,
             batch_size,
             writer_props,
             // Buffers use lazy allocation - they grow as needed to minimize
@@ -282,19 +286,7 @@ impl StreamingParquetWriter {
             tpu_op_writer: None,
             tpu_metric_writer: None,
             total_records: 0,
-        })
-    }
-
-    /// Get the output directory.
-    #[allow(dead_code)]
-    pub fn output_dir(&self) -> &Path {
-        &self.output_dir
-    }
-
-    /// Get the paths to all Parquet files.
-    #[allow(dead_code)]
-    pub fn paths(&self) -> &ParquetPaths {
-        &self.paths
+        }
     }
 
     /// Get the total number of records written.
@@ -320,18 +312,18 @@ impl StreamingParquetWriter {
 
     // Helper to create or get a writer
     fn get_or_create_writer<'a>(
-        writer_opt: &'a mut Option<ArrowWriter<File>>,
-        path: &Path,
+        writer_opt: &'a mut Option<TableWriter>,
+        sink: &ParquetSink,
+        table: &str,
         schema: Arc<Schema>,
         props: &WriterProperties,
-    ) -> Result<&'a mut ArrowWriter<File>> {
+    ) -> Result<&'a mut TableWriter> {
         if writer_opt.is_none() {
-            let file = File::create(path)
-                .with_context(|| format!("Failed to create file: {}", path.display()))?;
-            let writer =
-                ArrowWriter::try_new(file, schema, Some(props.clone())).with_context(|| {
-                    format!("Failed to create Parquet writer for: {}", path.display())
-                })?;
+            let out = sink
+                .open(table)
+                .with_context(|| format!("Failed to open parquet sink for table {table}"))?;
+            let writer = ArrowWriter::try_new(out, schema, Some(props.clone()))
+                .with_context(|| format!("Failed to create Parquet writer for table {table}"))?;
             *writer_opt = Some(writer);
         }
         Ok(writer_opt.as_mut().unwrap())
@@ -346,7 +338,8 @@ impl StreamingParquetWriter {
         let schema = trace::process_schema();
         let writer = Self::get_or_create_writer(
             &mut self.process_writer,
-            &self.paths.process,
+            &self.sink,
+            "process",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -366,7 +359,8 @@ impl StreamingParquetWriter {
         let schema = trace::thread_schema();
         let writer = Self::get_or_create_writer(
             &mut self.thread_writer,
-            &self.paths.thread,
+            &self.sink,
+            "thread",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -386,7 +380,8 @@ impl StreamingParquetWriter {
         let schema = trace::sched_slice_schema();
         let writer = Self::get_or_create_writer(
             &mut self.sched_slice_writer,
-            &self.paths.sched_slice,
+            &self.sink,
+            "sched_slice",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -411,7 +406,8 @@ impl StreamingParquetWriter {
         let schema = trace::thread_state_schema();
         let writer = Self::get_or_create_writer(
             &mut self.thread_state_writer,
-            &self.paths.thread_state,
+            &self.sink,
+            "thread_state",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -432,7 +428,8 @@ impl StreamingParquetWriter {
         let schema = trace::irq_slice_schema();
         let writer = Self::get_or_create_writer(
             &mut self.irq_slice_writer,
-            &self.paths.irq_slice,
+            &self.sink,
+            "irq_slice",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -453,7 +450,8 @@ impl StreamingParquetWriter {
         let schema = trace::softirq_slice_schema();
         let writer = Self::get_or_create_writer(
             &mut self.softirq_slice_writer,
-            &self.paths.softirq_slice,
+            &self.sink,
+            "softirq_slice",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -474,7 +472,8 @@ impl StreamingParquetWriter {
         let schema = trace::wakeup_new_schema();
         let writer = Self::get_or_create_writer(
             &mut self.wakeup_new_writer,
-            &self.paths.wakeup_new,
+            &self.sink,
+            "wakeup_new",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -494,7 +493,8 @@ impl StreamingParquetWriter {
         let schema = trace::process_exit_schema();
         let writer = Self::get_or_create_writer(
             &mut self.process_exit_writer,
-            &self.paths.process_exit,
+            &self.sink,
+            "process_exit",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -514,7 +514,8 @@ impl StreamingParquetWriter {
         let schema = trace::counter_schema();
         let writer = Self::get_or_create_writer(
             &mut self.counter_writer,
-            &self.paths.counter,
+            &self.sink,
+            "counter",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -535,7 +536,8 @@ impl StreamingParquetWriter {
         let schema = trace::counter_track_schema();
         let writer = Self::get_or_create_writer(
             &mut self.counter_track_writer,
-            &self.paths.counter_track,
+            &self.sink,
+            "counter_track",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -555,7 +557,8 @@ impl StreamingParquetWriter {
         let schema = trace::slice_schema();
         let writer = Self::get_or_create_writer(
             &mut self.slice_writer,
-            &self.paths.slice,
+            &self.sink,
+            "slice",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -575,7 +578,8 @@ impl StreamingParquetWriter {
         let schema = trace::track_schema();
         let writer = Self::get_or_create_writer(
             &mut self.track_writer,
-            &self.paths.track,
+            &self.sink,
+            "track",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -595,7 +599,8 @@ impl StreamingParquetWriter {
         let schema = trace::instant_schema();
         let writer = Self::get_or_create_writer(
             &mut self.instant_writer,
-            &self.paths.instant,
+            &self.sink,
+            "instant",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -615,7 +620,8 @@ impl StreamingParquetWriter {
         let schema = trace::args_schema();
         let writer = Self::get_or_create_writer(
             &mut self.args_writer,
-            &self.paths.args,
+            &self.sink,
+            "args",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -635,7 +641,8 @@ impl StreamingParquetWriter {
         let schema = trace::instant_args_schema();
         let writer = Self::get_or_create_writer(
             &mut self.instant_args_writer,
-            &self.paths.instant_args,
+            &self.sink,
+            "instant_args",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -655,7 +662,8 @@ impl StreamingParquetWriter {
         let schema = trace::stack_schema();
         let writer = Self::get_or_create_writer(
             &mut self.stack_writer,
-            &self.paths.stack,
+            &self.sink,
+            "stack",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -675,7 +683,8 @@ impl StreamingParquetWriter {
         let schema = trace::stack_sample_schema();
         let writer = Self::get_or_create_writer(
             &mut self.stack_sample_writer,
-            &self.paths.stack_sample,
+            &self.sink,
+            "stack_sample",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -696,7 +705,8 @@ impl StreamingParquetWriter {
         let schema = trace::network_interface_schema();
         let writer = Self::get_or_create_writer(
             &mut self.network_interface_writer,
-            &self.paths.network_interface,
+            &self.sink,
+            "network_interface",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -716,7 +726,8 @@ impl StreamingParquetWriter {
         let schema = trace::socket_connection_schema();
         let writer = Self::get_or_create_writer(
             &mut self.socket_connection_writer,
-            &self.paths.socket_connection,
+            &self.sink,
+            "socket_connection",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -736,7 +747,8 @@ impl StreamingParquetWriter {
         let schema = trace::clock_snapshot_schema();
         let writer = Self::get_or_create_writer(
             &mut self.clock_snapshot_writer,
-            &self.paths.clock_snapshot,
+            &self.sink,
+            "clock_snapshot",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -757,7 +769,8 @@ impl StreamingParquetWriter {
         let schema = trace::sysinfo_schema();
         let writer = Self::get_or_create_writer(
             &mut self.sysinfo_writer,
-            &self.paths.sysinfo,
+            &self.sink,
+            "sysinfo",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -776,7 +789,8 @@ impl StreamingParquetWriter {
         let schema = trace::cpu_info_schema();
         let writer = Self::get_or_create_writer(
             &mut self.cpu_info_writer,
-            &self.paths.cpu_info,
+            &self.sink,
+            "cpu_info",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -796,7 +810,8 @@ impl StreamingParquetWriter {
         let schema = trace::network_syscall_schema();
         let writer = Self::get_or_create_writer(
             &mut self.network_syscall_writer,
-            &self.paths.network_syscall,
+            &self.sink,
+            "network_syscall",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -816,7 +831,8 @@ impl StreamingParquetWriter {
         let schema = trace::network_packet_schema();
         let writer = Self::get_or_create_writer(
             &mut self.network_packet_writer,
-            &self.paths.network_packet,
+            &self.sink,
+            "network_packet",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -836,7 +852,8 @@ impl StreamingParquetWriter {
         let schema = trace::network_socket_schema();
         let writer = Self::get_or_create_writer(
             &mut self.network_socket_writer,
-            &self.paths.network_socket,
+            &self.sink,
+            "network_socket",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -856,7 +873,8 @@ impl StreamingParquetWriter {
         let schema = trace::network_poll_schema();
         let writer = Self::get_or_create_writer(
             &mut self.network_poll_writer,
-            &self.paths.network_poll,
+            &self.sink,
+            "network_poll",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -876,7 +894,8 @@ impl StreamingParquetWriter {
         let schema = trace::network_dns_schema();
         let writer = Self::get_or_create_writer(
             &mut self.network_dns_writer,
-            &self.paths.network_dns,
+            &self.sink,
+            "network_dns",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -894,7 +913,8 @@ impl StreamingParquetWriter {
         let schema = trace::memory_rss_schema();
         let writer = Self::get_or_create_writer(
             &mut self.memory_rss_writer,
-            &self.paths.memory_rss,
+            &self.sink,
+            "memory_rss",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -911,7 +931,8 @@ impl StreamingParquetWriter {
         let schema = trace::memory_map_schema();
         let writer = Self::get_or_create_writer(
             &mut self.memory_map_writer,
-            &self.paths.memory_map,
+            &self.sink,
+            "memory_map",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -928,7 +949,8 @@ impl StreamingParquetWriter {
         let schema = trace::memory_fault_schema();
         let writer = Self::get_or_create_writer(
             &mut self.memory_fault_writer,
-            &self.paths.memory_fault,
+            &self.sink,
+            "memory_fault",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -945,7 +967,8 @@ impl StreamingParquetWriter {
         let schema = trace::memory_alloc_schema();
         let writer = Self::get_or_create_writer(
             &mut self.memory_alloc_writer,
-            &self.paths.memory_alloc,
+            &self.sink,
+            "memory_alloc",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -964,7 +987,8 @@ impl StreamingParquetWriter {
         let schema = trace::tpu_device_schema();
         let writer = Self::get_or_create_writer(
             &mut self.tpu_device_writer,
-            &self.paths.tpu_device,
+            &self.sink,
+            "tpu_device",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -984,7 +1008,8 @@ impl StreamingParquetWriter {
         let schema = trace::tpu_op_schema();
         let writer = Self::get_or_create_writer(
             &mut self.tpu_op_writer,
-            &self.paths.tpu_op,
+            &self.sink,
+            "tpu_op",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -1004,7 +1029,8 @@ impl StreamingParquetWriter {
         let schema = trace::tpu_metric_schema();
         let writer = Self::get_or_create_writer(
             &mut self.tpu_metric_writer,
-            &self.paths.tpu_metric,
+            &self.sink,
+            "tpu_metric",
             schema.clone(),
             &self.writer_props,
         )?;
@@ -1111,8 +1137,8 @@ impl Drop for StreamingParquetWriter {
         if has_open_writers {
             eprintln!(
                 "Warning: StreamingParquetWriter dropped without calling finish(). \
-                 Parquet files in {:?} may be incomplete or corrupted.",
-                self.output_dir
+                 Parquet output at {} may be incomplete or corrupted.",
+                self.sink
             );
             // Attempt to close writers to at least flush pending data
             if let Err(e) = self.close_writers() {
@@ -2733,6 +2759,7 @@ mod tests {
     use arrow::array::AsArray;
     use arrow::array::{Float64Array, Int32Array, Int64Array};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
     use tempfile::TempDir;
 
     #[test]

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -10,7 +10,7 @@ use crate::events::SystingProbeRecorder;
 use crate::marker_recorder::MarkerRecorder;
 use crate::memory_recorder::MemoryRecorder;
 use crate::network_recorder::NetworkRecorder;
-use crate::parquet::StreamingParquetWriter;
+use crate::parquet::{ParquetSink, StreamingParquetWriter};
 use crate::perf_recorder::PerfCounterRecorder;
 use crate::record::{RecordCollector, SharedCollector};
 use crate::ringbuf::RingBuffer;
@@ -1008,44 +1008,41 @@ impl SessionRecorder {
 
     /// Initialize streaming parquet output for the scheduler, stack, and network recorders.
     /// This must be called BEFORE recording starts to enable streaming of events
-    /// directly to parquet files.
-    ///
-    /// # Arguments
-    /// * `output_dir` - Directory to write Parquet files to
-    pub fn init_streaming_parquet(&self, output_dir: &Path) -> Result<()> {
+    /// directly to the configured `sink` (a local directory or a socket
+    /// endpoint; see [`ParquetSink`]).
+    pub fn init_streaming_output(&self, sink: &ParquetSink) -> Result<()> {
+        let make_writer = || StreamingParquetWriter::for_sink(sink.clone());
+        let spill_dir = sink.spill_dir();
+
         // Set up streaming collector for scheduler events
-        let writer = StreamingParquetWriter::new(output_dir)?;
         self.event_recorder
             .lock()
             .unwrap()
-            .set_streaming_collector(Box::new(writer));
+            .set_streaming_collector(Box::new(make_writer()));
 
         // Set up streaming collector for stack recorder so samples are written
         // incrementally instead of buffered for the entire trace. Unique stack
-        // contents are spilled to a tempfile in the output directory so they
-        // don't accumulate in memory until end-of-trace symbolization.
-        let stack_writer = StreamingParquetWriter::new(output_dir)?;
+        // contents are spilled to a tempfile under the sink's spill directory so
+        // they don't accumulate in memory until end-of-trace symbolization.
         {
             let mut stack_recorder = self.stack_recorder.lock().unwrap();
-            stack_recorder.set_streaming_collector(Box::new(stack_writer));
-            stack_recorder.set_spill_dir(output_dir);
+            stack_recorder.set_streaming_collector(Box::new(make_writer()));
+            stack_recorder.set_spill_dir(spill_dir);
         }
 
         // Set up streaming collector for network recorder (events emitted immediately)
-        let network_writer = StreamingParquetWriter::new(output_dir)?;
         self.network_recorder
             .lock()
             .unwrap()
-            .set_streaming_collector(Box::new(network_writer));
+            .set_streaming_collector(Box::new(make_writer()));
 
         // Set up streaming collector for memory recorder (events emitted
         // immediately). Its unique alloc/fault stacks spill to disk like the
         // stack recorder's.
-        let memory_writer = StreamingParquetWriter::new(output_dir)?;
         {
             let mut memory_recorder = self.memory_recorder.lock().unwrap();
-            memory_recorder.set_streaming_collector(Box::new(memory_writer));
-            memory_recorder.set_spill_dir(output_dir);
+            memory_recorder.set_streaming_collector(Box::new(make_writer()));
+            memory_recorder.set_spill_dir(spill_dir);
         }
 
         // Set up streaming collector for probe recorder (events emitted on completion).
@@ -1053,11 +1050,10 @@ impl SessionRecorder {
         // generate_parquet_trace - markers share the track/slice/instant tables with
         // probe events, so writing them through a separate writer would clobber the
         // probe data (see the marker-write step in generate_parquet_trace).
-        let probe_writer = StreamingParquetWriter::new(output_dir)?;
         self.probe_recorder
             .lock()
             .unwrap()
-            .set_streaming_collector(Box::new(probe_writer));
+            .set_streaming_collector(Box::new(make_writer()));
 
         // The perf-counter and sysinfo (CPU frequency) recorders both emit
         // counter / counter_track rows, which map to the same counter.parquet /
@@ -1065,8 +1061,7 @@ impl SessionRecorder {
         // separate writers both would create the same files and the last one to
         // finish would clobber the other's data. Track IDs come from the shared
         // CounterTrackIdGenerator so they never collide either.
-        let counter_writer =
-            SharedCollector::new(Box::new(StreamingParquetWriter::new(output_dir)?));
+        let counter_writer = SharedCollector::new(Box::new(make_writer()));
         self.perf_counter_recorder
             .lock()
             .unwrap()
@@ -1078,11 +1073,10 @@ impl SessionRecorder {
 
         // Set up streaming collector for TPU metrics recorder (if enabled).
         if let Some(ref tpu_metrics) = self.tpu_metrics_recorder {
-            let tpu_metrics_writer = StreamingParquetWriter::new(output_dir)?;
             tpu_metrics
                 .lock()
                 .unwrap()
-                .set_streaming_collector(Box::new(tpu_metrics_writer));
+                .set_streaming_collector(Box::new(make_writer()));
         }
 
         Ok(())
@@ -1090,12 +1084,11 @@ impl SessionRecorder {
 
     /// Finalize the streaming parquet trace.
     ///
-    /// Flushes all streaming recorders and writes process/thread metadata to the
-    /// parquet output directory. Streaming must have been initialized via
-    /// `init_streaming_parquet` before calling this method.
+    /// Flushes all streaming recorders and writes process/thread metadata to
+    /// the configured sink. Streaming must have been initialized via
+    /// `init_streaming_output` before calling this method.
     pub fn generate_parquet_trace(
         &self,
-        output_dir: &Path,
         tpu_recorder: Option<crate::tpu::recorder::TpuRecorder>,
     ) -> Result<()> {
         // Per-stage elapsed lines below let fleet log pipelines attribute
@@ -1106,7 +1099,7 @@ impl SessionRecorder {
             eprintln!("{} in {:.2}s", label, start.elapsed().as_secs_f64());
             *start = std::time::Instant::now();
         };
-        eprintln!("Generating Parquet trace to {output_dir:?}...");
+        eprintln!("Generating Parquet trace...");
 
         // Get the end timestamp for flushing streaming data
         let end_ts = get_clock_value(libc::CLOCK_BOOTTIME) as i64;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,0 +1,445 @@
+//! Socket-streaming output transport.
+//!
+//! When `--stream <URI>` is passed, each parquet table is written to its own
+//! socket connection instead of a local file. The wire format is one ASCII
+//! header line followed by the raw parquet bytes:
+//!
+//! ```text
+//! systing/<SCHEMA_VERSION> <table_name>\n
+//! PAR1 ... <parquet row groups + footer> ... PAR1
+//! ```
+//!
+//! The receiver strips the header line and writes the remainder verbatim to
+//! `<table>.parquet`; the resulting directory is bit-identical to what
+//! `--output-dir` would have produced and can be fed to `parquet_to_duckdb`.
+//!
+//! Connections are opened lazily — one per table per writer instance — so a
+//! typical trace opens 20–30 connections over its lifetime.
+
+use std::fmt;
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::{bail, Context, Result};
+use vsock::{VsockAddr, VsockListener, VsockStream};
+
+use crate::duckdb::SCHEMA_VERSION;
+
+/// Prefix on every stream header line.
+pub const HEADER_PREFIX: &str = "systing/";
+
+/// Closed allowlist of table names the streaming writer can emit.
+///
+/// The receiver rejects any header whose table name is not in this list.
+/// Keep in sync with the writer fields in `StreamingParquetWriter` and the
+/// file stems in `ParquetPaths::new`.
+pub const TABLE_NAMES: &[&str] = &[
+    "process",
+    "thread",
+    "sched_slice",
+    "thread_state",
+    "irq_slice",
+    "softirq_slice",
+    "wakeup_new",
+    "process_exit",
+    "counter",
+    "counter_track",
+    "slice",
+    "track",
+    "instant",
+    "args",
+    "instant_args",
+    "stack",
+    "stack_sample",
+    "network_interface",
+    "socket_connection",
+    "network_syscall",
+    "network_packet",
+    "network_socket",
+    "network_poll",
+    "network_dns",
+    "memory_rss",
+    "memory_map",
+    "memory_fault",
+    "memory_alloc",
+    "clock_snapshot",
+    "sysinfo",
+    "cpu_info",
+    "tpu_device",
+    "tpu_op",
+    "tpu_metric",
+];
+
+/// A socket endpoint to stream parquet data to (or, on the receive side,
+/// to listen on).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StreamTarget {
+    /// AF_VSOCK — for guest-VM → host. From inside a guest, the host is CID 2.
+    Vsock { cid: u32, port: u32 },
+    /// AF_UNIX stream socket.
+    Unix(PathBuf),
+    /// TCP — `host:port`. Unauthenticated; for trusted networks only.
+    Tcp(String),
+}
+
+/// Wrap a connected socket in a 64 KiB BufWriter and emit the header line.
+/// Generic so the BufWriter holds the concrete stream type — avoids an extra
+/// `Box<dyn Write>` vtable hop under parquet's own internal buffering.
+fn dial<S: Write + Send + 'static>(sock: S, table: &str) -> Result<Box<dyn Write + Send>> {
+    let mut w = BufWriter::with_capacity(64 * 1024, sock);
+    writeln!(w, "{HEADER_PREFIX}{SCHEMA_VERSION} {table}")?;
+    Ok(Box::new(w))
+}
+
+impl StreamTarget {
+    /// Dial the target, write the protocol header for `table`, and return a
+    /// buffered writer ready for parquet bytes.
+    pub fn connect(&self, table: &str) -> Result<Box<dyn Write + Send>> {
+        if !TABLE_NAMES.contains(&table) {
+            bail!(
+                "table {table:?} missing from stream::TABLE_NAMES allowlist; \
+                 update the constant when adding a new parquet table"
+            );
+        }
+        match self {
+            Self::Vsock { cid, port } => dial(
+                VsockStream::connect(&VsockAddr::new(*cid, *port))
+                    .with_context(|| format!("vsock connect to cid={cid} port={port}"))?,
+                table,
+            ),
+            Self::Unix(path) => dial(
+                UnixStream::connect(path)
+                    .with_context(|| format!("unix connect to {}", path.display()))?,
+                table,
+            ),
+            Self::Tcp(addr) => dial(
+                TcpStream::connect(addr).with_context(|| format!("tcp connect to {addr}"))?,
+                table,
+            ),
+        }
+    }
+
+    /// Bind a listener on this target. Returns an iterator of accepted
+    /// `(stream, peer_description)` pairs for the receive side.
+    pub fn listen(&self) -> Result<StreamListener> {
+        match self {
+            Self::Vsock { cid, port } => {
+                let l = VsockListener::bind(&VsockAddr::new(*cid, *port))
+                    .with_context(|| format!("vsock bind cid={cid} port={port}"))?;
+                Ok(StreamListener::Vsock(l))
+            }
+            Self::Unix(path) => {
+                if path.exists() {
+                    std::fs::remove_file(path).with_context(|| {
+                        format!("removing existing socket path {}", path.display())
+                    })?;
+                }
+                let l = UnixListener::bind(path)
+                    .with_context(|| format!("unix bind {}", path.display()))?;
+                Ok(StreamListener::Unix(l))
+            }
+            Self::Tcp(addr) => {
+                let l = TcpListener::bind(addr).with_context(|| format!("tcp bind {addr}"))?;
+                Ok(StreamListener::Tcp(l))
+            }
+        }
+    }
+}
+
+/// Listener side, mirroring [`StreamTarget`].
+pub enum StreamListener {
+    Vsock(VsockListener),
+    Unix(UnixListener),
+    Tcp(TcpListener),
+}
+
+impl StreamListener {
+    /// Block until a peer connects; return the byte stream and a peer label
+    /// for logging.
+    pub fn accept(&self) -> io::Result<(Box<dyn Read + Send>, String)> {
+        match self {
+            Self::Vsock(l) => {
+                let (s, addr) = l.accept()?;
+                Ok((Box::new(s), format!("vsock:{addr:?}")))
+            }
+            Self::Unix(l) => {
+                let (s, _addr) = l.accept()?;
+                Ok((Box::new(s), "unix".to_string()))
+            }
+            Self::Tcp(l) => {
+                let (s, addr) = l.accept()?;
+                Ok((Box::new(s), format!("tcp:{addr}")))
+            }
+        }
+    }
+}
+
+impl FromStr for StreamTarget {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        if let Some(rest) = s.strip_prefix("vsock://") {
+            let (cid, port) = rest
+                .split_once(':')
+                .context("vsock URI must be vsock://CID:PORT")?;
+            let cid: u32 = match cid {
+                "any" => libc::VMADDR_CID_ANY,
+                "host" => libc::VMADDR_CID_HOST,
+                "local" => libc::VMADDR_CID_LOCAL,
+                n => n.parse().context("invalid vsock CID")?,
+            };
+            let port: u32 = port.parse().context("invalid vsock port")?;
+            Ok(Self::Vsock { cid, port })
+        } else if let Some(rest) = s.strip_prefix("unix://") {
+            if rest.is_empty() {
+                bail!("unix URI must be unix://PATH");
+            }
+            Ok(Self::Unix(PathBuf::from(rest)))
+        } else if let Some(rest) = s.strip_prefix("tcp://") {
+            if rest.is_empty() {
+                bail!("tcp URI must be tcp://HOST:PORT");
+            }
+            Ok(Self::Tcp(rest.to_string()))
+        } else {
+            bail!("unknown stream URI scheme: {s} (expected vsock://, unix://, or tcp://)")
+        }
+    }
+}
+
+impl fmt::Display for StreamTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Vsock { cid, port } => write!(f, "vsock://{cid}:{port}"),
+            Self::Unix(p) => write!(f, "unix://{}", p.display()),
+            Self::Tcp(a) => write!(f, "tcp://{a}"),
+        }
+    }
+}
+
+/// Parsed stream header line.
+#[derive(Debug, PartialEq, Eq)]
+pub struct StreamHeader {
+    pub schema_version: u32,
+    pub table: String,
+}
+
+impl StreamHeader {
+    /// Read and validate the header line from a freshly-accepted stream.
+    ///
+    /// Returns the parsed header and a `BufReader` positioned at the first
+    /// parquet byte. Rejects unknown table names so a hostile peer cannot
+    /// influence the output path.
+    pub fn read(stream: Box<dyn Read + Send>) -> Result<(Self, BufReader<Box<dyn Read + Send>>)> {
+        const MAX_HEADER_LEN: u64 = 256;
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        reader
+            .by_ref()
+            .take(MAX_HEADER_LEN)
+            .read_line(&mut line)
+            .context("reading stream header line")?;
+        if !line.ends_with('\n') {
+            bail!("stream header missing newline within {MAX_HEADER_LEN} bytes");
+        }
+        let line = line.trim_end_matches(['\r', '\n']);
+        let rest = line.strip_prefix(HEADER_PREFIX).with_context(|| {
+            format!("bad stream header (no {HEADER_PREFIX:?} prefix): {line:?}")
+        })?;
+        let (ver, table) = rest
+            .split_once(' ')
+            .with_context(|| format!("bad stream header (no table name): {line:?}"))?;
+        let schema_version: u32 = ver
+            .parse()
+            .with_context(|| format!("bad schema version in header: {line:?}"))?;
+        if !TABLE_NAMES.contains(&table) {
+            bail!("stream header names unknown table {table:?}; rejecting connection");
+        }
+        Ok((
+            Self {
+                schema_version,
+                table: table.to_string(),
+            },
+            reader,
+        ))
+    }
+}
+
+/// Reference receiver for `systing --stream`. Used by `systing-util receive`
+/// and the integration tests.
+pub mod receive {
+    use super::*;
+    use std::fs::{self, File, OpenOptions};
+    use std::net::ToSocketAddrs;
+    use std::os::unix::fs::OpenOptionsExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Listen on `target` and write each incoming table stream into
+    /// `output_dir`. Runs until interrupted (Ctrl-C) or the listener errors.
+    pub fn run(
+        target: StreamTarget,
+        output_dir: PathBuf,
+        insecure_tcp_bind_any: bool,
+    ) -> Result<()> {
+        if let StreamTarget::Tcp(addr) = &target {
+            // Resolve through the same path TcpListener::bind uses, then check
+            // for the unspecified address — string prefix matching would miss
+            // forms like `0:PORT` or `00.0.0.0:PORT`.
+            let bind_any = addr
+                .to_socket_addrs()
+                .with_context(|| format!("resolving tcp bind address {addr}"))?
+                .any(|sa| sa.ip().is_unspecified());
+            if bind_any && !insecure_tcp_bind_any {
+                bail!(
+                    "refusing to bind TCP listener on {addr} (any-address) without \
+                     --insecure-tcp-bind-any; this transport is unauthenticated"
+                );
+            }
+        }
+
+        fs::create_dir_all(&output_dir)
+            .with_context(|| format!("creating output dir {}", output_dir.display()))?;
+        let listener = target.listen()?;
+        eprintln!(
+            "Listening on {target} (schema version {SCHEMA_VERSION}); writing to {}",
+            output_dir.display()
+        );
+
+        let active = Arc::new(AtomicUsize::new(0));
+        loop {
+            let (stream, peer) = match listener.accept() {
+                Ok(x) => x,
+                Err(e) => {
+                    eprintln!("accept error: {e}");
+                    return Err(e.into());
+                }
+            };
+            let dir = output_dir.clone();
+            let active = active.clone();
+            active.fetch_add(1, Ordering::SeqCst);
+            std::thread::spawn(move || {
+                if let Err(e) = handle_connection(stream, &peer, &dir) {
+                    eprintln!("[{peer}] error: {e:#}");
+                }
+                let n = active.fetch_sub(1, Ordering::SeqCst) - 1;
+                eprintln!("[{peer}] closed ({n} active)");
+            });
+        }
+    }
+
+    /// Read one stream's header, validate it, and copy the parquet body into
+    /// `dir`. Exposed for the integration test in `tests/stream_unix.rs`.
+    pub fn handle_connection(stream: Box<dyn Read + Send>, peer: &str, dir: &Path) -> Result<()> {
+        let (hdr, mut body) = StreamHeader::read(stream)?;
+        if hdr.schema_version != SCHEMA_VERSION {
+            bail!(
+                "schema version mismatch: peer sent {}, this build is {}",
+                hdr.schema_version,
+                SCHEMA_VERSION
+            );
+        }
+        let (path, mut out) = create_unique(dir, &hdr.table)
+            .with_context(|| format!("creating output file for table {}", hdr.table))?;
+        eprintln!(
+            "[{peer}] table={} -> {}",
+            hdr.table,
+            path.file_name().unwrap().to_string_lossy()
+        );
+        let bytes = io::copy(&mut body, &mut out)?;
+        eprintln!("[{peer}] table={} {} bytes", hdr.table, bytes);
+        Ok(())
+    }
+
+    /// Atomically create `<dir>/<table>.parquet`, or `<dir>/<table>.<n>.parquet`
+    /// for the first free `n`. Uses `create_new` so two handler threads racing
+    /// on the same table can't both claim the same path. Multiple
+    /// `StreamingParquetWriter` instances may emit the same table, so the
+    /// receiver may see e.g. two `process` streams in one trace; duckdb's
+    /// `read_parquet` glob handles the suffixed files.
+    fn create_unique(dir: &Path, table: &str) -> io::Result<(PathBuf, File)> {
+        for n in 0.. {
+            let p = if n == 0 {
+                dir.join(format!("{table}.parquet"))
+            } else {
+                dir.join(format!("{table}.{n}.parquet"))
+            };
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&p)
+            {
+                Ok(f) => return Ok((p, f)),
+                Err(e) if e.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_roundtrip() {
+        for s in [
+            "vsock://2:5000",
+            "unix:///tmp/systing.sock",
+            "tcp://127.0.0.1:9000",
+        ] {
+            let t: StreamTarget = s.parse().unwrap();
+            assert_eq!(t.to_string(), s);
+        }
+    }
+
+    #[test]
+    fn parse_vsock() {
+        assert_eq!(
+            "vsock://2:5000".parse::<StreamTarget>().unwrap(),
+            StreamTarget::Vsock { cid: 2, port: 5000 }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_scheme() {
+        assert!("http://foo".parse::<StreamTarget>().is_err());
+        assert!("vsock://2".parse::<StreamTarget>().is_err());
+        assert!("unix://".parse::<StreamTarget>().is_err());
+    }
+
+    #[test]
+    fn header_rejects_oversize() {
+        let buf = vec![b'x'; 4096];
+        let r: Box<dyn Read + Send> = Box::new(io::Cursor::new(buf));
+        let err = StreamHeader::read(r)
+            .err()
+            .expect("expected error")
+            .to_string();
+        assert!(err.contains("newline"), "{err}");
+    }
+
+    #[test]
+    fn header_rejects_unknown_table() {
+        let buf = format!("{HEADER_PREFIX}{SCHEMA_VERSION} ../../etc/passwd\n").into_bytes();
+        let r: Box<dyn Read + Send> = Box::new(io::Cursor::new(buf));
+        assert!(StreamHeader::read(r).is_err());
+    }
+
+    #[test]
+    fn header_accepts_known_table() {
+        let buf = format!("{HEADER_PREFIX}{SCHEMA_VERSION} sched_slice\nPAR1rest").into_bytes();
+        let r: Box<dyn Read + Send> = Box::new(io::Cursor::new(buf));
+        let (hdr, mut rest) = StreamHeader::read(r).unwrap();
+        assert_eq!(hdr.table, "sched_slice");
+        assert_eq!(hdr.schema_version, SCHEMA_VERSION);
+        let mut body = Vec::new();
+        rest.read_to_end(&mut body).unwrap();
+        assert_eq!(body, b"PAR1rest");
+    }
+}

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -568,6 +568,8 @@ pub struct Config {
     pub output: PathBuf,
     /// Skip trace generation, keep only parquet
     pub parquet_only: bool,
+    /// Stream parquet over a socket instead of writing to disk
+    pub stream: Option<crate::stream::StreamTarget>,
     /// Command to run and trace (everything after --)
     pub run_command: Option<Vec<String>>,
 }
@@ -617,6 +619,7 @@ impl Default for Config {
             output_dir: PathBuf::from("./traces"),
             output: PathBuf::from("trace.pb"),
             parquet_only: false,
+            stream: None,
             run_command: None,
         }
     }
@@ -3115,12 +3118,15 @@ pub fn systing(
     recorder.snapshot_clocks();
 
     // Initialize streaming parquet output BEFORE recording starts
-    prepare_output_dir(&opts.output_dir)?;
-    recorder.init_streaming_parquet(&opts.output_dir)?;
-    eprintln!(
-        "Initialized streaming parquet output to {:?}",
-        opts.output_dir
-    );
+    let sink = match &opts.stream {
+        Some(target) => crate::parquet::ParquetSink::stream(target.clone())?,
+        None => {
+            prepare_output_dir(&opts.output_dir)?;
+            crate::parquet::ParquetSink::Directory(opts.output_dir.clone())
+        }
+    };
+    recorder.init_streaming_output(&sink)?;
+    eprintln!("Initialized streaming parquet output to {sink}");
 
     // TPU profiling thread handle - declared outside skel scope so it can be
     // joined after skel is dropped.
@@ -3700,17 +3706,25 @@ pub fn systing(
     };
 
     // Write trace files directly to Parquet
-    println!(
-        "Writing Parquet trace files to {}...",
-        opts.output_dir.display()
-    );
-    recorder.generate_parquet_trace(&opts.output_dir, tpu_recorder)?;
+    println!("Writing Parquet trace files to {sink}...");
+    recorder.generate_parquet_trace(tpu_recorder)?;
     println!("Successfully wrote Parquet trace files");
 
     // The recorder still holds process/thread maps, symbolizer caches, etc.
     // Drop our reference before the DuckDB/Perfetto conversion so that memory
     // is available to the importer rather than stacked underneath it.
     drop(recorder);
+
+    // In stream mode there's nothing on local disk to convert; the receiver
+    // owns assembly into duckdb. The private spill tempdir is removed when the
+    // last `Arc<TempDir>` clone drops — `drop(recorder)` above released the
+    // ones held inside the boxed writers, and `drop(sink)` releases the
+    // final one here.
+    if let Some(target) = &opts.stream {
+        drop(sink);
+        println!("Streamed trace to {target}");
+        return Ok(0);
+    }
 
     // Generate output trace (unless --parquet-only)
     // Format is auto-detected from the file extension

--- a/tests/stream_unix.rs
+++ b/tests/stream_unix.rs
@@ -1,0 +1,94 @@
+//! Integration test for `--stream unix://...`.
+//!
+//! Starts a unix-socket receiver in a background thread, runs a short systing
+//! trace with `Config::stream` set, and asserts that the receiver produced
+//! valid parquet files. Requires root/BPF privileges; marked `#[ignore]`.
+//!
+//! Run with: ./scripts/run-integration-tests.sh stream_unix
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use systing::stream::{receive, StreamTarget};
+use systing::{bump_memlock_rlimit, systing, Config};
+use tempfile::TempDir;
+
+/// Tables that the default recorder set always emits.
+const EXPECTED_TABLES: &[&str] = &["sched_slice", "sysinfo", "process", "thread"];
+
+/// Return Ok(rows) once `path` is a complete parquet file with rows; Err
+/// otherwise. A half-written file (footer not yet flushed) fails to parse,
+/// so this also serves as the "io::copy finished" check.
+fn parquet_rows(path: &Path) -> anyhow::Result<i64> {
+    let file = std::fs::File::open(path)?;
+    let reader = SerializedFileReader::new(file)?;
+    Ok(reader.metadata().file_metadata().num_rows())
+}
+
+#[test]
+#[ignore = "requires root/BPF; run via ./scripts/run-integration-tests.sh"]
+fn test_stream_unix_roundtrip() {
+    bump_memlock_rlimit().expect("memlock rlimit");
+
+    let recv_dir = TempDir::new().unwrap();
+    let sock_path = recv_dir.path().join("systing.sock");
+    let target = StreamTarget::Unix(sock_path.clone());
+
+    // Receiver: accept loop in a background thread, one handler thread per
+    // connection. `done` counts connections that have fully drained, so the
+    // main thread can wait for in-flight streams to finish after systing()
+    // returns.
+    let listener = target.listen().expect("bind unix listener");
+    let out = recv_dir.path().to_path_buf();
+    let done = Arc::new(AtomicUsize::new(0));
+    let done_rx = done.clone();
+    std::thread::spawn(move || loop {
+        let (stream, peer) = match listener.accept() {
+            Ok(x) => x,
+            Err(_) => return,
+        };
+        let out = out.clone();
+        let done = done.clone();
+        std::thread::spawn(move || {
+            receive::handle_connection(stream, &peer, &out).expect("handle_connection");
+            done.fetch_add(1, Ordering::SeqCst);
+        });
+    });
+
+    // Sender: short whole-system trace, default recorders, streamed.
+    let cfg = Config {
+        duration: 2,
+        stream: Some(target.clone()),
+        ..Default::default()
+    };
+    systing(cfg, None).expect("systing run");
+
+    // Connections close after the parquet footer is written (inside
+    // generate_parquet_trace, before systing() returns), so by now every
+    // sender is done; we only need to wait for the receiver-side io::copy
+    // threads to drain. Poll the actual postcondition — every expected file
+    // is a complete parquet with rows — rather than guessing a settle time.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let ready = EXPECTED_TABLES.iter().all(|t| {
+            let p = recv_dir.path().join(format!("{t}.parquet"));
+            matches!(parquet_rows(&p), Ok(n) if n > 0)
+        });
+        if ready {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for receiver output; {} connections handled",
+            done_rx.load(Ordering::SeqCst)
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        done_rx.load(Ordering::SeqCst) >= EXPECTED_TABLES.len(),
+        "receiver handled fewer connections than expected tables"
+    );
+}


### PR DESCRIPTION
## Summary
- `--stream vsock://CID:PORT | unix://PATH | tcp://HOST:PORT` makes systing send each parquet table over its own socket connection (header line `systing/<SCHEMA_VERSION> <table>\n` + raw parquet bytes) instead of writing to `--output-dir`. Intended for tracing inside a guest VM.
- `StreamingParquetWriter` now writes through a `ParquetSink` abstraction (`ArrowWriter<Box<dyn Write + Send>>`); the directory path is unchanged.
- `systing-util receive <URI> -o <dir>` is a reference receiver: validates the table name against a closed allowlist, atomically creates `<table>[.N].parquet` (mode 0600), and refuses any-address TCP binds without `--insecure-tcp-bind-any`.
- Spill files in stream mode go to a private auto-removed tempdir. See `STREAMING.md` for the full protocol.

## Test plan
- [x] `cargo fmt` / `cargo clippy --all-targets -D warnings`
- [x] `cargo test` (363 unit tests, including new `StreamTarget` parse + `StreamHeader` allowlist/length-cap tests)
- [x] `./scripts/run-integration-tests.sh stream_unix` — end-to-end BPF trace streamed over a unix socket, received parquet validated
- [x] Full integration suite: `trace_validation` (31), `perf_counter`, `memory_recorder` (5), `network_throughput`, `analyze_commands` — all pass
- [ ] Manual vsock test from a real guest (needs a VM; not coverable in CI)

https://claude.ai/code/session_01KMMSQtvZHyhrfirySVJRj7