### PR TITLE
Query gVisor control sockets for guest-side maps during symbolization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systing"
-version = "1.10.4"
+version = "1.10.5"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/gvisor_guest.rs
+++ b/src/gvisor_guest.rs
@@ -1,0 +1,461 @@
+//! Guest-side process truth for gVisor sandboxes.
+//!
+//! The host view of a sandboxed process (a systrap *stub*) is enough to
+//! symbolize file-backed guest text, but three things only the Sentry
+//! knows: which guest process a stub mirrors (host comm is always the
+//! runtime's own), the guest-path identity of mappings whose host backing
+//! is the memory pool (copied-up files, donation-less configurations), and
+//! the authoritative extent of runtime-injected regions (`[usertrap]`).
+//!
+//! runsc's control socket already serves all of it: the
+//! `containerManager.ProcfsDump` RPC returns, per guest process, the full
+//! guest maps (path, offset, perms), comm/exe/args, and the task creation
+//! time. The socket lives in the runsc state directory
+//! (`<root>/runsc-<sandbox-id>.sock`), the protocol is a single JSON
+//! request/response over a unix stream socket, and the call is
+//! Sentry-side only — nothing executes inside the guest.
+//!
+//! [`SandboxIndex::load`] snapshots every reachable sandbox once per
+//! symbolization pass; [`SandboxIndex::correlate`] matches a host stub's
+//! address space to the guest process it mirrors (stub VAs are guest VAs
+//! under systrap, so file-backed ranges must agree exactly); the returned
+//! [`GuestProcess`] then answers per-address queries.
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// State directories probed for control sockets: the containerd shim's
+/// (Kubernetes) and the standalone default. `SYSTING_RUNSC_ROOTS`
+/// (colon-separated) replaces the list when set.
+const DEFAULT_RUNSC_ROOTS: &[&str] = &["/run/containerd/runsc/k8s.io", "/var/run/runsc"];
+
+/// Per-call I/O timeout. The RPC is served from Sentry memory and is
+/// fast; a wedged sandbox must not stall symbolization.
+const RPC_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Response size cap: a sandbox with thousands of guest processes stays
+/// well under this; anything larger is malformed or hostile.
+const RPC_MAX_RESPONSE: usize = 64 << 20;
+
+/// Total time allowed for snapshotting all sandboxes on the host.
+const LOAD_BUDGET: Duration = Duration::from_secs(10);
+
+/// One guest memory mapping, from the Sentry's `/proc/<pid>/maps` view.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GuestMapping {
+    #[serde(rename = "address")]
+    addr: GuestAddrRange,
+    #[serde(rename = "permissions")]
+    perms: GuestPerms,
+    #[serde(default)]
+    offset: u64,
+    #[serde(default)]
+    pathname: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GuestAddrRange {
+    #[serde(rename = "Start")]
+    start: u64,
+    #[serde(rename = "End")]
+    end: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct GuestPerms {
+    #[serde(rename = "Read", default)]
+    read: bool,
+    #[serde(rename = "Execute", default)]
+    execute: bool,
+}
+
+impl GuestMapping {
+    fn contains(&self, addr: u64) -> bool {
+        self.addr.start <= addr && addr < self.addr.end
+    }
+
+    /// A regular guest file mapping (absolute path, not a `[...]` pseudo
+    /// entry).
+    fn is_file(&self) -> bool {
+        self.pathname.starts_with('/')
+    }
+}
+
+/// One guest process from the procfs dump.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GuestProcess {
+    #[serde(default)]
+    pub exe: String,
+    /// Task creation time, nanoseconds since the Unix epoch.
+    #[serde(rename = "clone_ts", default)]
+    pub clone_ts_ns: i64,
+    #[serde(default)]
+    status: GuestStatus,
+    #[serde(default)]
+    maps: Vec<GuestMapping>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct GuestStatus {
+    #[serde(default)]
+    comm: String,
+    #[serde(default)]
+    pid: i32,
+}
+
+/// What a guest-maps lookup says about one address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuestAddr {
+    /// Falls in a guest file mapping: symbolizable against the file at
+    /// `guest_path` (resolved via the container rootfs) at `file_offset`.
+    File {
+        guest_path: String,
+        file_offset: u64,
+        module: String,
+    },
+    /// Runtime-injected region (`[usertrap]`): sandbox overhead.
+    Runtime,
+    /// Guest-anonymous memory (JIT output, heap made executable, ...).
+    Anon,
+    /// Not mapped in the guest at all.
+    Unmapped,
+}
+
+impl GuestProcess {
+    pub fn comm(&self) -> &str {
+        &self.status.comm
+    }
+
+    pub fn pid(&self) -> i32 {
+        self.status.pid
+    }
+
+    /// Classify one guest virtual address against this process's maps.
+    pub fn lookup(&self, addr: u64) -> GuestAddr {
+        let Some(m) = self.maps.iter().find(|m| m.contains(addr)) else {
+            return GuestAddr::Unmapped;
+        };
+        match m.pathname.as_str() {
+            path if m.is_file() => {
+                let module = Path::new(path)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                GuestAddr::File {
+                    guest_path: path.to_string(),
+                    file_offset: addr - m.addr.start + m.offset,
+                    module,
+                }
+            }
+            "[usertrap]" => GuestAddr::Runtime,
+            _ => GuestAddr::Anon,
+        }
+    }
+
+    /// Executable file ranges, the correlation fingerprint: under systrap
+    /// a stub maps guest text at identical addresses, so a mirroring stub
+    /// agrees on every one of these.
+    fn exec_file_ranges(&self) -> impl Iterator<Item = (u64, u64)> + '_ {
+        self.maps
+            .iter()
+            .filter(|m| m.perms.execute && m.perms.read && m.is_file())
+            .map(|m| (m.addr.start, m.addr.end))
+    }
+}
+
+/// One sandbox reached over its control socket.
+#[derive(Debug)]
+struct Sandbox {
+    processes: Vec<GuestProcess>,
+}
+
+/// Snapshot of every reachable sandbox on the host.
+#[derive(Debug, Default)]
+pub struct SandboxIndex {
+    sandboxes: Vec<Sandbox>,
+}
+
+impl SandboxIndex {
+    /// Probe the runsc state roots and dump every reachable sandbox.
+    /// Errors are per-sandbox and non-fatal: an unreachable socket (racing
+    /// teardown, permissions) just leaves that sandbox out, and callers
+    /// degrade to host-only symbolization.
+    pub fn load() -> Self {
+        let roots = std::env::var("SYSTING_RUNSC_ROOTS")
+            .map(|v| v.split(':').map(PathBuf::from).collect::<Vec<_>>())
+            .unwrap_or_else(|_| DEFAULT_RUNSC_ROOTS.iter().map(PathBuf::from).collect());
+
+        // Each wedged sandbox can cost up to RPC_TIMEOUT per I/O step, so a
+        // host full of broken sandboxes must not stall symbolization: stop
+        // enumerating once the total budget is spent and work with what was
+        // gathered.
+        let deadline = std::time::Instant::now() + LOAD_BUDGET;
+
+        let mut index = SandboxIndex::default();
+        for root in roots {
+            let Ok(entries) = std::fs::read_dir(&root) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let Some(name) = name.to_str() else { continue };
+                if !name.starts_with("runsc-") || !name.ends_with(".sock") {
+                    continue;
+                }
+                if std::time::Instant::now() >= deadline {
+                    eprintln!(
+                        "Note: gvisor sandbox enumeration stopped after {LOAD_BUDGET:?}; \
+                         {} sandbox(es) snapshotted",
+                        index.sandboxes.len()
+                    );
+                    return index;
+                }
+                match procfs_dump(&entry.path()) {
+                    Ok(processes) => index.sandboxes.push(Sandbox { processes }),
+                    Err(e) => {
+                        eprintln!(
+                            "Note: gvisor guest maps unavailable for {}: {e}",
+                            entry.path().display()
+                        );
+                    }
+                }
+            }
+        }
+        index
+    }
+
+    /// Whether any sandbox was reached.
+    pub fn is_empty(&self) -> bool {
+        self.sandboxes.is_empty()
+    }
+
+    /// Find the guest process a host stub mirrors, from the stub's own
+    /// executable file-backed ranges (as `(start, end)` pairs). Every
+    /// stub exec-file range must appear in the guest's maps (the stub may
+    /// see *fewer* — pool islands split its view — never different ones),
+    /// and the best-scoring guest process wins. Fork-siblings can tie
+    /// (identical layouts); any of them symbolizes identically, so ties
+    /// resolve to the first.
+    pub fn correlate(&self, stub_exec_ranges: &[(u64, u64)]) -> Option<&GuestProcess> {
+        if stub_exec_ranges.is_empty() {
+            return None;
+        }
+        let mut best: Option<(usize, &GuestProcess)> = None;
+        for sandbox in &self.sandboxes {
+            for proc in &sandbox.processes {
+                let guest: Vec<(u64, u64)> = proc.exec_file_ranges().collect();
+                if guest.is_empty() {
+                    continue;
+                }
+                // Score: stub ranges contained in some guest range. The
+                // stub's file mappings are fragments of the guest's
+                // (usertrap islands split them), so containment — not
+                // equality — is the right test.
+                let score = stub_exec_ranges
+                    .iter()
+                    .filter(|(s, e)| guest.iter().any(|(gs, ge)| gs <= s && e <= ge))
+                    .count();
+                if score == stub_exec_ranges.len() && best.map(|(b, _)| score > b).unwrap_or(true) {
+                    best = Some((score, proc));
+                }
+            }
+        }
+        best.map(|(_, p)| p)
+    }
+}
+
+/// Issue one `containerManager.ProcfsDump` call on a control socket.
+fn procfs_dump(socket: &Path) -> std::io::Result<Vec<GuestProcess>> {
+    let mut stream = UnixStream::connect(socket)?;
+    stream.set_read_timeout(Some(RPC_TIMEOUT))?;
+    stream.set_write_timeout(Some(RPC_TIMEOUT))?;
+    stream.write_all(br#"{"method":"containerManager.ProcfsDump","arg":{}}"#)?;
+
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 65536];
+    loop {
+        let n = stream.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.len() > RPC_MAX_RESPONSE {
+            return Err(std::io::Error::other("oversized urpc response"));
+        }
+        if json_complete(&buf) {
+            break;
+        }
+    }
+    parse_dump_response(&buf)
+}
+
+/// The urpc response has no length framing — it is one JSON object on a
+/// stream socket — so completion is detected by brace balance outside
+/// string literals.
+fn json_complete(buf: &[u8]) -> bool {
+    let mut depth = 0i64;
+    let mut in_str = false;
+    let mut esc = false;
+    let mut seen = false;
+    for &b in buf {
+        if esc {
+            esc = false;
+            continue;
+        }
+        match b {
+            b'\\' if in_str => esc = true,
+            b'"' => in_str = !in_str,
+            b'{' | b'[' if !in_str => {
+                depth += 1;
+                seen = true;
+            }
+            b'}' | b']' if !in_str => depth -= 1,
+            _ => {}
+        }
+    }
+    seen && depth == 0
+}
+
+#[derive(Deserialize)]
+struct UrpcResponse {
+    #[serde(default)]
+    success: bool,
+    #[serde(default)]
+    err: String,
+    #[serde(default)]
+    result: Vec<GuestProcess>,
+}
+
+fn parse_dump_response(buf: &[u8]) -> std::io::Result<Vec<GuestProcess>> {
+    let resp: UrpcResponse = serde_json::from_slice(buf)
+        .map_err(|e| std::io::Error::other(format!("urpc decode: {e}")))?;
+    if !resp.success {
+        return Err(std::io::Error::other(format!("urpc error: {}", resp.err)));
+    }
+    Ok(resp.result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured from a live runsc (release-20260622.0, systrap) via
+    /// `containerManager.ProcfsDump`; trimmed to one process, values
+    /// verbatim (addresses are decimal in the wire format).
+    const DUMP_FIXTURE: &str = r#"{"success":true,"err":"","result":[{
+        "exe":"/bin/guestbox",
+        "args":["/bin/sh","-c","i=0; while true; do i=$((i+1)); done"],
+        "clone_ts":1783097237157224250,
+        "status":{"comm":"sh","pid":1,"ppid":0},
+        "maps":[
+            {"address":{"Start":405504,"End":425984},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "private":"p","offset":0,"pathname":"[usertrap]"},
+            {"address":{"Start":4194304,"End":5316608},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "private":"p","offset":0,"deviceMinor":17,"inode":8,
+             "pathname":"/bin/guestbox"},
+            {"address":{"Start":7409664,"End":7421952},
+             "permissions":{"Read":true,"Write":true,"Execute":false},
+             "private":"p","offset":1118208,"deviceMinor":17,"inode":8,
+             "pathname":"/bin/guestbox"},
+            {"address":{"Start":7426048,"End":7430144},
+             "permissions":{"Read":true,"Write":true,"Execute":false},
+             "private":"p","offset":0,"pathname":"[heap]"},
+            {"address":{"Start":139437156392960,"End":139437164781568},
+             "permissions":{"Read":true,"Write":true,"Execute":false},
+             "private":"p","offset":0,"pathname":"[stack]"}
+        ]}]}"#;
+
+    #[test]
+    fn test_parse_dump_fixture() {
+        let procs = parse_dump_response(DUMP_FIXTURE.as_bytes()).unwrap();
+        assert_eq!(procs.len(), 1);
+        let p = &procs[0];
+        assert_eq!(p.comm(), "sh");
+        assert_eq!(p.pid(), 1);
+        assert_eq!(p.exe, "/bin/guestbox");
+        assert_eq!(p.clone_ts_ns, 1783097237157224250);
+        assert_eq!(p.maps.len(), 5);
+    }
+
+    #[test]
+    fn test_lookup_classification() {
+        let procs = parse_dump_response(DUMP_FIXTURE.as_bytes()).unwrap();
+        let p = &procs[0];
+
+        // Guest text: file offset math against the mapping base.
+        match p.lookup(0x400000 + 0x1234) {
+            GuestAddr::File {
+                guest_path,
+                file_offset,
+                module,
+            } => {
+                assert_eq!(guest_path, "/bin/guestbox");
+                assert_eq!(file_offset, 0x1234);
+                assert_eq!(module, "guestbox");
+            }
+            other => panic!("expected File, got {other:?}"),
+        }
+
+        // Data segment carries its own file offset.
+        match p.lookup(7409664 + 0x10) {
+            GuestAddr::File { file_offset, .. } => assert_eq!(file_offset, 1118208 + 0x10),
+            other => panic!("expected File, got {other:?}"),
+        }
+
+        // The Sentry labels its trampoline table; heap/stack are guest
+        // anonymous; unmapped is unmapped.
+        assert_eq!(p.lookup(405504 + 0x100), GuestAddr::Runtime);
+        assert_eq!(p.lookup(7426048 + 0x10), GuestAddr::Anon);
+        assert_eq!(p.lookup(0xdead_0000_0000), GuestAddr::Unmapped);
+    }
+
+    #[test]
+    fn test_correlate_containment() {
+        let procs = parse_dump_response(DUMP_FIXTURE.as_bytes()).unwrap();
+        let index = SandboxIndex {
+            sandboxes: vec![Sandbox { processes: procs }],
+        };
+
+        // A stub's file view is fragments of the guest text range
+        // (usertrap islands split it) — containment must match.
+        let stub_fragments = vec![(0x400000u64, 0x4c2000u64), (0x4c3000u64, 0x4cd000u64)];
+        let p = index.correlate(&stub_fragments).expect("must correlate");
+        assert_eq!(p.comm(), "sh");
+
+        // A range outside every guest mapping must not correlate.
+        assert!(index
+            .correlate(&[(0x7f00_0000_0000, 0x7f00_0000_1000)])
+            .is_none());
+        // Partial agreement (one matching, one alien) must not correlate.
+        assert!(index
+            .correlate(&[(0x400000, 0x4c2000), (0x7f00_0000_0000, 0x7f00_0000_1000)])
+            .is_none());
+        // Empty stub view never correlates.
+        assert!(index.correlate(&[]).is_none());
+    }
+
+    #[test]
+    fn test_json_complete() {
+        assert!(json_complete(br#"{"a":1}"#));
+        assert!(json_complete(br#"{"a":"}{"}"#), "braces in strings ignored");
+        assert!(json_complete(br#"{"a":"\"}{"}"#), "escapes handled");
+        assert!(!json_complete(br#"{"a":1"#));
+        assert!(!json_complete(b""));
+        assert!(json_complete(DUMP_FIXTURE.as_bytes()));
+    }
+
+    #[test]
+    fn test_error_response() {
+        let err = parse_dump_response(br#"{"success":false,"err":"nope","result":[]}"#);
+        assert!(err.is_err());
+        let garbage = parse_dump_response(b"not json");
+        assert!(garbage.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod validation;
 
 // Tracing modules (previously in binary only)
 pub mod events;
+pub mod gvisor_guest;
 pub mod marker_recorder;
 pub mod memory_recorder;
 pub mod network_recorder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,10 @@ struct Command {
     /// labels like "unknown ([gvisor:runtime]) <0x...>" or "unknown ([jit:node]) <0x...>"
     #[arg(long)]
     no_frame_labels: bool,
+    /// Do not query gVisor sandboxes' control sockets for guest maps during
+    /// symbolization
+    #[arg(long)]
+    no_gvisor_guest_maps: bool,
     /// Disable scheduler event tracing (sched_* tracepoints and scheduler event recorder)
     #[arg(long)]
     no_sched: bool,
@@ -187,6 +191,7 @@ impl From<Command> for Config {
             pystacks_debug: cmd.pystacks_debug,
             enable_debuginfod: cmd.enable_debuginfod,
             no_frame_labels: cmd.no_frame_labels,
+            no_gvisor_guest_maps: cmd.no_gvisor_guest_maps,
             no_sched: cmd.no_sched,
             syscalls: cmd.syscalls,
             markers: cmd.markers,

--- a/src/sandbox_maps.rs
+++ b/src/sandbox_maps.rs
@@ -160,6 +160,18 @@ impl ProcessMaps {
         self.gvisor_exe || self.gvisor_memfd
     }
 
+    /// Executable file-backed ranges of this process — for a systrap stub,
+    /// the fragments of guest text it maps directly. Used as the
+    /// fingerprint for correlating a stub to the guest process it mirrors
+    /// (stub VAs are guest VAs).
+    pub fn exec_file_ranges(&self) -> Vec<(u64, u64)> {
+        self.entries
+            .iter()
+            .filter(|e| e.exec && matches!(e.backing, Backing::File(_)))
+            .map(|e| (e.start, e.end))
+            .collect()
+    }
+
     fn entry_for(&self, addr: u64) -> Option<&MapEntry> {
         // Entries are in address order as read from /proc.
         self.entries

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
+use crate::gvisor_guest::{GuestAddr, GuestProcess, SandboxIndex};
 use crate::pystacks::stack_walker::{PyAddr, StackWalkerRun};
 use crate::record::RecordCollector;
 use crate::ringbuf::RingBuffer;
@@ -483,6 +484,15 @@ fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32,
     )))
 }
 
+/// Everything known about one live process while symbolizing its user
+/// frames: the blazesym process source, the host-side maps analysis, and —
+/// for sandbox stubs — the guest process they mirror.
+struct UserSymbolizeCtx<'a> {
+    proc_src: &'a Source<'a>,
+    maps: Option<&'a ProcessMaps>,
+    guest: Option<&'a GuestProcess>,
+}
+
 /// Convert BPF stack_event_type (u32) to i8, clamping to valid range.
 /// Valid values are 0 (STACK_SLEEP_UNINTERRUPTIBLE), 1 (STACK_RUNNING), 2 (STACK_SLEEP_INTERRUPTIBLE).
 /// Unknown values are preserved but clamped to i8::MAX to avoid truncation issues.
@@ -526,6 +536,11 @@ pub struct StackRecorder {
     /// `unknown ([exited]) <addr>` — instead of bare hex. See
     /// [`crate::sandbox_maps`].
     frame_labels: bool,
+    /// When set (default), gVisor sandboxes on the host are queried over
+    /// their control sockets so guest processes' own maps refine the
+    /// classification of otherwise-unresolvable frames. See
+    /// [`crate::gvisor_guest`].
+    gvisor_guest_maps: bool,
 }
 
 impl ThreadAwareRecorder for StackRecorder {
@@ -553,12 +568,18 @@ impl StackRecorder {
             spill_dir: None,
             utid_generator,
             frame_labels: true,
+            gvisor_guest_maps: true,
         }
     }
 
     /// Disable contextual labels on unresolvable frames (revert to bare hex).
     pub fn set_frame_labels(&mut self, enabled: bool) {
         self.frame_labels = enabled;
+    }
+
+    /// Disable querying gVisor control sockets for guest maps.
+    pub fn set_gvisor_guest_maps(&mut self, enabled: bool) {
+        self.gvisor_guest_maps = enabled;
     }
 
     /// Enable streaming mode and attach a collector so that StackSampleRecords
@@ -759,6 +780,10 @@ impl StackRecorder {
             );
         };
 
+        // Guest-side sandbox snapshot, taken lazily on the first gVisor
+        // process encountered and shared by every group after it.
+        let mut sandbox_index: Option<SandboxIndex> = None;
+
         for mut bucket in respill {
             // Load this bucket's records and group by tgid so each process's
             // user addresses go through one Process source and one cache.
@@ -785,6 +810,25 @@ impl StackRecorder {
                 // frame labels for its whole group. `None` (process raced to
                 // exit, unreadable maps) degrades to plain symbolization.
                 let maps_info = ProcessMaps::load(tgid);
+                // For sandbox processes, the guest process this stub mirrors
+                // (if any). The sandbox snapshot is taken once, on first
+                // contact with a gVisor process.
+                let mut guest: Option<&GuestProcess> = None;
+                if self.gvisor_guest_maps {
+                    if let Some(m) = maps_info.as_ref().filter(|m| m.is_gvisor()) {
+                        if sandbox_index.is_none() {
+                            sandbox_index = Some(SandboxIndex::load());
+                        }
+                        guest = sandbox_index
+                            .as_ref()
+                            .and_then(|idx| idx.correlate(&m.exec_file_ranges()));
+                    }
+                }
+                let ctx = UserSymbolizeCtx {
+                    proc_src: &proc_src,
+                    maps: maps_info.as_ref(),
+                    guest,
+                };
                 // Per-process user-address cache, freed with the group. Survives
                 // a mid-group rebuild, so already-resolved addresses are not
                 // re-done.
@@ -797,7 +841,7 @@ impl StackRecorder {
                     let frame_names = self.symbolize_stack_frames(
                         &mut symbolizer,
                         &stack,
-                        Some((&proc_src, &mut user_cache, maps_info.as_ref())),
+                        Some((&ctx, &mut user_cache)),
                         &kernel_src,
                         &mut kernel_cache,
                     );
@@ -817,23 +861,24 @@ impl StackRecorder {
     /// Symbolize one user-space address of a live process: regular process
     /// symbolization, then — for sandboxed processes — bridging of
     /// pool-memfd islands back to their original file (see
-    /// [`crate::sandbox_maps`]), then the most specific label available.
+    /// [`crate::sandbox_maps`]), then the guest's own view of the address
+    /// (see [`crate::gvisor_guest`]), then the most specific label
+    /// available from the host side.
     fn symbolize_user_addr(
         &self,
         symbolizer: &mut Symbolizer,
-        proc_src: &Source<'_>,
-        maps_info: Option<&ProcessMaps>,
+        ctx: &UserSymbolizeCtx<'_>,
         addr: u64,
     ) -> String {
         if let Some(sym) = symbolizer
-            .symbolize_single(proc_src, Input::AbsAddr(addr))
+            .symbolize_single(ctx.proc_src, Input::AbsAddr(addr))
             .ok()
             .and_then(|s| s.into_sym())
         {
             return format_symbolized_frame(&sym, addr, "unknown");
         }
 
-        if let Some(bridge) = maps_info.and_then(|m| m.bridge_for(addr)) {
+        if let Some(bridge) = ctx.maps.and_then(|m| m.bridge_for(addr)) {
             let elf_src = Source::Elf(Elf::new(&bridge.map_files_path));
             if let Some(sym) = symbolizer
                 .symbolize_single(&elf_src, Input::FileOffset(bridge.file_offset))
@@ -846,26 +891,44 @@ impl StackRecorder {
             }
         }
 
-        if self.frame_labels {
-            crate::sandbox_maps::format_unresolved(addr, maps_info)
-        } else {
-            format!("0x{addr:x}")
+        if !self.frame_labels {
+            return format!("0x{addr:x}");
         }
+
+        // The guest's own maps are authoritative where the host view is a
+        // pool memfd: they name the file a pool-backed range belongs to and
+        // bound the runtime-injected regions exactly.
+        if let Some(guest) = ctx.guest {
+            match guest.lookup(addr) {
+                GuestAddr::File { module, .. } => {
+                    return format!("unknown ({module}) <{addr:#x}>");
+                }
+                GuestAddr::Runtime => {
+                    return format!("unknown ([gvisor:runtime]) <{addr:#x}>");
+                }
+                GuestAddr::Anon => {
+                    return format!("unknown ([gvisor:guest]) <{addr:#x}>");
+                }
+                GuestAddr::Unmapped => {}
+            }
+        }
+
+        crate::sandbox_maps::format_unresolved(addr, ctx.maps)
     }
 
     /// Symbolize a single stack and return frame names.
     ///
-    /// `user` carries the process source, per-process address cache, and
-    /// optional maps analysis for a live process; `None` means the process
-    /// has exited, in which case user addresses cannot be symbolized (no
-    /// /proc/<pid>/maps) and are rendered as `unknown ([exited]) <addr>` (or
-    /// raw hex with labels disabled). Kernel addresses go through the shared
+    /// `user` carries the symbolization context and per-process address
+    /// cache for a live process; `None` means the process has exited, in
+    /// which case user addresses cannot be symbolized (no /proc/<pid>/maps)
+    /// and are rendered as `unknown ([exited]) <addr>` (or raw hex with
+    /// labels disabled). Kernel addresses go through the shared
     /// `kernel_cache`.
     fn symbolize_stack_frames(
         &self,
         symbolizer: &mut Symbolizer,
         stack: &Stack,
-        user: Option<(&Source<'_>, &mut HashMap<u64, String>, Option<&ProcessMaps>)>,
+        user: Option<(&UserSymbolizeCtx<'_>, &mut HashMap<u64, String>)>,
         kernel_src: &Source<'_>,
         kernel_cache: &mut HashMap<u64, String>,
     ) -> Vec<String> {
@@ -879,13 +942,12 @@ impl StackRecorder {
 
         // Symbolize user addresses (leaf)
         match user {
-            Some((proc_src, user_cache, maps_info)) => {
+            Some((ctx, user_cache)) => {
                 for &addr in &stack.user_stack {
                     let frame_name = match user_cache.get(&addr) {
                         Some(name) => name.clone(),
                         None => {
-                            let name =
-                                self.symbolize_user_addr(symbolizer, proc_src, maps_info, addr);
+                            let name = self.symbolize_user_addr(symbolizer, ctx, addr);
                             user_cache.insert(addr, name.clone());
                             name
                         }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -521,6 +521,8 @@ pub struct Config {
     /// Render frames that fail symbolization as bare hex instead of
     /// contextual labels (`unknown ([gvisor:runtime]) <addr>`, ...)
     pub no_frame_labels: bool,
+    /// Do not query gVisor sandboxes' control sockets for guest maps
+    pub no_gvisor_guest_maps: bool,
     /// Disable scheduler tracing
     pub no_sched: bool,
     /// Enable syscall tracing
@@ -597,6 +599,7 @@ impl Default for Config {
             pystacks_debug: false,
             enable_debuginfod: false,
             no_frame_labels: false,
+            no_gvisor_guest_maps: false,
             no_sched: false,
             syscalls: false,
             markers: false,
@@ -1358,6 +1361,13 @@ fn configure_recorder(opts: &Config, recorder: &Arc<SessionRecorder>) {
             .lock()
             .unwrap()
             .set_frame_labels(false);
+    }
+    if opts.no_gvisor_guest_maps {
+        recorder
+            .stack_recorder
+            .lock()
+            .unwrap()
+            .set_gvisor_guest_maps(false);
     }
 }
 

--- a/tests/gvisor_record.rs
+++ b/tests/gvisor_record.rs
@@ -311,6 +311,34 @@ fn test_gvisor_record() {
         runsc_tids.len()
     );
 
+    // Guest-side truth over the control socket: point discovery at our
+    // private state root (also picked up by the recording below), dump the
+    // live sandbox, and correlate a real stub's address space to the guest
+    // shell — end to end against the running runsc.
+    std::env::set_var("SYSTING_RUNSC_ROOTS", state_root.path());
+    let sandbox_index = systing::gvisor_guest::SandboxIndex::load();
+    assert!(
+        !sandbox_index.is_empty(),
+        "[gvisor guest maps] control socket in {} not reachable",
+        state_root.path().display()
+    );
+    let correlated = runsc_tids.iter().find_map(|tid| {
+        let maps = systing::sandbox_maps::ProcessMaps::load(*tid)?;
+        if !maps.is_gvisor() {
+            return None;
+        }
+        let ranges = maps.exec_file_ranges();
+        sandbox_index
+            .correlate(&ranges)
+            .map(|g| g.comm().to_string())
+    });
+    eprintln!("stub correlation result: {correlated:?}");
+    assert_eq!(
+        correlated.as_deref(),
+        Some("sh"),
+        "[gvisor guest maps] no stub correlated to the guest shell"
+    );
+
     eprintln!("Recording trace ({GVISOR_RECORDING_DURATION_SECS}s, sandboxed exec loop)...");
     let config = Config {
         duration: GVISOR_RECORDING_DURATION_SECS,


### PR DESCRIPTION
Second phase of the gVisor symbolization work from #137: consume the *guest's own* view of
its address space, so classification no longer depends on host-side inference where the
Sentry has the authoritative answer.

## Mechanism

runsc's per-sandbox control socket (`<state-root>/runsc-<sandbox-id>.sock`) serves
`containerManager.ProcfsDump`: per guest process, the full guest maps (path, offset,
permissions), comm/exe/args, and task creation time. The wire protocol is one JSON
request/response over a unix stream socket. Crucially this is Sentry-side only — nothing
executes inside the guest, unlike `runsc exec`-based approaches, which makes it appropriate
for a profiler to do routinely.

The new `gvisor_guest` module:

- **Discovery**: probes the containerd-shim and standalone state roots
  (`SYSTING_RUNSC_ROOTS` overrides) for control sockets, one `ProcfsDump` per sandbox, once
  per symbolization pass and only after a gVisor process is actually encountered.
  Defenses for production nodes: per-call timeouts, a response size cap, and a total
  enumeration budget so a host full of wedged sandboxes cannot stall the pass — any
  failure just degrades that sandbox to host-only symbolization.
- **Correlation**: a stub is matched to the guest process it mirrors by exec-file range
  containment. Stub VAs are guest VAs under systrap, and the stub's file view is a fragment
  set of the guest's (syscall-patch islands split it), so every stub exec-file range must be
  contained in some guest range. Fork-siblings tie with identical layouts and symbolize
  identically, so ties are benign.
- **Lookup**: for a correlated process, one address query answers file (guest path + file
  offset + module), `[usertrap]` (runtime-injected), guest-anonymous, or unmapped.

The symbolization chain gains one step, between island bridging and the host-side label
fallback. What changes in output:

| case | before | after |
|---|---|---|
| pool-backed guest file mapping (copied-up, donation-less configs) | `unknown ([gvisor:guest])` | `unknown (<real module>)` |
| usertrap trampoline region | `[gvisor:runtime]` via below-image heuristic | `[gvisor:runtime]` via the Sentry's own `[usertrap]` label |
| guest anon (JIT output, heap) | inferred `[gvisor:guest]` | confirmed `[gvisor:guest]` |

`--no-gvisor-guest-maps` disables the lookups entirely. With them disabled (or the socket
unreachable, or nothing correlated) behavior is exactly #137's.

## Deliberately not in this PR

- **Guest comm/pid attribution enrichment** (naming stub processes after their guest
  workload): high value, but process records are written before the stack pass runs, so it
  needs its own ordering design — next PR.
- **Symbolizing pool-backed file content via the container rootfs**: `GuestAddr::File`
  carries the guest path and file offset as the seam, but resolving guest paths to host
  files (bundle `root.path`, multi-container ambiguity, staleness of copied-up binaries)
  is left until a deployment demonstrates the need — on the cluster measured in #137's
  analysis, gofer FD donation makes file-backed text resolve host-side already.
- Guest perf-map translation (guest `/tmp` is usually sandbox-internal tmpfs — needs the
  rootfs work above where it's feasible at all) and pystacks-in-sandbox.

## Validation

- Wire format and response shape verified against a live sandbox first (runsc
  `release-20260622.0`, systrap): the module's test fixture is the captured `ProcfsDump`
  response, values verbatim.
- Unit tests: wire framing (brace-balance completion incl. string/escape cases), fixture
  parsing, address classification (file offset math, `[usertrap]`, anon, unmapped), and
  correlation (fragment containment, alien-range rejection, partial-agreement rejection).
- The gVisor integration test now also drives the new path against the sandbox it launches:
  control socket reached in the test's private state root, dump parsed, and a live stub
  correlated back to the guest shell — asserted as `comm == "sh"`. Green under
  virtme-ng/QEMU-TCG on a BPF 6.12 kernel alongside all of #137's assertions
  (38K resolved-user frames of which 12K guest-module, labels present).
- `cargo test` (377), fmt, `clippy --no-default-features -- -D warnings` clean.

Reviewed pre-commit per repo policy (rust-bpf-code-reviewer): the review caught a missing
total-enumeration budget (a host of wedged sandboxes would have stalled symbolization —
fixed) and a match-over-if/else cleanup in the guest lookup (applied); non-schema patch
bump to 1.10.5 included.
