### PR TITLE
Add --sample-freq to set CPU stack-sampling rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.2"
+version = "1.10.3"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.10.2"
+version = "1.10.3"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/docs/USAGE.adoc
+++ b/docs/USAGE.adoc
@@ -216,6 +216,14 @@ If you are having too many missed events you can increase this size.
 NOTE: You will always have missed events for perf events, this is normal.
 Only increase this if you are having misseed sched events, as that affects the trace quality.
 
+=== *--sample-freq* _HZ_
+
+Sets the target CPU stack-sampling rate in samples per second per CPU.
+The default is 1000.
+Sampling runs in fixed-period mode: with `--sw-event` (cpu-clock) the rate is exact; with the cpu-cycles hardware event it is the rate at the CPU's maximum frequency, so a throttled CPU samples proportionally slower.
+The chosen period is recorded in the trace's `sysinfo.sample_period` column.
+Higher values give finer-grained profiles at the cost of more overhead and larger traces; very high rates may be throttled by the kernel's perf interrupt-rate limit and can increase ringbuf drops (raise `--ringbuf-size-mib` if needed).
+
 === *--sw-event*
 
 If recording inside of a VM, this can be specified to enable the software events necessary to record stack traces.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub mod utid;
 
 // Re-export for convenience
 pub use parquet_paths::ParquetPaths;
-pub use systing_core::{get_available_recorders, systing, Config};
+pub use systing_core::{get_available_recorders, systing, Config, DEFAULT_SAMPLE_FREQ_HZ};
 pub use validation::{
     cross_validate_parquet_perfetto, validate_duckdb, validate_parquet_dir,
     validate_perfetto_trace, ValidationError, ValidationResult, ValidationWarning,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,12 @@ struct Command {
     trace_event_pid: Vec<u32>,
     #[arg(short, long)]
     sw_event: bool,
+    /// Target CPU stack-sampling rate in Hz (samples per second per CPU). The
+    /// perf clock event runs in fixed-period mode, so this is exact for
+    /// --sw-event and the rate at max CPU frequency for cpu-cycles.
+    #[arg(long, default_value_t = systing::DEFAULT_SAMPLE_FREQ_HZ,
+          value_parser = clap::value_parser!(u64).range(1..))]
+    sample_freq: u64,
     #[arg(long)]
     cpu_frequency: bool,
     #[arg(long)]
