### PR TITLE
Fix test_memory_alloc_jemalloc_preload race on slow machines

### DIFF
--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -2486,6 +2486,15 @@ fn dedup_by_inode(raw: HashMap<String, &'static str>) -> (Vec<(String, &'static 
 fn discover_allocator_paths(pids: &[u32]) -> (Vec<(String, &'static str)>, usize) {
     let mut raw: HashMap<String, &'static str> = HashMap::new();
     'pid: for pid in pids {
+        // A dead pid fails every lookup below the same way a live one with no
+        // matching maps entry does; name the actual problem. Common when the
+        // target is short-lived and BPF load (which precedes attach) is slow.
+        if !std::path::Path::new(&format!("/proc/{pid}")).exists() {
+            eprintln!(
+                "Warning: memory-alloc: target pid {pid} exited before uprobe attach; skipping"
+            );
+            continue 'pid;
+        }
         for name in OVERRIDE_ALLOCATORS {
             if let Some(p) = resolve_library_path_for_pid(*pid, name) {
                 raw.entry(p).or_insert(name);

--- a/tests/memory_recorder.rs
+++ b/tests/memory_recorder.rs
@@ -444,16 +444,25 @@ fn test_memory_alloc_jemalloc_preload() {
     // allocator discovery scans a process that has already exec'd and mapped
     // jemalloc. Run-command mode attaches pre-exec and would only see the
     // parent's libc.
+    //
+    // The workload must stay alive until uprobe attach, which happens after
+    // BPF skeleton load — tens of seconds on slow/emulated machines (e.g.
+    // QEMU TCG). A fixed iteration count races that, so it runs until the
+    // test drops a stop file (with a deadline as the orphan backstop should
+    // the test die before cleanup).
+    let stop_file = dir.path().join("stop-workload");
     let mut child = std::process::Command::new("python3")
         .env("LD_PRELOAD", &jemalloc)
         .arg("-c")
         .arg(
-            "import time\n\
-             for _ in range(1000):\n\
+            "import os, sys, time\n\
+             deadline = time.time() + 600\n\
+             while time.time() < deadline and not os.path.exists(sys.argv[1]):\n\
              \x20 objs=[bytes(512) for _ in range(200)]\n\
              \x20 del objs\n\
              \x20 time.sleep(0.005)\n",
         )
+        .arg(&stop_file)
         .spawn()
         .expect("Failed to spawn jemalloc workload");
     let child_pid = child.id();
@@ -484,8 +493,15 @@ fn test_memory_alloc_jemalloc_preload() {
     };
     let exit_code = systing(config, None).expect("systing recording failed");
     assert_eq!(exit_code, 0);
+    let exited_early = child.try_wait().expect("try_wait failed");
+    let _ = std::fs::write(&stop_file, b"");
     let _ = child.kill();
     let _ = child.wait();
+    assert!(
+        exited_early.is_none(),
+        "workload exited before the trace completed (status {exited_early:?}); \
+         it must outlive BPF load + attach + the 2s trace window"
+    );
 
     assert!(
         dir.path().join("memory_alloc.parquet").exists(),


### PR DESCRIPTION
`test_memory_alloc_jemalloc_preload` fails consistently on slow machines — observed under QEMU TCG (no KVM) on the repo's own vmtest kernel (`bzImage-v6.12-bpf` from the vmtest-kernels release).

## What happens

The test spawns a finite python3 workload (1000 × ~5 ms iterations ≈ 8 s), then runs systing with the memory-alloc recorder. Allocator discovery and uprobe attach only happen after the BPF skeleton loads, and under TCG that takes ~22–24 s — by then the workload pid is gone. `discover_allocator_paths` fails a dead pid's maps lookup the same way it fails a live pid with no allocator, so it silently attaches zero uprobes, `memory_alloc.parquet` is never written, and the test dies on the misleading "discovery missed jemalloc?" assertion.

Timestamped in-VM repro (T0 = systing invoke):

- workload exited at T+7.8 s (8.25 s after its spawn)
- skeleton load finished and discovery ran at T+21.6 s — 13.8 s after the workload died; systing logged `Warning: memory-alloc recorder could not locate an allocator … no uprobes attached`
- control run against a long-lived preloaded pid in the same VM: 11 uprobes attached — the mechanism is fine, the workload just has to be alive when attach happens

## Fix

- The workload now runs until the test drops a stop file (with a 10-minute deadline as the orphan backstop), so it survives arbitrarily slow skeleton load.
- After the trace, the test asserts the workload outlived the trace window — a recurrence of this race now fails with the actual reason instead of pointing at discovery.
- `discover_allocator_paths` warns when a target pid is already dead, making the silent-skip case diagnosable from stderr.

Tested under QEMU TCG: memory_recorder target now 5/5 (was 4/5). `cargo clippy --all-targets -- -D warnings` and unit tests clean.
