### PR TITLE
Drop manual RLIMIT_MEMLOCK handling; check caps via capget(2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod utid;
 
 // Re-export for convenience
 pub use parquet_paths::ParquetPaths;
-pub use systing_core::{bump_memlock_rlimit, get_available_recorders, systing, Config};
+pub use systing_core::{get_available_recorders, systing, Config};
 pub use validation::{
     cross_validate_parquet_perfetto, validate_duckdb, validate_parquet_dir,
     validate_perfetto_trace, ValidationError, ValidationResult, ValidationWarning,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,6 @@ use systing::stream::StreamTarget;
 use systing::traced_command;
 use systing::{get_available_recorders, systing, Config};
 
-/// Memory lock limit used for capability probing (128 MiB).
-/// This value should match the limit in systing_core::MEMLOCK_RLIMIT_BYTES.
-const CAPABILITY_PROBE_MEMLOCK_BYTES: u64 = 128 << 20;
-
 #[derive(Debug, Parser)]
 struct Command {
     /// Increase verbosity (can be supplied multiple times).
@@ -283,30 +279,52 @@ fn process_recorder_options(opts: &mut Command) -> Result<()> {
     Ok(())
 }
 
-/// Check if we have the necessary capabilities to run BPF programs
-/// We need CAP_BPF, CAP_PERFMON, or at a minimum CAP_SYS_ADMIN
+/// Check if we have the necessary capabilities to run BPF programs.
+///
+/// systing needs to load BPF programs and open tracing perf events, which on
+/// modern kernels requires CAP_BPF + CAP_PERFMON (split out in 5.8), or
+/// CAP_SYS_ADMIN as the legacy catch-all. Checks the effective set via
+/// capget(2) so file capabilities / ambient caps are honored even when
+/// euid != 0.
 fn has_bpf_capabilities() -> bool {
-    // If we're root, we have all capabilities
-    if unsafe { libc::getuid() } == 0 {
-        return true;
+    const LINUX_CAPABILITY_VERSION_3: u32 = 0x20080522;
+    const CAP_SYS_ADMIN: u32 = 21;
+    const CAP_PERFMON: u32 = 38;
+    const CAP_BPF: u32 = 39;
+
+    #[repr(C)]
+    struct CapHeader {
+        version: u32,
+        pid: libc::c_int,
+    }
+    #[repr(C)]
+    #[derive(Default, Clone, Copy)]
+    struct CapData {
+        effective: u32,
+        permitted: u32,
+        inheritable: u32,
     }
 
-    // Try to load a simple BPF program to check if we have the necessary capabilities
-    // This is the most reliable way to check since capability APIs may not accurately
-    // reflect the effective capabilities needed for BPF
-
-    // For now, we'll do a simple check: if we can bump memlock rlimit,
-    // we likely have capabilities. Otherwise, we need systemd-run.
-    // A better approach would be to actually try loading a minimal BPF program,
-    // but that's more complex.
-
-    // Check if we can set rlimit - this is a good proxy for having needed capabilities
-    let rlimit = libc::rlimit {
-        rlim_cur: CAPABILITY_PROBE_MEMLOCK_BYTES,
-        rlim_max: CAPABILITY_PROBE_MEMLOCK_BYTES,
+    let mut hdr = CapHeader {
+        version: LINUX_CAPABILITY_VERSION_3,
+        pid: 0,
     };
+    let mut data = [CapData::default(); 2];
+    // SAFETY: hdr/data are #[repr(C)] with the kernel ABI layout for capget(2);
+    // version 3 always writes exactly two cap_data structs.
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_capget,
+            &mut hdr as *mut CapHeader,
+            data.as_mut_ptr(),
+        )
+    };
+    if ret != 0 {
+        return false;
+    }
 
-    unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) == 0 }
+    let has = |cap: u32| data[(cap >> 5) as usize].effective & (1u32 << (cap & 31)) != 0;
+    has(CAP_SYS_ADMIN) || (has(CAP_BPF) && has(CAP_PERFMON))
 }
 
 /// Re-execute the current program using systemd-run to get elevated privileges

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -59,9 +59,6 @@ const SW_CLOCK_SAMPLE_PERIOD_NS: u64 = 1_000_000_000 / PERF_CLOCK_TARGET_FREQ_HZ
 /// available from sysfs: assume a 3 GHz part, sampling at ~1kHz.
 const DEFAULT_CYCLES_SAMPLE_PERIOD: u64 = 3_000_000_000 / PERF_CLOCK_TARGET_FREQ_HZ;
 
-/// Memory lock limit for BPF programs (128 MiB)
-const MEMLOCK_RLIMIT_BYTES: u64 = 128 << 20;
-
 /// Sleep duration before stopping in continuous mode (1 second)
 const CONTINUOUS_MODE_STOP_DELAY_SECS: u64 = 1;
 
@@ -623,24 +620,6 @@ impl Default for Config {
             run_command: None,
         }
     }