@@ -164,6 +170,7 @@ impl From<Command> for Config {
             trace_event: cmd.trace_event,
             trace_event_pid: cmd.trace_event_pid,
             sw_event: cmd.sw_event,
+            sample_freq: cmd.sample_freq,
             cpu_frequency: cmd.cpu_frequency,
             perf_counter: cmd.perf_counter,
             no_cpu_stack_traces: cmd.no_cpu_stack_traces,

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -44,20 +44,16 @@ use libbpf_rs::{
 
 use plain::Plain;
 
-/// Target stack-sampling rate for the perf clock event, in samples per second
-/// per CPU. The clock event runs in period mode (see `PerfOpenEvents::
-/// open_events`), so this target is hit exactly for the cpu-clock software
-/// event and at max CPU frequency for the cpu-cycles hardware event; a
-/// throttled CPU samples proportionally slower.
-const PERF_CLOCK_TARGET_FREQ_HZ: u64 = 1000;
+/// Default target stack-sampling rate for the perf clock event, in samples per
+/// second per CPU. Overridable via `--sample-freq`. The clock event runs in
+/// period mode (see `PerfOpenEvents::open_events`), so this target is hit
+/// exactly for the cpu-clock software event and at max CPU frequency for the
+/// cpu-cycles hardware event; a throttled CPU samples proportionally slower.
+pub const DEFAULT_SAMPLE_FREQ_HZ: u64 = 1000;
 
-/// Sample period for the cpu-clock software clock event, which counts
-/// nanoseconds: 1ms between samples = PERF_CLOCK_TARGET_FREQ_HZ.
-const SW_CLOCK_SAMPLE_PERIOD_NS: u64 = 1_000_000_000 / PERF_CLOCK_TARGET_FREQ_HZ;
-
-/// Fallback cpu-cycles sample period when no CPU frequency information is
-/// available from sysfs: assume a 3 GHz part, sampling at ~1kHz.
-const DEFAULT_CYCLES_SAMPLE_PERIOD: u64 = 3_000_000_000 / PERF_CLOCK_TARGET_FREQ_HZ;
+/// Assumed CPU clock rate for picking a cpu-cycles sample period when no
+/// cpufreq data is available from sysfs.
+const FALLBACK_CPU_FREQ_HZ: u64 = 3_000_000_000;
 
 /// Sleep duration before stopping in continuous mode (1 second)
 const CONTINUOUS_MODE_STOP_DELAY_SECS: u64 = 1;
@@ -498,6 +494,8 @@ pub struct Config {
     pub trace_event_pid: Vec<u32>,
     /// Use software events instead of hardware
     pub sw_event: bool,
+    /// Target CPU stack-sampling rate in Hz (samples/sec/CPU)
+    pub sample_freq: u64,
     /// Record CPU frequency
     pub cpu_frequency: bool,
     /// Perf counters to collect
@@ -583,6 +581,7 @@ impl Default for Config {
             trace_event: Vec::new(),
             trace_event_pid: Vec::new(),
             sw_event: false,
+            sample_freq: DEFAULT_SAMPLE_FREQ_HZ,
             cpu_frequency: false,
             perf_counter: Vec::new(),
             no_cpu_stack_traces: false,
@@ -2186,20 +2185,20 @@ fn configure_bpf_skeleton(
     Ok(())
 }
 
-/// Pick the cpu-cycles sample period that yields PERF_CLOCK_TARGET_FREQ_HZ
-/// samples/sec at the fastest CPU's maximum frequency. Using the max across
-/// CPUs (rather than per-CPU periods) keeps the period uniform so every sample
-/// in the trace represents the same number of cycles; slower or throttled CPUs
-/// simply sample at a proportionally lower rate.
-fn cycles_sample_period() -> u64 {
-    let max_khz = crate::session_recorder::cpu_freq_limits()
+/// Pick the cpu-cycles sample period that yields `target_freq_hz` samples/sec
+/// at the fastest CPU's maximum frequency. Using the max across CPUs (rather
+/// than per-CPU periods) keeps the period uniform so every sample in the trace
+/// represents the same number of cycles; slower or throttled CPUs simply
+/// sample at a proportionally lower rate.
+fn cycles_sample_period(target_freq_hz: u64) -> u64 {
+    let max_hz = crate::session_recorder::cpu_freq_limits()
         .into_iter()
         .filter_map(|c| c.max_freq_khz)
-        .max();
-    match max_khz {
-        Some(khz) if khz > 0 => (khz as u64 * 1000) / PERF_CLOCK_TARGET_FREQ_HZ,
-        _ => DEFAULT_CYCLES_SAMPLE_PERIOD,
-    }
+        .max()
+        .filter(|&khz| khz > 0)
+        .map(|khz| khz as u64 * 1000)
+        .unwrap_or(FALLBACK_CPU_FREQ_HZ);
+    (max_hz / target_freq_hz).max(1)
 }
 
 fn setup_perf_events(
@@ -2218,9 +2217,12 @@ fn setup_perf_events(
     let mut perf_links = Vec::new();
     let mut event_files_vec = Vec::new();
 
+    // Clamp to avoid divide-by-zero for library callers that bypass the
+    // clap range(1..) validator on --sample-freq.
+    let target_hz = opts.sample_freq.max(1);
     let sw_clock_sampling = ClockSamplingConfig {
         event: "cpu-clock",
-        period: SW_CLOCK_SAMPLE_PERIOD_NS,
+        period: (1_000_000_000 / target_hz).max(1),
     };
 
     // Set up clock perf events with automatic VM detection and fallback
@@ -2247,7 +2249,7 @@ fn setup_perf_events(
         } else {
             ClockSamplingConfig {
                 event: "cpu-cycles",
-                period: cycles_sample_period(),
+                period: cycles_sample_period(target_hz),
             }
         };
 


### PR DESCRIPTION
## Summary
- Adds a `--sample-freq <HZ>` option (default 1000) so the CPU stack-sampling rate is configurable instead of hardcoded, letting users trade profile resolution against overhead and trace size.
- Replaces the derived 1 kHz constants with `DEFAULT_SAMPLE_FREQ_HZ` / `FALLBACK_CPU_FREQ_HZ` and threads `Config::sample_freq` into `setup_perf_events`, computing the cpu-clock (ns) and cpu-cycles periods from it. The chosen period still flows into `sysinfo.sample_period`, so no schema change.
- Clamps `sample_freq` to `>=1` inside `setup_perf_events` so library callers that bypass the clap `range(1..)` validator can't trigger a divide-by-zero; periods are floored at 1 so a zero period never reaches `perf_event_open`.
- Docs entry in `USAGE.adoc`; version bumped to 1.10.3.

## Test plan
- [x] `cargo fmt` / `cargo clippy --all-targets` / `cargo test` clean
- [x] `systing --help` shows the option with default 1000; `--sample-freq 0` rejected by clap; `--sample-freq 99` accepted
- [x] Full integration suite (`trace_validation`, `perf_counter`, `memory_recorder`, `analyze_commands`, `network_throughput`, `stream_unix`) — 40 passed, 0 failed