### PR TITLE
Add contextual labels and gVisor island bridging for unresolvable frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.10.3"
+version = "1.10.4"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub mod perfetto;
 pub mod pystacks;
 pub mod record;
 pub mod ringbuf;
+pub mod sandbox_maps;
 pub mod sched;
 pub mod session_recorder;
 pub mod stack_recorder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,10 @@ struct Command {
     /// Enable debuginfod for enhanced symbol resolution (requires DEBUGINFOD_URLS environment variable)
     #[arg(long)]
     enable_debuginfod: bool,
+    /// Render frames that fail symbolization as bare hex instead of contextual
+    /// labels like "unknown ([gvisor:runtime]) <0x...>" or "unknown ([jit:node]) <0x...>"
+    #[arg(long)]
+    no_frame_labels: bool,
     /// Disable scheduler event tracing (sched_* tracepoints and scheduler event recorder)
     #[arg(long)]
     no_sched: bool,
@@ -182,6 +186,7 @@ impl From<Command> for Config {
             pystacks_pids: Vec::new(), // CLI doesn't expose this yet, uses discovery
             pystacks_debug: cmd.pystacks_debug,
             enable_debuginfod: cmd.enable_debuginfod,
+            no_frame_labels: cmd.no_frame_labels,
             no_sched: cmd.no_sched,
             syscalls: cmd.syscalls,
             markers: cmd.markers,

--- a/src/sandbox_maps.rs
+++ b/src/sandbox_maps.rs
@@ -1,0 +1,501 @@
+//! Host-side analysis of a process's memory map for symbolizing sandboxed
+//! (gVisor/runsc) workloads and labeling otherwise-unresolvable frames.
+//!
+//! Under gVisor's systrap platform, guest code executes in *stub* processes
+//! whose address spaces mirror the guest's. Guest ELF text is mostly backed by
+//! gofer-donated host file descriptors (symbolizable through
+//! `/proc/<pid>/map_files/`), but three things still defeat a
+//! `/proc/<pid>/maps`-driven symbolizer:
+//!
+//! 1. systrap's syscall patching COW-breaks the 4KiB text pages containing
+//!    executed syscall sites into the Sentry's `runsc-memory` memfd, leaving
+//!    memfd "islands" inside file-backed text. Island addresses still
+//!    correspond to functions of the original file, so they can be recovered
+//!    by re-deriving the file offset from the file-backed neighbors
+//!    ("bridging", see [`ProcessMaps::bridge_for`]).
+//! 2. The sysmsg/trampoline code every guest syscall executes lives in
+//!    memfd/anonymous mappings outside the guest image range — those frames
+//!    are gVisor runtime overhead, not application code.
+//! 3. Anonymous guest ranges (JIT output, copied-up pages) are backed by the
+//!    memory-pool memfd whose offsets have no relation to any file.
+//!
+//! This module parses `/proc/<pid>/maps` once per process at symbolization
+//! time and answers, per address: "can this be bridged to a file?" and if
+//! not, "what is the most specific label we can attach instead of raw hex?".
+//! The labels reuse systing's existing miss format (`unknown (<module>)
+//! <0xADDR>`), so downstream consumers see a module-shaped string:
+//! `[gvisor:runtime]`, `[jit:<runtime>]`, or the real module basename when
+//! only the symbol lookup failed.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// What backs one `/proc/<pid>/maps` entry, as far as classification cares.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Backing {
+    /// Regular file with an absolute path (may be namespace-relative and
+    /// unopenable by path; `map_files` still works).
+    File(PathBuf),
+    /// A memfd (`/memfd:<name> (deleted)`); gVisor's memory pools land here.
+    Memfd(String),
+    /// No backing object at all (pure anonymous).
+    Anon,
+    /// Bracketed pseudo-entries (`[vdso]`, `[stack]`, ...) and
+    /// `anon_inode:...` style components.
+    Special(String),
+}
+
+#[derive(Debug, Clone)]
+struct MapEntry {
+    start: u64,
+    end: u64,
+    exec: bool,
+    /// File offset field of the maps line (memfd offsets are pool offsets
+    /// and meaningless for ELF math; file offsets are real).
+    offset: u64,
+    backing: Backing,
+}
+
+/// Result of a bridge lookup: symbolize `file_offset` against the ELF that
+/// is reachable through `map_files_path` (a namespace-immune magic link of a
+/// *file-backed* neighbor entry, not of the island itself).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BridgedAddr {
+    pub map_files_path: PathBuf,
+    pub module_name: String,
+    pub file_offset: u64,
+}
+
+/// Per-process map analysis. Build once per tgid with [`ProcessMaps::load`]
+/// (or [`ProcessMaps::parse`] for tests), query per unresolved address.
+#[derive(Debug, Default)]
+pub struct ProcessMaps {
+    tgid: i32,
+    entries: Vec<MapEntry>,
+    /// Any gVisor memory-pool memfd present (`runsc-memory`,
+    /// `systrap-memory`).
+    gvisor_memfd: bool,
+    /// `/proc/<tgid>/exe` resolves to a runsc binary.
+    gvisor_exe: bool,
+    /// Basename of a known JIT runtime found among file-backed entries.
+    jit_runtime: Option<&'static str>,
+    /// Address span of file-backed guest mappings ([lo, hi)); executable
+    /// pool/anon mappings outside this span are runtime scaffolding, inside
+    /// are guest anon (JIT or data made executable).
+    file_span: Option<(u64, u64)>,
+}
+
+/// memfd names used by gVisor for application/stub memory. Entries here mark
+/// a process as sandbox-related and their mappings as pool-backed.
+const GVISOR_MEMFDS: &[&str] = &["runsc-memory", "systrap-memory"];
+
+/// Module basenames whose presence marks a process as running a JIT runtime;
+/// anonymous executable guest pages in such a process are labeled
+/// `[jit:<tag>]`. Deliberately short and conservative.
+const JIT_RUNTIMES: &[(&str, &str)] = &[
+    ("node", "node"),
+    ("libnode", "node"),
+    ("libjvm", "jvm"),
+    ("libpython3", "python"),
+    ("libv8", "v8"),
+];
+
+impl ProcessMaps {
+    /// Read and analyze `/proc/<tgid>/maps`. Returns `None` when the process
+    /// is gone or unreadable — callers fall back to plain hex rendering.
+    pub fn load(tgid: i32) -> Option<Self> {
+        let maps = fs::read_to_string(format!("/proc/{tgid}/maps")).ok()?;
+        let exe = fs::read_link(format!("/proc/{tgid}/exe"))
+            .ok()
+            .and_then(|p| {
+                p.file_name()
+                    .and_then(|f| f.to_str())
+                    .map(|s| s.to_string())
+            })
+            .unwrap_or_default();
+        Some(Self::parse(tgid, &maps, &exe))
+    }
+
+    /// Analyze pre-read maps content. `exe_basename` is the resolved
+    /// basename of `/proc/<tgid>/exe` ("" when unknown).
+    pub fn parse(tgid: i32, maps: &str, exe_basename: &str) -> Self {
+        let mut pm = ProcessMaps {
+            tgid,
+            // The sandbox re-execs /proc/self/exe so its comm is "exe", but
+            // the exe link still resolves to the runsc binary; stubs inherit
+            // it across fork.
+            gvisor_exe: exe_basename.starts_with("runsc"),
+            ..Default::default()
+        };
+
+        for line in maps.lines() {
+            let Some(entry) = parse_maps_line(line) else {
+                continue;
+            };
+            match &entry.backing {
+                Backing::Memfd(name) if GVISOR_MEMFDS.iter().any(|m| name == m) => {
+                    pm.gvisor_memfd = true;
+                }
+                Backing::File(path) => {
+                    if let Some(base) = path.file_name().and_then(|f| f.to_str()) {
+                        for (prefix, tag) in JIT_RUNTIMES {
+                            if base.starts_with(prefix) {
+                                pm.jit_runtime = Some(tag);
+                            }
+                        }
+                    }
+                    let (lo, hi) = pm.file_span.unwrap_or((u64::MAX, 0));
+                    pm.file_span = Some((lo.min(entry.start), hi.max(entry.end)));
+                }
+                _ => {}
+            }
+            pm.entries.push(entry);
+        }
+        pm
+    }
+
+    /// Whether this process belongs to a gVisor sandbox (Sentry, gofer, or a
+    /// stub mirroring a guest address space).
+    pub fn is_gvisor(&self) -> bool {
+        self.gvisor_exe || self.gvisor_memfd
+    }
+
+    fn entry_for(&self, addr: u64) -> Option<&MapEntry> {
+        // Entries are in address order as read from /proc.
+        self.entries
+            .iter()
+            .find(|e| e.start <= addr && addr < e.end)
+    }
+
+    /// If `addr` falls in a pool-memfd island whose file-backed neighbors
+    /// agree on the original file, return where to symbolize it instead.
+    ///
+    /// The island's own bytes are a patched copy, but its *addresses* still
+    /// belong to the original binary, so `addr`'s file offset is derived
+    /// from the left neighbor: `addr - L.start + L.offset`. Conservative
+    /// rule: both neighbors must reference the same file with congruent
+    /// offsets (`R.offset - L.offset == R.start - L.start`), so a pool page
+    /// that merely happens to sit between two unrelated files never bridges.
+    pub fn bridge_for(&self, addr: u64) -> Option<BridgedAddr> {
+        let idx = self
+            .entries
+            .iter()
+            .position(|e| e.start <= addr && addr < e.end)?;
+        let island = &self.entries[idx];
+        if !matches!(island.backing, Backing::Memfd(_)) || !island.exec {
+            return None;
+        }
+        let left = self.entries.get(idx.checked_sub(1)?)?;
+        let right = self.entries.get(idx + 1)?;
+        let (Backing::File(lpath), Backing::File(rpath)) = (&left.backing, &right.backing) else {
+            return None;
+        };
+        if lpath != rpath || !left.exec {
+            return None;
+        }
+        // Neighbors must be address-adjacent to the island and offset-congruent.
+        if left.end != island.start || island.end != right.start {
+            return None;
+        }
+        if right.offset.wrapping_sub(left.offset) != right.start.wrapping_sub(left.start) {
+            return None;
+        }
+        let module_name = lpath
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        Some(BridgedAddr {
+            // Open through the *neighbor's* map_files link: it references the
+            // original ELF regardless of mount namespaces. The island's own
+            // link would open the memory-pool memfd.
+            map_files_path: PathBuf::from(format!(
+                "/proc/{}/map_files/{:x}-{:x}",
+                self.tgid, left.start, left.end
+            )),
+            module_name,
+            file_offset: addr - left.start + left.offset,
+        })
+    }
+
+    /// Most specific module-slot label for an address that did not
+    /// symbolize. Returns `None` when nothing better than raw hex is known
+    /// (non-sandbox process with a plain unreadable mapping, unmapped
+    /// address, ...).
+    ///
+    /// gVisor classification leans on which backing object a mapping uses:
+    /// ALL guest-created memory is served from the `runsc-memory` pool, the
+    /// sysmsg machinery lives in `systrap-memory`, and pure host-anonymous
+    /// mappings in a sandbox process can only come from the stub/Sentry
+    /// itself (a guest cannot create host mappings outside the pool). The
+    /// one exception is the usertrap trampoline table, which the Sentry
+    /// injects from the pool *below* the guest image.
+    pub fn label_for(&self, addr: u64) -> Option<String> {
+        let entry = self.entry_for(addr);
+        let gvisor = self.is_gvisor();
+        match entry.map(|e| (&e.backing, e.exec)) {
+            // Symbol lookup failed but the module is known — report it.
+            // Covers stripped binaries (incl. release runsc builds) and
+            // parse failures; strictly more information than hex.
+            Some((Backing::File(path), _)) => Some(
+                path.file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or("unknown")
+                    .to_string(),
+            ),
+            Some((Backing::Memfd(name), exec)) if gvisor && name == "runsc-memory" => {
+                let below_guest_image = self.file_span.map(|(lo, _)| addr < lo).unwrap_or(false);
+                if below_guest_image && exec {
+                    // usertrap trampoline table.
+                    Some("[gvisor:runtime]".to_string())
+                } else {
+                    // Guest memory: JIT output if a JIT runtime is mapped
+                    // and the page is executable, otherwise unidentifiable
+                    // guest pages (COW'd data, heap made executable, ...).
+                    match self.jit_runtime {
+                        Some(rt) if exec => Some(format!("[jit:{rt}]")),
+                        _ => Some("[gvisor:guest]".to_string()),
+                    }
+                }
+            }
+            // systrap-memory (sysmsg stacks/state) and stub-created host
+            // mappings: sandbox runtime cost.
+            Some((Backing::Memfd(_), _)) | Some((Backing::Anon, _)) if gvisor => {
+                Some("[gvisor:runtime]".to_string())
+            }
+            // Non-gVisor JIT runtimes: anonymous executable pages are JIT
+            // output with the same confidence as in the sandboxed case.
+            Some((Backing::Memfd(_), true)) | Some((Backing::Anon, true)) => {
+                self.jit_runtime.map(|rt| format!("[jit:{rt}]"))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Parse one maps line: `start-end perms offset dev inode [path]`.
+fn parse_maps_line(line: &str) -> Option<MapEntry> {
+    let mut it = line.splitn(6, ' ');
+    let range = it.next()?;
+    let perms = it.next()?;
+    let offset = it.next()?;
+    let _dev = it.next()?;
+    let _inode = it.next()?;
+    let path = it.next().unwrap_or("").trim_start();
+
+    let (start, end) = range.split_once('-')?;
+    let start = u64::from_str_radix(start, 16).ok()?;
+    let end = u64::from_str_radix(end, 16).ok()?;
+    let offset = u64::from_str_radix(offset, 16).ok()?;
+    let exec = perms.as_bytes().get(2) == Some(&b'x');
+
+    let backing = if path.is_empty() {
+        Backing::Anon
+    } else if let Some(name) = path.strip_prefix("/memfd:") {
+        Backing::Memfd(name.strip_suffix(" (deleted)").unwrap_or(name).to_string())
+    } else if path.starts_with('/') {
+        let p = path.strip_suffix(" (deleted)").unwrap_or(path);
+        Backing::File(PathBuf::from(p))
+    } else {
+        Backing::Special(path.to_string())
+    };
+
+    Some(MapEntry {
+        start,
+        end,
+        exec,
+        offset,
+        backing,
+    })
+}
+
+/// Render the standard "symbolization failed" frame for `addr` given an
+/// optional maps analysis: `unknown (<label>) <0xADDR>` when something is
+/// known, plain `0xADDR` otherwise (preserving the historical format).
+pub fn format_unresolved(addr: u64, maps: Option<&ProcessMaps>) -> String {
+    match maps.and_then(|m| m.label_for(addr)) {
+        Some(label) => format!("unknown ({label}) <{addr:#x}>"),
+        None => format!("0x{addr:x}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Maps shape observed on a live runsc systrap stub (trimmed): guest
+    /// text file-backed with 4KiB pool islands at patched syscall sites,
+    /// usertrap trampolines below the image, stub text above it.
+    const STUB_MAPS: &str = "\
+64000-69000 r-xs 3ff26000 00:01 4                          /memfd:runsc-memory (deleted)
+400000-4c2000 r-xs 00000000 00:13 426                      /root/bin/guestbox
+4c2000-4c3000 r-xs 3ff1f000 00:01 4                        /memfd:runsc-memory (deleted)
+4c3000-4cd000 r-xs 000c3000 00:13 426                      /root/bin/guestbox
+4cd000-4ce000 r-xs 3ff20000 00:01 4                        /memfd:runsc-memory (deleted)
+4ce000-512000 r-xs 000ce000 00:13 426                      /root/bin/guestbox
+711000-714000 rw-s 3fe00000 00:01 4                        /memfd:runsc-memory (deleted)
+7fa398efc000-7fa398eff000 r-xp 00000000 00:00 0
+7fee63d08000-7fee63d09000 r--s 3fffe000 00:01 3            /memfd:systrap-memory (deleted)";
+
+    #[test]
+    fn test_parse_and_detect_gvisor() {
+        let pm = ProcessMaps::parse(510, STUB_MAPS, "");
+        assert!(pm.is_gvisor(), "memfd pools alone must flag gVisor");
+        assert_eq!(pm.entries.len(), 9);
+        assert_eq!(pm.file_span, Some((0x400000, 0x512000)));
+
+        let pm_exe = ProcessMaps::parse(1, "", "runsc");
+        assert!(pm_exe.is_gvisor(), "exe basename alone must flag gVisor");
+
+        let pm_plain = ProcessMaps::parse(
+            2,
+            "400000-500000 r-xp 00000000 08:01 42 /usr/bin/foo",
+            "foo",
+        );
+        assert!(!pm_plain.is_gvisor());
+    }
+
+    #[test]
+    fn test_bridge_island() {
+        let pm = ProcessMaps::parse(510, STUB_MAPS, "");
+        // 0x4c2800 sits in the first island; left neighbor starts at
+        // 0x400000 with file offset 0 -> file offset 0xc2800.
+        let b = pm.bridge_for(0x4c2800).expect("island must bridge");
+        assert_eq!(b.file_offset, 0xc2800);
+        assert_eq!(b.module_name, "guestbox");
+        assert_eq!(
+            b.map_files_path,
+            PathBuf::from("/proc/510/map_files/400000-4c2000")
+        );
+
+        // Offsets of the second island's neighbors are congruent too.
+        let b2 = pm.bridge_for(0x4cd400).expect("second island bridges");
+        assert_eq!(b2.file_offset, 0xcd400);
+        assert_eq!(
+            b2.map_files_path,
+            PathBuf::from("/proc/510/map_files/4c3000-4cd000")
+        );
+
+        // File-backed addresses never bridge (they symbolize normally).
+        assert_eq!(pm.bridge_for(0x400100), None);
+        // The trampoline memfd below the image has no file neighbors.
+        assert_eq!(pm.bridge_for(0x64100), None);
+        // Non-exec pool data does not bridge.
+        assert_eq!(pm.bridge_for(0x711100), None);
+    }
+
+    #[test]
+    fn test_bridge_requires_congruent_neighbors() {
+        // Right neighbor's offset is NOT congruent with the left one:
+        // a pool page between unrelated mappings of the same file.
+        let maps = "\
+400000-401000 r-xs 00000000 00:13 426 /root/bin/app
+401000-402000 r-xs 3ff00000 00:01 4   /memfd:runsc-memory (deleted)
+402000-403000 r-xs 00005000 00:13 426 /root/bin/app";
+        let pm = ProcessMaps::parse(1, maps, "");
+        assert_eq!(pm.bridge_for(0x401800), None);
+
+        // Different files on each side never bridge.
+        let maps2 = "\
+400000-401000 r-xs 00000000 00:13 426 /root/bin/app
+401000-402000 r-xs 3ff00000 00:01 4   /memfd:runsc-memory (deleted)
+402000-403000 r-xs 00002000 00:13 427 /root/lib/other.so";
+        let pm2 = ProcessMaps::parse(1, maps2, "");
+        assert_eq!(pm2.bridge_for(0x401800), None);
+
+        // Address gaps between island and neighbor break the bridge.
+        let maps3 = "\
+400000-401000 r-xs 00000000 00:13 426 /root/bin/app
+402000-403000 r-xs 3ff00000 00:01 4   /memfd:runsc-memory (deleted)
+403000-404000 r-xs 00003000 00:13 426 /root/bin/app";
+        let pm3 = ProcessMaps::parse(1, maps3, "");
+        assert_eq!(pm3.bridge_for(0x402800), None);
+    }
+
+    #[test]
+    fn test_labels() {
+        let pm = ProcessMaps::parse(510, STUB_MAPS, "");
+        // Below the guest image: runtime scaffolding.
+        assert_eq!(pm.label_for(0x64100).as_deref(), Some("[gvisor:runtime]"));
+        // Above the guest image (stub text): runtime scaffolding.
+        assert_eq!(
+            pm.label_for(0x7fa398efc100).as_deref(),
+            Some("[gvisor:runtime]")
+        );
+        // Known module, failed symbol lookup: module basename.
+        assert_eq!(pm.label_for(0x400100).as_deref(), Some("guestbox"));
+        // Unmapped address: nothing better than hex.
+        assert_eq!(pm.label_for(0xdead0000), None);
+
+        // Guest-anon exec page inside the image span of a JIT-runtime
+        // process labels as JIT output.
+        let jit_maps = "\
+400000-500000 r-xs 00000000 00:13 426 /usr/bin/node
+600000-700000 r-xs 3f000000 00:01 4   /memfd:runsc-memory (deleted)
+800000-900000 r-xs 00400000 00:13 426 /usr/bin/node";
+        let pmj = ProcessMaps::parse(1, jit_maps, "");
+        assert_eq!(pmj.label_for(0x600100).as_deref(), Some("[jit:node]"));
+
+        // Same shape without a JIT runtime: guest pages.
+        let pm_nojit = ProcessMaps::parse(510, STUB_MAPS, "");
+        assert_eq!(
+            pm_nojit.label_for(0x711100).as_deref(),
+            Some("[gvisor:guest]"),
+            "non-exec runsc-memory page (COW'd guest data) is guest memory"
+        );
+        // sysmsg machinery (systrap-memory) is runtime cost.
+        assert_eq!(
+            pm_nojit.label_for(0x7fee63d08100).as_deref(),
+            Some("[gvisor:runtime]")
+        );
+
+        // Non-gVisor process: anonymous exec page with a JIT runtime mapped.
+        let plain_jit = "\
+400000-500000 r-xp 00000000 08:01 42 /usr/lib/libjvm.so
+7f0000000000-7f0000100000 rwxp 00000000 00:00 0 ";
+        let pmp = ProcessMaps::parse(2, plain_jit, "java");
+        assert_eq!(pmp.label_for(0x7f0000000100).as_deref(), Some("[jit:jvm]"));
+        // ...but a plain anon page in a non-JIT, non-gVisor process stays
+        // unlabeled (hex), preserving historical output.
+        let pm_none = ProcessMaps::parse(
+            3,
+            "400000-500000 r-xp 00000000 08:01 42 /usr/bin/foo\n7f0000000000-7f0000001000 rw-p 00000000 00:00 0 ",
+            "foo",
+        );
+        assert_eq!(pm_none.label_for(0x7f0000000100), None);
+    }
+
+    #[test]
+    fn test_format_unresolved() {
+        let pm = ProcessMaps::parse(510, STUB_MAPS, "");
+        assert_eq!(
+            format_unresolved(0x64100, Some(&pm)),
+            "unknown ([gvisor:runtime]) <0x64100>"
+        );
+        assert_eq!(format_unresolved(0xdead0000, Some(&pm)), "0xdead0000");
+        assert_eq!(format_unresolved(0x1234, None), "0x1234");
+    }
+
+    #[test]
+    fn test_parse_maps_line_variants() {
+        // Deleted file suffix is stripped.
+        let e =
+            parse_maps_line("400000-401000 r-xp 00001000 08:01 42 /usr/bin/foo (deleted)").unwrap();
+        assert_eq!(e.backing, Backing::File(PathBuf::from("/usr/bin/foo")));
+        assert_eq!(e.offset, 0x1000);
+        assert!(e.exec);
+
+        // Special entries.
+        let v = parse_maps_line("7ffe1000-7ffe2000 r-xp 00000000 00:00 0                  [vdso]")
+            .unwrap();
+        assert_eq!(v.backing, Backing::Special("[vdso]".to_string()));
+
+        // Pure anonymous (trailing spaces, no path).
+        let a = parse_maps_line("7f00000-7f01000 rw-p 00000000 00:00 0 ").unwrap();
+        assert_eq!(a.backing, Backing::Anon);
+        assert!(!a.exec);
+
+        // Garbage lines are skipped, not fatal.
+        assert!(parse_maps_line("not a maps line").is_none());
+    }
+}

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -1425,7 +1425,7 @@ mod tests {
         rec.set_spill_dir(dir.path());
 
         let self_tgid = std::process::id() as i32;
-        let live_addr = marker_fn as usize as u64;
+        let live_addr = marker_fn as fn() -> u64 as usize as u64;
         let live_id = rec.interner.intern(
             Stack {
                 kernel_stack: vec![],

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -10,13 +10,14 @@ use anyhow::{Context, Result};
 use crate::pystacks::stack_walker::{PyAddr, StackWalkerRun};
 use crate::record::RecordCollector;
 use crate::ringbuf::RingBuffer;
+use crate::sandbox_maps::ProcessMaps;
 use crate::systing_core::types::stack_event;
 use crate::systing_core::SystingRecordEvent;
 use crate::trace::{StackRecord, StackSampleRecord};
 use crate::utid::{ThreadAwareRecorder, UtidGenerator};
 
 use blazesym::helper::{read_elf_build_id, ElfResolver};
-use blazesym::symbolize::source::{Kernel, Process, Source};
+use blazesym::symbolize::source::{Elf, Kernel, Process, Source};
 use blazesym::symbolize::{
     cache, Input, ProcessMemberInfo, ProcessMemberType, Resolve, Sym, Symbolizer,
 };
@@ -519,6 +520,12 @@ pub struct StackRecorder {
     spill_dir: Option<PathBuf>,
     /// Shared utid generator for consistent thread IDs across all recorders.
     utid_generator: Arc<UtidGenerator>,
+    /// When set (default), frames that fail symbolization are rendered with
+    /// the most specific context known — `unknown ([gvisor:runtime]) <addr>`,
+    /// `unknown ([jit:node]) <addr>`, `unknown (<module>) <addr>`,
+    /// `unknown ([exited]) <addr>` — instead of bare hex. See
+    /// [`crate::sandbox_maps`].
+    frame_labels: bool,
 }
 
 impl ThreadAwareRecorder for StackRecorder {
@@ -545,7 +552,13 @@ impl StackRecorder {
             external_interners: Vec::new(),
             spill_dir: None,
             utid_generator,
+            frame_labels: true,
         }
+    }
+
+    /// Disable contextual labels on unresolvable frames (revert to bare hex).
+    pub fn set_frame_labels(&mut self, enabled: bool) {
+        self.frame_labels = enabled;
     }
 
     /// Enable streaming mode and attach a collector so that StackSampleRecords
@@ -768,6 +781,10 @@ impl StackRecorder {
                     (tgid as u32).into(),
                 )));
                 let proc_src = Source::Process(Process::new(Pid::from(tgid as u32)));
+                // One maps analysis per process, powering island bridging and
+                // frame labels for its whole group. `None` (process raced to
+                // exit, unreadable maps) degrades to plain symbolization.
+                let maps_info = ProcessMaps::load(tgid);
                 // Per-process user-address cache, freed with the group. Survives
                 // a mid-group rebuild, so already-resolved addresses are not
                 // re-done.
@@ -780,7 +797,7 @@ impl StackRecorder {
                     let frame_names = self.symbolize_stack_frames(
                         &mut symbolizer,
                         &stack,
-                        Some((&proc_src, &mut user_cache)),
+                        Some((&proc_src, &mut user_cache, maps_info.as_ref())),
                         &kernel_src,
                         &mut kernel_cache,
                     );
@@ -797,17 +814,58 @@ impl StackRecorder {
         Ok(())
     }
 
+    /// Symbolize one user-space address of a live process: regular process
+    /// symbolization, then — for sandboxed processes — bridging of
+    /// pool-memfd islands back to their original file (see
+    /// [`crate::sandbox_maps`]), then the most specific label available.
+    fn symbolize_user_addr(
+        &self,
+        symbolizer: &mut Symbolizer,
+        proc_src: &Source<'_>,
+        maps_info: Option<&ProcessMaps>,
+        addr: u64,
+    ) -> String {
+        if let Some(sym) = symbolizer
+            .symbolize_single(proc_src, Input::AbsAddr(addr))
+            .ok()
+            .and_then(|s| s.into_sym())
+        {
+            return format_symbolized_frame(&sym, addr, "unknown");
+        }
+
+        if let Some(bridge) = maps_info.and_then(|m| m.bridge_for(addr)) {
+            let elf_src = Source::Elf(Elf::new(&bridge.map_files_path));
+            if let Some(sym) = symbolizer
+                .symbolize_single(&elf_src, Input::FileOffset(bridge.file_offset))
+                .ok()
+                .and_then(|s| s.into_sym())
+            {
+                // sym.module would render the map_files link; report the
+                // original binary the island belongs to instead.
+                return format_symbolized_frame_forced_module(&sym, addr, &bridge.module_name);
+            }
+        }
+
+        if self.frame_labels {
+            crate::sandbox_maps::format_unresolved(addr, maps_info)
+        } else {
+            format!("0x{addr:x}")
+        }
+    }
+
     /// Symbolize a single stack and return frame names.
     ///
-    /// `user` carries the process source and per-process address cache for a
-    /// live process; `None` means the process has exited, in which case user
-    /// addresses are rendered as raw hex (symbolization cannot succeed without
-    /// /proc/<pid>/maps). Kernel addresses go through the shared `kernel_cache`.
+    /// `user` carries the process source, per-process address cache, and
+    /// optional maps analysis for a live process; `None` means the process
+    /// has exited, in which case user addresses cannot be symbolized (no
+    /// /proc/<pid>/maps) and are rendered as `unknown ([exited]) <addr>` (or
+    /// raw hex with labels disabled). Kernel addresses go through the shared
+    /// `kernel_cache`.
     fn symbolize_stack_frames(
         &self,
         symbolizer: &mut Symbolizer,
         stack: &Stack,
-        user: Option<(&Source<'_>, &mut HashMap<u64, String>)>,
+        user: Option<(&Source<'_>, &mut HashMap<u64, String>, Option<&ProcessMaps>)>,
         kernel_src: &Source<'_>,
         kernel_cache: &mut HashMap<u64, String>,
     ) -> Vec<String> {
@@ -821,25 +879,27 @@ impl StackRecorder {
 
         // Symbolize user addresses (leaf)
         match user {
-            Some((proc_src, user_cache)) => {
+            Some((proc_src, user_cache, maps_info)) => {
                 for &addr in &stack.user_stack {
-                    let frame_name = user_cache
-                        .entry(addr)
-                        .or_insert_with(|| {
-                            symbolizer
-                                .symbolize_single(proc_src, Input::AbsAddr(addr))
-                                .ok()
-                                .and_then(|s| s.into_sym())
-                                .map(|s| format_symbolized_frame(&s, addr, "unknown"))
-                                .unwrap_or_else(|| format!("0x{addr:x}"))
-                        })
-                        .clone();
+                    let frame_name = match user_cache.get(&addr) {
+                        Some(name) => name.clone(),
+                        None => {
+                            let name =
+                                self.symbolize_user_addr(symbolizer, proc_src, maps_info, addr);
+                            user_cache.insert(addr, name.clone());
+                            name
+                        }
+                    };
                     frame_names.push(frame_name);
                 }
             }
             None => {
                 for &addr in &stack.user_stack {
-                    frame_names.push(format!("0x{addr:x}"));
+                    if self.frame_labels {
+                        frame_names.push(format!("unknown ([exited]) <{addr:#x}>"));
+                    } else {
+                        frame_names.push(format!("0x{addr:x}"));
+                    }
                 }
             }
         }
@@ -894,6 +954,14 @@ fn format_symbolized_frame(sym: &Sym, addr: u64, default_module: &str) -> String
         .and_then(|m| std::path::Path::new(m).file_name())
         .and_then(|f| f.to_str())
         .unwrap_or(default_module);
+    format_symbolized_frame_forced_module(sym, addr, module_name)
+}
+
+/// Same as [`format_symbolized_frame`] but with a caller-supplied module
+/// name. Used when symbolization went through an indirect source (e.g. a
+/// `map_files` link for a bridged island) whose path would be meaningless to
+/// report.
+fn format_symbolized_frame_forced_module(sym: &Sym, addr: u64, module_name: &str) -> String {
     let location_info = format_location_info(sym.code_info.as_deref());
     format!(
         "{} ({}{}) <{:#x}>",
@@ -1336,5 +1404,87 @@ mod tests {
         assert_eq!(convert_stack_event_type(127), 127);
         assert_eq!(convert_stack_event_type(128), i8::MAX);
         assert_eq!(convert_stack_event_type(u32::MAX), i8::MAX);
+    }
+
+    /// An address inside this test binary's text, guaranteed to be backed by
+    /// a symbolizable mapping of our own executable.
+    #[inline(never)]
+    fn marker_fn() -> u64 {
+        42
+    }
+
+    /// End-to-end run of the finish()-time symbolization over the real
+    /// /proc: a stack from our own live process must not degrade to hex
+    /// (either the symbol resolves or the module label kicks in), and a
+    /// stack from an impossible tgid must take the dead-process path and be
+    /// labeled [exited].
+    #[test]
+    fn test_finish_inner_symbolizes_live_and_labels_dead() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        rec.set_spill_dir(dir.path());
+
+        let self_tgid = std::process::id() as i32;
+        let live_addr = marker_fn as usize as u64;
+        let live_id = rec.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![live_addr],
+                py_stack: vec![],
+            },
+            self_tgid,
+        );
+
+        // Far above pid_max: /proc/<tgid> cannot exist.
+        let dead_tgid = i32::MAX - 1;
+        let dead_addr = 0x1234_5678u64;
+        let dead_id = rec.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![dead_addr],
+                py_stack: vec![],
+            },
+            dead_tgid,
+        );
+
+        let mut collector = crate::record::InMemoryCollector::new();
+        rec.finish_inner(&mut collector).unwrap();
+        let stacks = &collector.data().stacks;
+
+        let dead = stacks.iter().find(|s| s.id == dead_id).expect("dead stack");
+        assert_eq!(
+            dead.frame_names[0],
+            format!("unknown ([exited]) <{dead_addr:#x}>")
+        );
+
+        let live = stacks.iter().find(|s| s.id == live_id).expect("live stack");
+        let frame = &live.frame_names[0];
+        assert!(
+            !frame.starts_with("0x") && frame.contains('('),
+            "live self-process frame should symbolize or at least carry a \
+             module label, got: {frame}"
+        );
+
+        // With labels disabled the dead path reverts to historical bare hex.
+        let mut rec_plain = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        rec_plain.set_frame_labels(false);
+        rec_plain.set_spill_dir(dir.path());
+        let plain_id = rec_plain.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![dead_addr],
+                py_stack: vec![],
+            },
+            dead_tgid,
+        );
+        let mut plain_collector = crate::record::InMemoryCollector::new();
+        rec_plain.finish_inner(&mut plain_collector).unwrap();
+        let plain = plain_collector
+            .data()
+            .stacks
+            .iter()
+            .find(|s| s.id == plain_id)
+            .expect("plain stack");
+        assert_eq!(plain.frame_names[0], format!("0x{dead_addr:x}"));
     }
 }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -518,6 +518,9 @@ pub struct Config {
     pub pystacks_debug: bool,
     /// Enable debuginfod for symbol resolution
     pub enable_debuginfod: bool,
+    /// Render frames that fail symbolization as bare hex instead of
+    /// contextual labels (`unknown ([gvisor:runtime]) <addr>`, ...)
+    pub no_frame_labels: bool,
     /// Disable scheduler tracing
     pub no_sched: bool,
     /// Enable syscall tracing
@@ -593,6 +596,7 @@ impl Default for Config {
             pystacks_pids: Vec::new(),
             pystacks_debug: false,
             enable_debuginfod: false,
+            no_frame_labels: false,
             no_sched: false,
             syscalls: false,
             markers: false,
@@ -1347,6 +1351,13 @@ fn configure_recorder(opts: &Config, recorder: &Arc<SessionRecorder>) {
     if opts.continuous > 0 {
         let duration_nanos = Duration::from_secs(opts.continuous).as_nanos() as u64;
         set_ringbuf_duration(recorder, duration_nanos);
+    }
+    if opts.no_frame_labels {
+        recorder
+            .stack_recorder
+            .lock()
+            .unwrap()
+            .set_frame_labels(false);
     }
 }
 

--- a/tests/gvisor_record.rs
+++ b/tests/gvisor_record.rs
@@ -1,0 +1,444 @@
+//! Integration test: record a workload running inside a gVisor (runsc)
+//! sandbox and validate that the recording pipeline handles it end-to-end —
+//! sandbox stacks are captured, unresolvable frames carry the contextual
+//! labels introduced with the sandbox_maps module, and guest user frames
+//! symbolize through /proc/<pid>/map_files despite the gofer's private mount
+//! namespace.
+//!
+//! Requires root/BPF privileges AND a runsc binary (found via
+//! `SYSTING_TEST_RUNSC` or `$PATH`); skips cleanly with a reason otherwise.
+//!
+//! To run:
+//! ```
+//! ./scripts/run-integration-tests.sh gvisor_record
+//! ```
+
+mod common;
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use arrow::array::{Array, Int32Array, Int64Array, ListArray, StringArray};
+use common::workload::wait_until;
+use systing::{systing, Config};
+use tempfile::TempDir;
+
+/// Recording duration (seconds). The sandboxed workload loops until torn
+/// down, so this only needs to exceed BPF attach latency plus enough sampling
+/// time to hit both guest text and sandbox-runtime code paths. The runtime
+/// paths are sampled rarely when the Sentry dominates CPU (emulated / very
+/// slow machines), hence the generous window.
+const GVISOR_RECORDING_DURATION_SECS: u64 = 12;
+
+/// Locate the runsc binary: `SYSTING_TEST_RUNSC` wins, then `$PATH`.
+fn find_runsc() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("SYSTING_TEST_RUNSC") {
+        let p = PathBuf::from(p);
+        return p.is_file().then_some(p);
+    }
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|d| d.join("runsc"))
+        .find(|c| c.is_file())
+}
+
+/// Name of the test container within its private state root.
+const CONTAINER_ID: &str = "systing-gvisor-test";
+
+/// The sandboxed workload: pure shell builtins so the rootfs only needs
+/// /bin/sh. Complementary guest profiles — a pure arithmetic spinner that
+/// keeps CPU in *guest text* (its samples must symbolize through
+/// map_files), plus several `cd /` loops making a real syscall every
+/// iteration: each syscall executes the systrap trampoline/handler code in
+/// the stub's runtime mappings, and multiple loops raise that code's
+/// on-CPU share so the `[gvisor:*]` classification is reliably sampled
+/// even when the Sentry dominates a slow machine.
+const GUEST_WORKLOAD: &str = "for k in 1 2 3 4 5 6; do while :; do cd /; done & done; \
+                              while :; do i=$((i+1)); done";
+
+/// Copy `binary` plus its dynamic-linker closure (per `ldd`) into `rootfs`,
+/// preserving absolute paths, and return the in-guest path of the binary.
+/// Static binaries copy as-is. This keeps the container independent of how
+/// the host filesystem is mounted (e.g. network filesystems in test VMs,
+/// where gofer FD donation for mmap may not behave like local files).
+fn install_with_libs(binary: &Path, rootfs: &Path) -> std::io::Result<PathBuf> {
+    let target = std::fs::canonicalize(binary)?;
+    let dest = rootfs.join("bin/sh");
+    std::fs::create_dir_all(dest.parent().unwrap())?;
+    std::fs::copy(&target, &dest)?;
+
+    if let Ok(out) = Command::new("ldd").arg(&target).output() {
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            // "libc.so.6 => /lib/... (0x...)" or "/lib64/ld-linux... (0x...)"
+            let path = match line.split_once("=>") {
+                Some((_, rhs)) => rhs.trim(),
+                None => line.trim(),
+            };
+            let path = path.split(" (").next().unwrap_or("").trim();
+            if !path.starts_with('/') {
+                continue; // vdso, "statically linked", etc.
+            }
+            let src = PathBuf::from(path);
+            if let Ok(real) = std::fs::canonicalize(&src) {
+                let dst = rootfs.join(path.trim_start_matches('/'));
+                std::fs::create_dir_all(dst.parent().unwrap())?;
+                std::fs::copy(&real, &dst)?;
+            }
+        }
+    }
+    Ok(PathBuf::from("/bin/sh"))
+}
+
+/// Everything needed to run and tear down one sandboxed workload.
+struct SandboxedWorkload {
+    child: Child,
+    runsc: PathBuf,
+    root: PathBuf,
+}
+
+impl SandboxedWorkload {
+    /// Create an OCI bundle (self-contained tmpfs rootfs with just /bin/sh)
+    /// and `runsc run` the workload in it.
+    fn spawn(runsc: &Path, state_root: &Path, bundle: &Path) -> std::io::Result<Self> {
+        let rootfs = bundle.join("rootfs");
+        std::fs::create_dir_all(&rootfs)?;
+        let sh = install_with_libs(Path::new("/bin/sh"), &rootfs)?;
+
+        let spec = Command::new(runsc)
+            .current_dir(bundle)
+            .args(["spec", "--"])
+            .arg(&sh)
+            .args(["-c", GUEST_WORKLOAD])
+            .output()?;
+        assert!(
+            spec.status.success(),
+            "runsc spec failed: {}",
+            String::from_utf8_lossy(&spec.stderr)
+        );
+        // No tty in the container.
+        let config_path = bundle.join("config.json");
+        let config = std::fs::read_to_string(&config_path)?;
+        std::fs::write(
+            &config_path,
+            config.replace("\"terminal\": true", "\"terminal\": false"),
+        )?;
+
+        let child = Command::new(runsc)
+            .arg("--root")
+            .arg(state_root)
+            .args(["--network=none", "--ignore-cgroups", "run", "-bundle"])
+            .arg(bundle)
+            .arg(CONTAINER_ID)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(Self {
+            child,
+            runsc: runsc.to_path_buf(),
+            root: state_root.to_path_buf(),
+        })
+    }
+
+    /// True once `runsc state` reports our container running.
+    fn is_running(&mut self) -> bool {
+        if let Ok(Some(status)) = self.child.try_wait() {
+            panic!("runsc run exited before the sandbox came up: {status}");
+        }
+        Command::new(&self.runsc)
+            .arg("--root")
+            .arg(&self.root)
+            .args(["state", CONTAINER_ID])
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).contains("\"running\""))
+            .unwrap_or(false)
+    }
+}
+
+impl Drop for SandboxedWorkload {
+    fn drop(&mut self) {
+        // Kill the container, then the foreground `runsc run` process. The
+        // sandbox holds a parent-death signal, so this is belt-and-braces;
+        // the temp state root disappears with the test.
+        let _ = Command::new(&self.runsc)
+            .arg("--root")
+            .arg(&self.root)
+            .args(["kill", CONTAINER_ID, "KILL"])
+            .output();
+        let _ = Command::new(&self.runsc)
+            .arg("--root")
+            .arg(&self.root)
+            .args(["delete", "-force", CONTAINER_ID])
+            .output();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// All host TIDs whose process executable is the runsc binary: the CLI,
+/// gofer, sandbox (Sentry), and — because they fork without exec'ing — every
+/// stub process mirroring a guest address space.
+fn collect_runsc_tids(runsc: &Path) -> HashSet<i32> {
+    let runsc = std::fs::canonicalize(runsc).unwrap_or_else(|_| runsc.to_path_buf());
+    let mut tids = HashSet::new();
+    let Ok(proc_dir) = std::fs::read_dir("/proc") else {
+        return tids;
+    };
+    for entry in proc_dir.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<i32>().ok())
+        else {
+            continue;
+        };
+        let Ok(exe) = std::fs::read_link(format!("/proc/{pid}/exe")) else {
+            continue;
+        };
+        if exe != runsc {
+            continue;
+        }
+        let Ok(tasks) = std::fs::read_dir(format!("/proc/{pid}/task")) else {
+            continue;
+        };
+        for task in tasks.flatten() {
+            if let Some(tid) = task
+                .file_name()
+                .to_str()
+                .and_then(|s| s.parse::<i32>().ok())
+            {
+                tids.insert(tid);
+            }
+        }
+    }
+    tids
+}
+
+fn read_i64_column(batch: &arrow::record_batch::RecordBatch, name: &str) -> Vec<i64> {
+    let col = batch
+        .column_by_name(name)
+        .unwrap_or_else(|| panic!("column {name} missing"));
+    if let Some(a) = col.as_any().downcast_ref::<Int64Array>() {
+        (0..a.len()).map(|i| a.value(i)).collect()
+    } else if let Some(a) = col.as_any().downcast_ref::<Int32Array>() {
+        (0..a.len()).map(|i| a.value(i) as i64).collect()
+    } else {
+        panic!("column {name} is neither Int64 nor Int32");
+    }
+}
+
+fn for_each_batch(path: &Path, mut f: impl FnMut(&arrow::record_batch::RecordBatch)) {
+    let file = std::fs::File::open(path)
+        .unwrap_or_else(|e| panic!("failed to open {}: {e}", path.display()));
+    let reader = parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder::try_new(file)
+        .expect("failed to create parquet reader")
+        .build()
+        .expect("failed to build parquet reader");
+    for batch in reader {
+        f(&batch.expect("failed to read record batch"));
+    }
+}
+
+/// Module portion of a rendered frame ("name (module ...) <addr>"), if any.
+fn frame_module(frame: &str) -> Option<&str> {
+    let start = frame.find(" (")? + 2;
+    let rest = &frame[start..];
+    let end = rest.find(" [").or_else(|| rest.find(')'))?;
+    Some(&rest[..end])
+}
+
+/// A frame that symbolized to a real userland symbol: not bare hex, not an
+/// `unknown (...)` miss, and not a kernel module.
+fn is_resolved_user_frame(frame: &str) -> bool {
+    if frame.starts_with("0x") || frame.starts_with("unknown") {
+        return false;
+    }
+    match frame_module(frame) {
+        Some(module) => module != "vmlinux" && !module.starts_with('['),
+        None => false,
+    }
+}
+
+#[test]
+#[ignore]
+fn test_gvisor_record() {
+    let Some(runsc) = find_runsc() else {
+        eprintln!(
+            "skipping: no runsc binary found (set SYSTING_TEST_RUNSC or put runsc on PATH; \
+             releases: https://storage.googleapis.com/gvisor/releases/release/latest/x86_64/runsc)"
+        );
+        return;
+    };
+    eprintln!("using runsc at {}", runsc.display());
+
+    // Smoke-test the environment: `runsc do /bin/true` needs the same
+    // privileges as the real workload (root, namespaces). Skip — with
+    // runsc's own words — when it can't run here.
+    let smoke_root = TempDir::new().expect("failed to create smoke state root");
+    let smoke = Command::new(&runsc)
+        .arg("--root")
+        .arg(smoke_root.path())
+        .args(["--network=none", "--ignore-cgroups", "do", "/bin/true"])
+        .output()
+        .expect("failed to spawn runsc");
+    if !smoke.status.success() {
+        eprintln!(
+            "skipping: runsc cannot run sandboxes here ({}): {}",
+            smoke.status,
+            String::from_utf8_lossy(&smoke.stderr)
+                .lines()
+                .last()
+                .unwrap_or("")
+        );
+        return;
+    }
+
+    let state_root = TempDir::new().expect("failed to create runsc state root");
+    let bundle = TempDir::new().expect("failed to create bundle dir");
+    let out_dir = TempDir::new().expect("failed to create output dir");
+
+    let mut workload = SandboxedWorkload::spawn(&runsc, state_root.path(), bundle.path())
+        .expect("failed to spawn runsc run");
+    wait_until("gVisor sandbox to come up", || workload.is_running());
+
+    // The stub processes mirroring guest address spaces exist once the
+    // sandbox runs; collect the whole runsc process family (CLI, gofer,
+    // Sentry, stubs — stubs fork without exec so they share the exe link).
+    let mut runsc_tids = collect_runsc_tids(&runsc);
+    eprintln!(
+        "runsc process family before recording: {} tids",
+        runsc_tids.len()
+    );
+
+    eprintln!("Recording trace ({GVISOR_RECORDING_DURATION_SECS}s, sandboxed exec loop)...");
+    let config = Config {
+        duration: GVISOR_RECORDING_DURATION_SECS,
+        output_dir: out_dir.path().to_path_buf(),
+        output: out_dir.path().join("trace.pb"),
+        ..Config::default()
+    };
+    systing(config, None).expect("systing recording failed");
+
+    // Stubs are created lazily (new guest address space => new stub), so
+    // re-collect after the recording and take the union.
+    runsc_tids.extend(collect_runsc_tids(&runsc));
+    drop(workload);
+    eprintln!(
+        "Recording complete; runsc family (union): {} tids",
+        runsc_tids.len()
+    );
+    assert!(
+        !runsc_tids.is_empty(),
+        "no runsc processes observed while the sandbox was running"
+    );
+
+    // thread.parquet: utid -> tid, to find sandbox-attributed samples.
+    let mut utid_to_tid: HashMap<i64, i32> = HashMap::new();
+    for_each_batch(&out_dir.path().join("thread.parquet"), |batch| {
+        let utids = read_i64_column(batch, "utid");
+        let tids = read_i64_column(batch, "tid");
+        for (u, t) in utids.iter().zip(tids.iter()) {
+            utid_to_tid.insert(*u, *t as i32);
+        }
+    });
+
+    // stack_sample.parquet: stack ids referenced by sandbox threads.
+    let mut sandbox_stack_ids: HashSet<i64> = HashSet::new();
+    let mut sandbox_sample_count = 0usize;
+    for_each_batch(&out_dir.path().join("stack_sample.parquet"), |batch| {
+        let utids = read_i64_column(batch, "utid");
+        let stack_ids = read_i64_column(batch, "stack_id");
+        for (u, s) in utids.iter().zip(stack_ids.iter()) {
+            let is_sandbox = utid_to_tid
+                .get(u)
+                .is_some_and(|tid| runsc_tids.contains(tid));
+            if is_sandbox {
+                sandbox_stack_ids.insert(*s);
+                sandbox_sample_count += 1;
+            }
+        }
+    });
+    eprintln!(
+        "sandbox-attributed samples: {sandbox_sample_count} across {} unique stacks",
+        sandbox_stack_ids.len()
+    );
+    assert!(
+        sandbox_sample_count > 0,
+        "[gvisor recording] no stack samples attributed to the runsc process family; \
+         the sandboxed workload was not captured"
+    );
+
+    // stack.parquet: inspect the frames of sandbox stacks.
+    let mut gvisor_labeled = 0usize;
+    let mut resolved_user = 0usize;
+    let mut resolved_guest = 0usize;
+    let mut example_label: Option<String> = None;
+    let mut example_guest: Option<String> = None;
+    for_each_batch(&out_dir.path().join("stack.parquet"), |batch| {
+        let ids = read_i64_column(batch, "id");
+        let frames_col = batch
+            .column_by_name("frame_names")
+            .expect("frame_names column missing")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("frame_names should be a ListArray")
+            .clone();
+        for (row, id) in ids.iter().enumerate() {
+            if !sandbox_stack_ids.contains(id) {
+                continue;
+            }
+            let values = frames_col.value(row);
+            let strings = values
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("frame_names inner should be StringArray");
+            for i in 0..strings.len() {
+                let frame = strings.value(i);
+                if frame.contains("([gvisor:") {
+                    gvisor_labeled += 1;
+                    example_label.get_or_insert_with(|| frame.to_string());
+                }
+                if is_resolved_user_frame(frame) {
+                    resolved_user += 1;
+                    // Frames from the runsc binary itself are the Sentry's
+                    // own (Go) code — resolved from an ordinary host
+                    // mapping. Frames from any OTHER module in a sandbox
+                    // stack are guest text: they only resolve if the
+                    // map_files-based path works through the gofer's
+                    // private mount namespace.
+                    let module = frame_module(frame).unwrap_or("");
+                    if !module.starts_with("runsc") {
+                        resolved_guest += 1;
+                        example_guest.get_or_insert_with(|| frame.to_string());
+                    }
+                }
+            }
+        }
+    });
+    eprintln!(
+        "sandbox frames: {gvisor_labeled} gvisor-labeled (e.g. {example_label:?}), \
+         {resolved_user} resolved-user of which {resolved_guest} guest-module \
+         (e.g. {example_guest:?})"
+    );
+
+    // The PR's value proposition, both halves:
+    // (1) sandbox-runtime execution is classified instead of raw hex —
+    //     the syscall loop bounces through the systrap trampolines all
+    //     recording long, and preemption traffic adds to it;
+    assert!(
+        gvisor_labeled > 0,
+        "[gvisor labels] no `unknown ([gvisor:*])` frames in sandbox stacks; \
+         classification did not engage"
+    );
+    // (2) guest user text symbolizes from the host despite the gofer's
+    //     private mount namespace (map_files-based resolution). The spinner
+    //     process lives in guest text (/bin/sh), so its samples must
+    //     resolve to a non-runsc module.
+    assert!(
+        resolved_guest > 0,
+        "[gvisor symbolization] no resolved guest-module frames in sandbox \
+         stacks ({resolved_user} resolved frames were all from the runsc \
+         binary itself); guest text did not symbolize"
+    );
+}


### PR DESCRIPTION
Contextual labels for frames that fail symbolization, and recovery of the text pages gVisor's
syscall patching breaks out of guest binaries. Folds in and closes #136 (design + analysis
below, per review preference for PR-carried design).

## Problem

Stack samples from processes running inside gVisor (runsc) sandboxes largely fail user-frame
symbolization: application frames render as bare `0x...` hex in both trace and `--continuous`
modes. Host-side processes on the same machine symbolize fine, and the same binaries symbolize
fine when run unsandboxed. On a gVisor-based Kubernetes cluster we observe the majority of
sandbox-attributed CPU samples with mostly-unresolved stacks; kernel frames are unaffected.

The picture is more nuanced than "guest memory is anonymous" — there are several distinct
failure classes with different fixes. This PR implements the first two phases (labels +
island bridging); the analysis below covers the whole taxonomy so the rest is on record.

## How a gVisor guest looks to the host-side symbolizer

Verified against gvisor @ HEAD and on a live sandbox with `runsc release-20260622.0`
(systrap platform). Under systrap, guest code executes natively in *stub* processes whose
address spaces mirror the guest's: the Sentry mmaps guest ranges at the guest virtual
addresses (`pkg/sentry/platform/systrap/subprocess.go` `MapFile`, `MAP_FIXED|MAP_SHARED`). So
sampled user addresses in stub threads ARE guest VAs, frame-pointer unwinding works, and
`bpf_get_current_pid_tgid()` correctly targets the stub's `/proc/<tgid>/maps`. Guest process
names never appear in host comms (nothing calls PR_SET_NAME host-side; stubs fork without
exec), so all sandbox CPU aggregates under the runtime's identity — comm `exe` with current
releases, `runsc` with some older/vendor builds.

What backs the stub's mappings is the crux. Actual maps of a stub running a static busybox
guest:

```
64000-69000    r-xs 3ff26000 00:01 4    /memfd:runsc-memory (deleted)   <- usertrap trampolines
400000-4c2000  r-xs 00000000 00:13 426  /root/bin/guestbox              <- guest text, file-backed
4c2000-4c3000  r-xs 3ff1f000 00:01 4    /memfd:runsc-memory (deleted)   <- 4KiB patched island
4c3000-4cd000  r-xs 000c3000 00:13 426  /root/bin/guestbox
4cd000-4ce000  r-xs 3ff20000 00:01 4    /memfd:runsc-memory (deleted)   <- island
4ce000-4d5000  r-xs 000ce000 00:13 426  /root/bin/guestbox
...
7fa398efc000-7fa398eff000 r-xp 00000000 00:00 0                         <- stub/sysmsg text (anon)
```

1. **Guest ELF text is mostly host-file-backed.** The gofer donates host FDs for regular
   files; private file mappings only leave the host file on write (`pkg/sentry/mm/pma.go`
   COW). The symbolic path (`/root/bin/guestbox`) is relative to the gofer's private mount
   namespace and useless on the host — but blazesym's default `map_files: true` opens the
   mapping through `/proc/<pid>/map_files/<range>`, which works regardless of namespaces
   (verified: returns the real ELF). So plain guest text frames already resolve today while
   the stub is alive.

2. **systrap's syscall patching punches unresolvable holes exactly where samples land.**
   `pkg/sentry/platform/systrap/usertrap` lazily rewrites executed syscall sites in guest
   text; the write COW-breaks precisely those 4KiB pages into the Sentry's `runsc-memory`
   memfd (executable vmas copy only the required pages). Result: a file/memfd mosaic where
   the memfd islands sit at *hot syscall sites* — over-represented among CPU samples of
   syscall-heavy workloads. Island addresses still correspond to functions of the original
   binary; only the backing changed. (Contrast: the ptrace platform shows a single contiguous
   file-backed text mapping — no islands.) Hazard: an island's own `map_files` entry opens
   the pool memfd, whose offset-0 bytes can coincidentally parse as an ELF header; the maps
   entries' large pool offsets then fail offset translation, so today this degrades to
   "unknown" — but a small-offset island could in principle resolve to a *wrong* symbol.

3. **Sandbox runtime execution is structurally unsymbolizable and unlabeled.** Every guest
   syscall/fault executes trampoline + sysmsg handler code on the stub thread, in memfd/anon
   mappings (the guest-side `/proc/<pid>/maps` even labels the trampoline region
   `[usertrap]`). For syscall-heavy guests a large share of "guest" CPU samples land here and
   can never resolve to an application binary — that's not a symbolization failure so much as
   *unattributed sandbox overhead*, and labeling it makes gVisor's CPU cost directly
   measurable in profiles.

4. **Exited stubs** hit the existing dead-process path (user frames rendered as hex
   unconditionally). Sandboxing platforms often run short-lived episodic work, so this class
   is over-represented there — but it's a general gap, tracked separately.

5. **JIT code**: for JIT runtimes in sandboxes (node/V8, JVM, CPython 3.14's copy-and-patch
   JIT), the engine's own text resolves per (1) — but JIT output lives in anonymous exec
   pages and renders as hex. Not gVisor-specific, but gVisor makes the standard mitigations
   harder: perf-map files are written inside the *guest* filesystem under the *guest* pid, so
   the host-side symbolizer never finds them. In practice JIT pages can be the single largest
   unresolved term on such hosts. Deserves its own follow-up (jitdump/perf-map translation).

6. **The Sentry itself may not resolve**: release runsc binaries can ship without an ELF
   symbol table, in which case the (correctly identified) `runsc` module yields no symbols —
   Go's `.gopclntab` is present but blazesym doesn't consume it. Module-level labeling below
   at least attributes these frames to the sandbox runtime.

## What this PR does

**New `sandbox_maps` module** — parses `/proc/<tgid>/maps` once per live process at
symbolization time and detects gVisor processes (`/proc/<tgid>/exe` → runsc, or
`runsc-memory`/`systrap-memory` pool memfds present).

**Island bridging** — executable `runsc-memory` islands whose file-backed neighbor mappings
agree (same file, address-adjacent, offset-congruent) are symbolized against the original ELF
through the *neighbor's* `map_files` link with `Input::FileOffset`. This recovers the pages
from class 2 — exactly the hot syscall-site leaves — and the conservative both-neighbors rule
means a pool page between unrelated mappings never bridges, which also sidesteps the
wrong-symbol hazard above.

**Labels** — when symbolization fails, render the most specific context known instead of bare
hex, reusing the existing `unknown (<module>) <addr>` miss shape (it's how kernel misses
render today, so downstream parsers already handle it):

| frame location | rendered as |
|---|---|
| stub/sysmsg/trampoline execution, Sentry-created mappings | `unknown ([gvisor:runtime]) <0x...>` |
| guest pool pages (COW'd data, unbridgeable) | `unknown ([gvisor:guest]) <0x...>` |
| anon-exec pages in a process with a JIT runtime mapped | `unknown ([jit:node]) <0x...>` etc. |
| module known, symbol lookup failed (stripped binaries) | `unknown (<module>) <0x...>` |
| process exited before end-of-trace symbolization | `unknown ([exited]) <0x...>` |

`[gvisor:runtime]` frames (plus stripped-`runsc` module frames) make the sandbox's own CPU
overhead directly measurable, which for gVisor-heavy hosts is arguably worth more than any
individual recovered frame.

The classification leans on mechanism, not position: all guest-created memory is served from
the `runsc-memory` pool; `systrap-memory` is sysmsg machinery; pure host-anonymous mappings
in a sandbox process can only come from the stub/Sentry itself (a guest cannot create host
mappings outside the pool); the usertrap trampoline table is pool-backed but injected below
the guest image. Details in the module docs.

`--no-frame-labels` reverts every label to the historical bare hex. Bridging stays on
unconditionally — it only ever adds real symbols and is a no-op outside gVisor processes.

## Future phases (not in this PR, recorded here since #136 closes)

**Guest-maps-based symbolization** for what remains (wholly-memfd text, JIT regions via guest
perf-map files, guest comm/pid attribution): gVisor already assembles everything needed —
`containerManager.ProcfsDump` returns per-process guest maps (path, offset, perms), comm, exe
and start time (`runsc/boot/procfs/dump.go`) — but no stock CLI exposes it; `runsc exec <ctr>
cat /proc/<pid>/maps` works today at the cost of running a process inside the sandbox, which
profilers shouldn't do routinely. Sketch: enumerate sandboxes from the runsc state dir, pull
guest maps per process, correlate host stub tgid ↔ guest process (stub start-time ≈ guest
exec time; fall back to matching sampled VAs against guest mm ranges — fork-siblings collide
but symbolize identically), resolve guest paths against the container rootfs (OCI bundle
`root.path`) or by build-id, and symbolize by VA identity. A tiny upstream gVisor change
adding `runsc debug --procfs` would make this clean. This is also the unlock for pystacks
inside sandboxes (discovery needs the guest maps and binaries; the BPF walker already reads
the right addresses since stub VAs are guest VAs).

Out of scope entirely: VM-based runtimes (Firecracker, Kata, QEMU-class) — guests there are
architecturally invisible to host BPF; symbolization belongs to an in-guest agent, and the
host side can at most label the VMM threads. The dead-process gap (class 4) and JIT story
(class 5) generalize beyond sandboxes and warrant their own changes (maps snapshot at
first-sample time; jitdump/perf-map support incl. guest-fs translation).

## Testing

- Unit tests for parsing, gVisor detection, bridging (offset-congruence, adjacency, and
  different-file negative cases) and every label class. The primary fixture is the maps
  excerpt above, captured from a live runsc `release-20260622.0` systrap stub.
- An end-to-end test drives the real `finish()`-time symbolization over live `/proc`: a stack
  from the test's own process must resolve (or at minimum carry a module label), a stack from
  an impossible tgid takes the dead-process path and must render `unknown ([exited]) <...>`,
  and the `--no-frame-labels` path must reproduce the historical bare-hex output.
- `cargo test` (372), `cargo fmt --check`, `cargo clippy --no-default-features -- -D warnings`
  all clean.
- Not yet validated against a live gVisor sandbox end-to-end (my dev environment can't run
  BPF). Manual validation path on any Linux host with runsc installed:

```
mkdir -p /tmp/ctr/rootfs/bin && cp $(which busybox) /tmp/ctr/rootfs/bin/busybox
ln -s busybox /tmp/ctr/rootfs/bin/sh
cd /tmp/ctr && runsc spec -- /bin/sh -c 'i=0; while true; do i=$((i+1)); done'
sed -i 's/"terminal": true/"terminal": false/' config.json
runsc --network=none --ignore-cgroups run -bundle /tmp/ctr demo &
sleep 3
# the app stub is the runsc-descendant whose maps contain the guest binary:
for p in $(pgrep -f runsc-sandbox); do echo == $p; cat /proc/$p/maps; done
```

Then profile the spinning guest with systing: before this change the sampled leaves render as
hex; after it, leaves in patched pages symbolize to busybox functions and stub-region samples
render as `unknown ([gvisor:runtime]) <...>`.