-}
-
-/// Bump the memory lock rlimit for BPF programs.
-pub fn bump_memlock_rlimit() -> Result<()> {
-    let rlimit = libc::rlimit {
-        rlim_cur: MEMLOCK_RLIMIT_BYTES,
-        rlim_max: MEMLOCK_RLIMIT_BYTES,
-    };
-
-    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
-        bail!(
-            "Failed to increase RLIMIT_MEMLOCK to {} bytes ({} MiB). This is required for BPF programs.",
-            MEMLOCK_RLIMIT_BYTES,
-            MEMLOCK_RLIMIT_BYTES >> 20
-        );
-    }
-
-    Ok(())
 }
 
 /// Prepare the output directory for parquet files.
@@ -3092,8 +3071,6 @@ pub fn systing(
     mut opts: Config,
     mut traced_child: Option<crate::traced_command::TracedChild>,
 ) -> Result<i32> {
-    bump_memlock_rlimit()?;
-
     // Add the traced child's PID to the PID filter list
     if let Some(ref child) = traced_child {
         opts.pid.push(child.pid);

--- a/tests/analyze_commands.rs
+++ b/tests/analyze_commands.rs
@@ -17,13 +17,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use systing::{bump_memlock_rlimit, systing, validate_duckdb, Config};
+use systing::{systing, validate_duckdb, Config};
 use tempfile::TempDir;
-
-/// Helper to set up the environment for BPF tests.
-fn setup_bpf_environment() {
-    bump_memlock_rlimit().expect("Failed to bump memlock rlimit");
-}
 
 /// Run systing-analyze with the given arguments, returning the full Output.
 fn run_analyze(args: &[&str]) -> Output {
@@ -35,8 +30,6 @@ fn run_analyze(args: &[&str]) -> Output {
 
 /// Record a trace to DuckDB and return the temp dir (kept alive by caller).
 fn record_trace() -> (TempDir, std::path::PathBuf) {
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let duckdb_path = dir.path().join("trace.duckdb");
 

--- a/tests/memory_recorder.rs
+++ b/tests/memory_recorder.rs
@@ -8,7 +8,7 @@
 //! ./scripts/run-integration-tests.sh memory_recorder
 //! ```
 
-use systing::{bump_memlock_rlimit, systing, Config};
+use systing::{systing, Config};
 use tempfile::TempDir;
 
 /// Size of each allocation in the workload. Must be well above the glibc
@@ -23,15 +23,9 @@ const RSS_SANITY_CEILING_BYTES: i64 = 64 * 1024 * 1024 * 1024;
 const UTIDS_FOR_PID: &str =
     "(SELECT t.utid FROM thread t JOIN process p ON p.upid = t.upid WHERE p.pid = ?)";
 
-fn setup_bpf_environment() {
-    bump_memlock_rlimit().expect("Failed to bump memlock rlimit");
-}
-
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_memory_recorder_e2e() {
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -241,8 +235,6 @@ fn test_memory_recorder_e2e() {
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_memory_alloc_e2e() {
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -385,7 +377,6 @@ fn test_memory_alloc_e2e() {
 /// `malloc` rows attributed to the workload pid. Returns 0 if no parquet was
 /// emitted (i.e., no uprobes attached / no events).
 fn count_malloc_rows(run_cmd: Vec<String>, memory_alloc_lib: Option<String>) -> i64 {
-    setup_bpf_environment();
     let dir = TempDir::new().expect("Failed to create temp dir");
     let traced_child =
         systing::traced_command::spawn_traced_child(&run_cmd).expect("Failed to spawn child");
@@ -447,7 +438,6 @@ fn test_memory_alloc_jemalloc_preload() {
         return;
     };
     eprintln!("Using LD_PRELOAD={jemalloc}");
-    setup_bpf_environment();
     let dir = TempDir::new().expect("Failed to create temp dir");
 
     // Spawn the workload independently (not via spawn_traced_child) so that

--- a/tests/perf_counter.rs
+++ b/tests/perf_counter.rs
@@ -12,7 +12,7 @@
 //! ./scripts/run-integration-tests.sh perf_counter
 //! ```
 
-use systing::{bump_memlock_rlimit, systing, Config};
+use systing::{systing, Config};
 use tempfile::TempDir;
 
 /// Counters used by the test. `instructions` and `cpu-cycles` are backed by
@@ -24,10 +24,6 @@ const TEST_COUNTERS: [&str; 2] = ["instructions", "cpu-cycles"];
 /// Long enough for the sampling clock to read the counters many times and for
 /// the CPU-frequency poller (100ms interval) to record plenty of samples.
 const RECORDING_SECS: u64 = 3;
-
-fn setup_bpf_environment() {
-    bump_memlock_rlimit().expect("Failed to bump memlock rlimit");
-}
 
 /// Returns true if the host can actually open the hardware perf counters used
 /// by the test. Virtualized/CI hosts frequently expose no PMU at all; in that
@@ -75,8 +71,6 @@ fn perf_counters_available() -> bool {
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_perf_counter_with_cpu_frequency() {
-    setup_bpf_environment();
-
     if !perf_counters_available() {
         eprintln!("skipping: hardware perf counters are not available on this host");
         return;

--- a/tests/stream_unix.rs
+++ b/tests/stream_unix.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use systing::stream::{receive, StreamTarget};
-use systing::{bump_memlock_rlimit, systing, Config};
+use systing::{systing, Config};
 use tempfile::TempDir;
 
 /// Tables that the default recorder set always emits.
@@ -31,8 +31,6 @@ fn parquet_rows(path: &Path) -> anyhow::Result<i64> {
 #[test]
 #[ignore = "requires root/BPF; run via ./scripts/run-integration-tests.sh"]
 fn test_stream_unix_roundtrip() {
-    bump_memlock_rlimit().expect("memlock rlimit");
-
     let recv_dir = TempDir::new().unwrap();
     let sock_path = recv_dir.path().join("systing.sock");
     let target = StreamTarget::Unix(sock_path.clone());

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -19,10 +19,7 @@ use common::{
 };
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use systing::{
-    bump_memlock_rlimit, systing, validate_duckdb, validate_parquet_dir, validate_perfetto_trace,
-    Config,
-};
+use systing::{systing, validate_duckdb, validate_parquet_dir, validate_perfetto_trace, Config};
 use tempfile::TempDir;
 
 /// Total recording duration for netns tests (seconds). Workloads loop until
@@ -37,11 +34,6 @@ const VALIDATION_SUITE_DURATION_SECS: u64 = 4;
 
 /// Recording duration for the network suite (seconds).
 const NETWORK_SUITE_DURATION_SECS: u64 = 3;
-
-/// Helper to set up the environment for BPF tests.
-fn setup_bpf_environment() {
-    bump_memlock_rlimit().expect("Failed to bump memlock rlimit");
-}
 
 /// Read the current process's cgroup v2 path (relative to the cgroup root, e.g.
 /// "/system.slice/foo.service") from `/proc/self/cgroup`. Returns `None` on a
@@ -363,8 +355,6 @@ fn test_e2e_validation_suite() {
 
     const EXIT_DEAD: i32 = 16;
     const EXIT_ZOMBIE: i32 = 32;
-
-    setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
@@ -927,8 +917,6 @@ fn test_e2e_network_suite() {
     use std::thread;
     use std::time::Duration;
 
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -1217,8 +1205,6 @@ fn test_network_recording_with_netns() {
     use std::thread;
     use std::time::Duration;
 
-    setup_bpf_environment();
-
     let netns_env = NetnsTestEnv::new(NetworkTestConfig::default())
         .expect("Failed to create network namespace test environment");
 
@@ -1370,8 +1356,6 @@ fn test_network_recording_with_netns() {
 fn test_pystacks_symbol_resolution() {
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::fs::File;
-
-    setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
@@ -1601,8 +1585,6 @@ fn test_pystacks_sleep_stacks() {
     use std::collections::HashMap;
     use std::fs::File;
 
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -1807,8 +1789,6 @@ fn test_pystacks_frame_error_rate() {
         }
     };
 
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -1958,8 +1938,6 @@ def level1():
 fn run_pystacks_version_test(full_ver: &str) {
     let python_bin = pyenv_python(full_ver);
 
-    setup_bpf_environment();
-
     let defs = r#"
 def pystacks_version_test_function():
     """Function that does busy work to show up in profiling."""
@@ -2085,8 +2063,6 @@ fn run_pystacks_workload_and_check(
     target_function: &str,
     duration: u64,
 ) {
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -2313,8 +2289,6 @@ def systing_mp_step():
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_pystacks_fork_exec() {
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -2444,8 +2418,6 @@ fn test_run_command_suite() {
     use arrow::array::{Int32Array, StringArray};
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
     use std::fs::File;
-
-    setup_bpf_environment();
 
     // --- Sub-test: basic command with perfetto output (combines basic + perfetto_output) ---
     eprintln!("\n  run command: basic (sleep 0.5, with perfetto)...");
@@ -2706,8 +2678,6 @@ fn test_pystacks_run_and_trace() {
     use std::fs::File;
     use std::io::Write;
 
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
 
@@ -2810,8 +2780,6 @@ fn test_pystacks_exec_discovery() {
     use std::fs::File;
     use std::io::Write;
     use std::os::unix::fs::PermissionsExt;
-
-    setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let trace_path = dir.path().join("trace.pb");
@@ -3095,7 +3063,6 @@ fn test_e2e_marker_recording() {
     // value of 0xFFFFFFFFFFFFFC31 (sign-extended). This exercises the sign-extended
     // calling convention. See test_e2e_marker_recording_zero_extended for the
     // zero-extended path (e.g. Python ctypes, some JVM runtimes).
-    setup_bpf_environment();
 
     let dir = run_marker_recording(MarkerWorkloadConfig {
         mode: -975i64,
@@ -3199,8 +3166,6 @@ fn test_e2e_marker_recording_zero_extended() {
         "zero-extended and sign-extended representations must differ for this test to be meaningful"
     );
 
-    setup_bpf_environment();
-
     let dir = run_marker_recording(MarkerWorkloadConfig {
         mode: mode_zero_extended,
         range_name: "ZETrack:ze_range",
@@ -3258,8 +3223,6 @@ fn test_e2e_marker_recording_zero_extended() {
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_e2e_marker_syscall_no_clobber() {
-    setup_bpf_environment();
-
     // The marker workload's own syscalls (faccessat2 + nanosleep) provide the
     // syscall activity, so no extra workload is needed.
     let dir = run_marker_recording(MarkerWorkloadConfig {
@@ -3438,8 +3401,6 @@ fn test_e2e_marker_threshold() {
     use std::time::{Duration, Instant};
     use syscalls::Sysno;
 
-    setup_bpf_environment();
-
     let dir = TempDir::new().expect("Failed to create temp dir");
     let stop = Arc::new(AtomicBool::new(false));
     let stop_clone = stop.clone();
@@ -3541,8 +3502,6 @@ fn test_e2e_marker_duration_threshold() {
 
     use arrow::array::Int64Array;
     use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-
-    setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
     let stop = Arc::new(AtomicBool::new(false));
@@ -3777,8 +3736,6 @@ fn run_events_recording(config_json: &str, workload: EventsWorkload) -> TempDir 
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_e2e_tracepoint_instant() {
-    setup_bpf_environment();
-
     let config_json = r#"
     {
         "events": [
@@ -3824,8 +3781,6 @@ fn test_e2e_tracepoint_instant() {
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_e2e_tracepoint_range() {
-    setup_bpf_environment();
-
     let config_json = r#"
     {
         "events": [
@@ -3874,8 +3829,6 @@ fn test_e2e_tracepoint_range() {
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_e2e_kprobe_range() {
-    setup_bpf_environment();
-
     let config_json = r#"
     {
         "events": [
@@ -3924,8 +3877,6 @@ fn test_e2e_kprobe_range() {
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_e2e_syscall_tracking() {
-    setup_bpf_environment();
-
     let dir = run_events_recording_with(EventsWorkload::FileOpen, |config| {
         config.syscalls = true;
     });
@@ -3961,8 +3912,6 @@ fn test_e2e_syscall_tracking() {
 #[test]
 #[ignore] // Requires root/BPF privileges
 fn test_e2e_event_scope_cpu() {
-    setup_bpf_environment();
-
     let config_json = r#"
     {
         "events": [
@@ -4016,8 +3965,6 @@ fn test_network_dns_resolution() {
     use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
-
-    setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
 
@@ -4138,8 +4085,6 @@ fn test_e2e_only_cpu_stacks_emits_samples() {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::thread;
-
-    setup_bpf_environment();
 
     let dir = TempDir::new().expect("Failed to create temp dir");
 


### PR DESCRIPTION
## Summary
- Remove `bump_memlock_rlimit()` and all callers/re-exports. BPF stopped using `RLIMIT_MEMLOCK` in v5.11 (memcg accounting; `80ee81e0403c` / `3ac1f01b43b6`), and libbpf ≥0.7 — we vendor 1.5.0 — auto-handles the rlimit on older kernels. Our version unconditionally set `rlim_max=128MiB`, which lowered the limit under root and `bail!()`ed with EPERM on non-root callers that had `CAP_BPF` but a sub-128MiB hard limit.
- Replace the `setrlimit`-based `has_bpf_capabilities()` probe with a real `capget(2)` check of the effective set for `CAP_SYS_ADMIN || (CAP_BPF && CAP_PERFMON)`. Drops the `getuid()==0` short-circuit since capget subsumes it and is correct for cap-dropped root.
- Bump to 1.10.2.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (unit + doc tests)
- [ ] `./scripts/run-integration-tests.sh` (CI)