### PR TITLE
Poll missed-event counters into per-class counter tracks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.9"
+version = "1.10.10"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/gopclntab"]
 
 [package]
 name = "systing"
-version = "1.10.9"
+version = "1.10.10"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -145,6 +145,7 @@ pub struct SessionRecorder {
     pub stack_recorder: Mutex<StackRecorder>,
     pub perf_counter_recorder: Mutex<PerfCounterRecorder>,
     pub sysinfo_recorder: Mutex<SysinfoRecorder>,
+    pub missed_events_recorder: Mutex<MissedEventsRecorder>,
     pub probe_recorder: Mutex<SystingProbeRecorder>,
     pub network_recorder: Mutex<NetworkRecorder>,
     pub memory_recorder: Mutex<MemoryRecorder>,
@@ -631,6 +632,149 @@ impl SysinfoRecorder {
     }
 }
 
+/// Labels for the BPF `missed_events` map classes, index-matched to the
+/// MISSED_*_EVENT defines in systing_system.bpf.c. Wording matches the exit
+/// summary lines so the in-trace tracks and the final printout name the same
+/// things.
+pub const MISSED_EVENT_CLASS_LABELS: &[(u32, &str)] = &[
+    (0, "sched/IRQ"),
+    (1, "stack"),
+    (2, "probe"),
+    (3, "cache"),
+    (4, "network"),
+    (5, "packet"),
+    (6, "poll"),
+    (7, "marker"),
+    (8, "memory"),
+];
+
+/// One sample of one missed-event class: the cumulative (per-CPU-summed)
+/// counter for `class` as read from the BPF `missed_events` map at `ts`.
+#[derive(Default, Clone, Copy)]
+pub struct MissedEvent {
+    pub ts: u64,
+    pub class: u32,
+    pub count: u64,
+}
+
+/// Records per-class missed-event counts as counter tracks, so event loss is
+/// visible and time-localized in the trace instead of only in the exit
+/// summary. Same streaming shape as `SysinfoRecorder`: one counter track per
+/// class, created lazily on the first sample; values are the map's cumulative
+/// totals, so a loss burst shows up as a step at the second it happened.
+pub struct MissedEventsRecorder {
+    pub ringbuf: RingBuffer<MissedEvent>,
+    streaming_collector: Option<Box<dyn RecordCollector + Send>>,
+    track_ids: HashMap<u32, i64>,
+    /// Shared with every other recorder that emits counter tracks so track
+    /// IDs stay unique across them.
+    counter_track_ids: Arc<CounterTrackIdGenerator>,
+    utid_generator: Arc<UtidGenerator>,
+}
+
+impl ThreadAwareRecorder for MissedEventsRecorder {
+    fn utid_generator(&self) -> &UtidGenerator {
+        &self.utid_generator
+    }
+}
+
+impl MissedEventsRecorder {
+    pub fn new(
+        utid_generator: Arc<UtidGenerator>,
+        counter_track_ids: Arc<CounterTrackIdGenerator>,
+    ) -> Self {
+        Self {
+            ringbuf: RingBuffer::default(),
+            streaming_collector: None,
+            track_ids: HashMap::new(),
+            counter_track_ids,
+            utid_generator,
+        }
+    }
+
+    fn class_label(class: u32) -> &'static str {
+        MISSED_EVENT_CLASS_LABELS
+            .iter()
+            .find(|(idx, _)| *idx == class)
+            .map(|(_, label)| *label)
+            .unwrap_or("unknown")
+    }
+
+    /// Note: this recorder writes counter / counter_track rows, the same
+    /// tables the perf-counter and sysinfo recorders write to, so the
+    /// collector passed here must share its underlying writer with those
+    /// recorders (see `SharedCollector`).
+    pub fn set_streaming_collector(&mut self, collector: Box<dyn RecordCollector + Send>) {
+        self.streaming_collector = Some(collector);
+    }
+
+    /// Finish streaming and return the collector for finalization.
+    pub fn finish(&mut self) -> Result<Option<Box<dyn RecordCollector + Send>>> {
+        if let Some(mut collector) = self.streaming_collector.take() {
+            collector.flush()?;
+            self.track_ids.clear();
+            Ok(Some(collector))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+impl SystingRecordEvent<MissedEvent> for MissedEventsRecorder {
+    fn ringbuf(&self) -> &RingBuffer<MissedEvent> {
+        &self.ringbuf
+    }
+    fn ringbuf_mut(&mut self) -> &mut RingBuffer<MissedEvent> {
+        &mut self.ringbuf
+    }
+    fn handle_event(&mut self, event: MissedEvent) {
+        debug_assert!(
+            self.streaming_collector.is_some(),
+            "streaming collector must be set before handling events"
+        );
+
+        let Some(ref mut collector) = self.streaming_collector else {
+            return;
+        };
+
+        let class = event.class;
+        let track_id = if let Some(&id) = self.track_ids.get(&class) {
+            id
+        } else {
+            // First sample for this class - create the track
+            let track_id = self.counter_track_ids.next_id();
+
+            // "count" is the validated counter-unit vocabulary's term for
+            // event counts (see VALID_COUNTER_UNITS) and maps to perfetto's
+            // UNIT_COUNT; the track name already says what is being counted.
+            if let Err(e) = collector.add_counter_track(CounterTrackRecord {
+                id: track_id,
+                name: format!("Missed {} events", Self::class_label(class)),
+                unit: Some("count".to_string()),
+            }) {
+                eprintln!("Warning: Failed to create missed-events track: {e}");
+            }
+
+            self.track_ids.insert(class, track_id);
+            track_id
+        };
+
+        if let Err(e) = collector.add_counter(CounterRecord {
+            ts: event.ts as i64,
+            track_id,
+            value: event.count as f64,
+        }) {
+            eprintln!("Warning: Failed to stream missed-events record: {e}");
+        }
+    }
+}
+
+impl crate::systing_core::SystingEvent for MissedEvent {
+    fn ts(&self) -> u64 {
+        self.ts
+    }
+}
+
 impl SessionRecorder {
     pub fn new(
         enable_debuginfod: bool,
@@ -662,6 +806,10 @@ impl SessionRecorder {
                 Arc::clone(&counter_track_ids),
             )),
             sysinfo_recorder: Mutex::new(SysinfoRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&counter_track_ids),
+            )),
+            missed_events_recorder: Mutex::new(MissedEventsRecorder::new(
                 Arc::clone(&utid_generator),
                 Arc::clone(&counter_track_ids),
             )),
@@ -883,6 +1031,7 @@ impl SessionRecorder {
         self.stack_recorder.lock().unwrap().drain_ringbuf();
         self.perf_counter_recorder.lock().unwrap().drain_ringbuf();
         self.sysinfo_recorder.lock().unwrap().drain_ringbuf();
+        self.missed_events_recorder.lock().unwrap().drain_ringbuf();
         self.probe_recorder.lock().unwrap().drain_ringbuf();
         self.network_recorder.lock().unwrap().drain_ringbuf();
         self.marker_recorder.lock().unwrap().drain_ringbuf();
@@ -1077,18 +1226,23 @@ impl SessionRecorder {
             .unwrap()
             .set_streaming_collector(Box::new(make_writer()));
 
-        // The perf-counter and sysinfo (CPU frequency) recorders both emit
-        // counter / counter_track rows, which map to the same counter.parquet /
-        // counter_track.parquet files. They must share a single writer: with
-        // separate writers both would create the same files and the last one to
-        // finish would clobber the other's data. Track IDs come from the shared
-        // CounterTrackIdGenerator so they never collide either.
+        // The perf-counter, sysinfo (CPU frequency), and missed-events
+        // recorders all emit counter / counter_track rows, which map to the
+        // same counter.parquet / counter_track.parquet files. They must share
+        // a single writer: with separate writers each would create the same
+        // files and the last one to finish would clobber the others' data.
+        // Track IDs come from the shared CounterTrackIdGenerator so they
+        // never collide either.
         let counter_writer = SharedCollector::new(Box::new(make_writer()));
         self.perf_counter_recorder
             .lock()
             .unwrap()
             .set_streaming_collector(Box::new(counter_writer.clone()));
         self.sysinfo_recorder
+            .lock()
+            .unwrap()
+            .set_streaming_collector(Box::new(counter_writer.clone()));
+        self.missed_events_recorder
             .lock()
             .unwrap()
             .set_streaming_collector(Box::new(counter_writer));
@@ -1325,6 +1479,12 @@ impl SessionRecorder {
             sysinfo_collector.finish_boxed()?;
         }
         stage_done("Flushed sysinfo records", &mut stage_start);
+
+        eprintln!("Flushing missed-event records from streaming...");
+        if let Some(missed_collector) = self.missed_events_recorder.lock().unwrap().finish()? {
+            missed_collector.finish_boxed()?;
+        }
+        stage_done("Flushed missed-event records", &mut stage_start);
 
         // The probe recorder (trace-events/syscalls) and the marker recorder both
         // emit track/slice/instant/args rows, which map to the same parquet files.
@@ -1601,6 +1761,10 @@ mod tests {
                 Arc::clone(&counter_track_ids),
             )),
             sysinfo_recorder: Mutex::new(SysinfoRecorder::new(
+                Arc::clone(&utid_generator),
+                Arc::clone(&counter_track_ids),
+            )),
+            missed_events_recorder: Mutex::new(MissedEventsRecorder::new(
                 Arc::clone(&utid_generator),
                 Arc::clone(&counter_track_ids),
             )),
@@ -2225,5 +2389,197 @@ mod tests {
             ts > 0,
             "Should return current BOOTTIME when no events recorded"
         );
+    }
+
+    // =========================================================================
+    // MissedEventsRecorder
+    // =========================================================================
+
+    /// Streams two classes of missed-event samples through a real parquet
+    /// writer and reads them back: one track per class with exit-summary
+    /// naming, samples in order with cumulative values intact.
+    #[test]
+    fn test_missed_events_recorder_streams_counter_tracks() {
+        use crate::parquet::StreamingParquetWriter;
+        use crate::systing_core::SystingRecordEvent;
+        use arrow::array::{Float64Array, Int64Array, StringArray};
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use std::fs::File;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let mut rec = MissedEventsRecorder::new(
+            Arc::new(UtidGenerator::new()),
+            Arc::new(CounterTrackIdGenerator::new()),
+        );
+        rec.set_streaming_collector(Box::new(StreamingParquetWriter::new(dir.path()).unwrap()));
+
+        // Non-continuous mode streams straight through handle_event. Two
+        // classes, two samples each; class 0 steps 0 -> 7 at the second
+        // sample (a loss burst must appear as a step, not a fresh track).
+        rec.record_event(MissedEvent {
+            ts: 1_000,
+            class: 0,
+            count: 0,
+        });
+        rec.record_event(MissedEvent {
+            ts: 1_000,
+            class: 1,
+            count: 0,
+        });
+        rec.record_event(MissedEvent {
+            ts: 2_000,
+            class: 0,
+            count: 7,
+        });
+        rec.record_event(MissedEvent {
+            ts: 2_000,
+            class: 1,
+            count: 0,
+        });
+
+        let collector = rec.finish().unwrap().expect("collector was set");
+        collector.finish_boxed().unwrap();
+
+        // counter_track.parquet: exactly one track per class, named like the
+        // exit summary lines.
+        let file = File::open(dir.path().join("counter_track.parquet")).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut tracks = Vec::new(); // (id, name)
+        for batch in reader.collect::<Result<Vec<_>, _>>().unwrap() {
+            let ids = batch
+                .column_by_name("id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let names = batch
+                .column_by_name("name")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            let units = batch
+                .column_by_name("unit")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap();
+            for i in 0..batch.num_rows() {
+                assert_eq!(
+                    units.value(i),
+                    "count",
+                    "unit must stay in the validated counter-unit vocabulary"
+                );
+                tracks.push((ids.value(i), names.value(i).to_string()));
+            }
+        }
+        let mut names: Vec<_> = tracks.iter().map(|(_, n)| n.clone()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "Missed sched/IRQ events".to_string(),
+                "Missed stack events".to_string()
+            ],
+            "one track per class, exit-summary naming, no duplicates"
+        );
+        let sched_track_id = tracks
+            .iter()
+            .find(|(_, n)| n == "Missed sched/IRQ events")
+            .unwrap()
+            .0;
+
+        // counter.parquet: the sched track carries [0, 7] in ts order.
+        let file = File::open(dir.path().join("counter.parquet")).unwrap();
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let mut sched_samples = Vec::new(); // (ts, value)
+        let mut total_samples = 0;
+        for batch in reader.collect::<Result<Vec<_>, _>>().unwrap() {
+            let ts = batch
+                .column_by_name("ts")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let track_ids = batch
+                .column_by_name("track_id")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            let values = batch
+                .column_by_name("value")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap();
+            for i in 0..batch.num_rows() {
+                total_samples += 1;
+                if track_ids.value(i) == sched_track_id {
+                    sched_samples.push((ts.value(i), values.value(i)));
+                }
+            }
+        }
+        assert_eq!(total_samples, 4, "all four samples survive");
+        sched_samples.sort_by_key(|(ts, _)| *ts);
+        assert_eq!(
+            sched_samples,
+            vec![(1_000, 0.0), (2_000, 7.0)],
+            "cumulative values ride the same track in ts order"
+        );
+    }
+
+    /// In continuous mode samples buffer in the ring and only reach the
+    /// collector on drain, so the flight-recorder window rotation applies to
+    /// loss counters like any other event.
+    #[test]
+    fn test_missed_events_recorder_continuous_drains_through_ringbuf() {
+        use crate::parquet::StreamingParquetWriter;
+        use crate::systing_core::SystingRecordEvent;
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use std::fs::File;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let mut rec = MissedEventsRecorder::new(
+            Arc::new(UtidGenerator::new()),
+            Arc::new(CounterTrackIdGenerator::new()),
+        );
+        rec.set_streaming_collector(Box::new(StreamingParquetWriter::new(dir.path()).unwrap()));
+        rec.ringbuf.set_max_duration(1_000_000_000);
+
+        rec.record_event(MissedEvent {
+            ts: 1_000,
+            class: 0,
+            count: 3,
+        });
+        assert_eq!(
+            rec.track_ids.len(),
+            0,
+            "continuous-mode samples must buffer in the ring, not stream"
+        );
+
+        rec.drain_ringbuf();
+        let collector = rec.finish().unwrap().expect("collector was set");
+        collector.finish_boxed().unwrap();
+
+        let file = File::open(dir.path().join("counter.parquet")).unwrap();
+        let rows: usize = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+            .iter()
+            .map(|b| b.num_rows())
+            .sum();
+        assert_eq!(rows, 1, "drained sample reaches the collector");
     }
 }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -27,7 +27,7 @@ use crate::perf_recorder::PerfCounterRecorder;
 use crate::ringbuf::RingBuffer;
 use crate::sched::SchedEventRecorder;
 use crate::session_recorder::{
-    get_clock_value, ClockSamplingConfig, SessionRecorder, SysInfoEvent,
+    get_clock_value, ClockSamplingConfig, MissedEvent, SessionRecorder, SysInfoEvent,
 };
 use crate::stack_recorder::StackRecorder;
 
@@ -60,6 +60,15 @@ const CONTINUOUS_MODE_STOP_DELAY_SECS: u64 = 1;
 
 /// Interval for refreshing system info like CPU frequency (100ms)
 const SYSINFO_REFRESH_INTERVAL_MS: u64 = 100;
+/// How often the missed-events poller samples the per-class BPF counters
+/// into counter tracks. Coarser than sysinfo: the value is a cumulative
+/// total, so one-second steps localize a loss burst well enough while
+/// keeping the added trace volume negligible.
+const MISSED_EVENTS_POLL_INTERVAL_MS: u64 = 1000;
+/// While waiting out the poll interval the missed-events poller re-checks the
+/// shutdown flag at this granularity, so stopping doesn't have to wait out a
+/// full poll interval.
+const MISSED_EVENTS_SHUTDOWN_CHECK_MS: u64 = 100;
 
 struct ShutdownSignal {
     eventfd: OwnedFd,
@@ -1279,12 +1288,9 @@ fn spawn_recorder_threads(
     Ok(threads)
 }
 
-fn dump_missed_events(skel: &SystingSystemSkel, index: u32) -> u64 {
+fn dump_missed_events(map: &dyn libbpf_rs::MapCore, index: u32) -> u64 {
     let index = index.to_ne_bytes();
-    let result = skel
-        .maps
-        .missed_events
-        .lookup_percpu(&index, libbpf_rs::MapFlags::ANY);
+    let result = map.lookup_percpu(&index, libbpf_rs::MapFlags::ANY);
     let mut missed = 0;
     if let Ok(Some(results)) = result {
         for cpu_data in results {
@@ -1379,6 +1385,12 @@ fn set_ringbuf_duration(recorder: &Arc<SessionRecorder>, duration_nanos: u64) {
         .set_max_duration(duration_nanos);
     recorder
         .sysinfo_recorder
+        .lock()
+        .unwrap()
+        .ringbuf
+        .set_max_duration(duration_nanos);
+    recorder
+        .missed_events_recorder
         .lock()
         .unwrap()
         .ringbuf
@@ -2985,6 +2997,7 @@ fn attach_probes(
 struct ThreadHandles {
     ringbuf_threads: Vec<thread::JoinHandle<i32>>,
     sysinfo_thread: Option<thread::JoinHandle<i32>>,
+    missed_poller_thread: thread::JoinHandle<i32>,
     recorder_threads: Vec<thread::JoinHandle<i32>>,
     discovery_thread: thread::JoinHandle<i32>,
     symbol_loader_thread: thread::JoinHandle<i32>,
@@ -3099,6 +3112,13 @@ fn run_tracing_loop(
     if let Some(thread) = handles.sysinfo_thread {
         thread.join().expect("Failed to join sysinfo thread");
     }
+    // The missed-events poller takes one final sample after it observes the
+    // shutdown flag; the ringbuf threads are already joined by then, so that
+    // sample carries the settled totals.
+    handles
+        .missed_poller_thread
+        .join()
+        .expect("Failed to join missed-events poller thread");
     if let Some(thread) = handles.tpu_metrics_thread {
         if let Err(e) = thread.join() {
             eprintln!("TPU metrics thread panicked: {:?}", e);
@@ -3118,17 +3138,41 @@ fn run_tracing_loop(
         .join()
         .expect("Failed to join symbol thread");
 
-    println!("Missed sched/IRQ events: {}", dump_missed_events(skel, 0));
-    println!("Missed stack events: {}", dump_missed_events(skel, 1));
-    println!("Missed probe events: {}", dump_missed_events(skel, 2));
-    println!("Missed cache events: {}", dump_missed_events(skel, 3));
+    println!(
+        "Missed sched/IRQ events: {}",
+        dump_missed_events(&skel.maps.missed_events, 0)
+    );
+    println!(
+        "Missed stack events: {}",
+        dump_missed_events(&skel.maps.missed_events, 1)
+    );
+    println!(
+        "Missed probe events: {}",
+        dump_missed_events(&skel.maps.missed_events, 2)
+    );
+    println!(
+        "Missed cache events: {}",
+        dump_missed_events(&skel.maps.missed_events, 3)
+    );
     if opts.network {
-        println!("Missed network events: {}", dump_missed_events(skel, 4));
-        println!("Missed packet events: {}", dump_missed_events(skel, 5));
-        println!("Missed poll events: {}", dump_missed_events(skel, 6));
+        println!(
+            "Missed network events: {}",
+            dump_missed_events(&skel.maps.missed_events, 4)
+        );
+        println!(
+            "Missed packet events: {}",
+            dump_missed_events(&skel.maps.missed_events, 5)
+        );
+        println!(
+            "Missed poll events: {}",
+            dump_missed_events(&skel.maps.missed_events, 6)
+        );
     }
     if opts.memory || opts.memory_alloc {
-        println!("Missed memory events: {}", dump_missed_events(skel, 8));
+        println!(
+            "Missed memory events: {}",
+            dump_missed_events(&skel.maps.missed_events, 8)
+        );
     }
     if opts.memory_alloc {
         let enters = sum_percpu_counter(&skel.maps.memory_alloc_enter_count);
@@ -3143,7 +3187,7 @@ fn run_tracing_loop(
     if opts.markers {
         println!(
             "Missed marker events (ringbuf full): {}",
-            dump_missed_events(skel, 7)
+            dump_missed_events(&skel.maps.missed_events, 7)
         );
     }
 
@@ -3617,6 +3661,62 @@ pub fn systing(
             }
         }
 
+        // Poll the per-class missed-event counters into counter tracks so
+        // event loss is visible and time-localized in the trace instead of
+        // only in the exit summary. Always on: it's a handful of map lookups
+        // per second, and "loss was zero the whole run" is itself useful
+        // signal. Only the classes whose subsystems are active this run are
+        // polled - same conditions as the exit summary. The map handle is
+        // duplicated so the thread doesn't borrow the skeleton.
+        let missed_poller_thread = {
+            let missed_map = libbpf_rs::MapHandle::try_from(&skel.maps.missed_events)?;
+            let mut classes: Vec<u32> = vec![0, 1, 2, 3];
+            if opts.network {
+                classes.extend([4, 5, 6]);
+            }
+            if opts.markers {
+                classes.push(7);
+            }
+            if opts.memory || opts.memory_alloc {
+                classes.push(8);
+            }
+            let shutdown_clone = shutdown_signal.clone();
+            let missed_recorder = recorder.clone();
+            thread::Builder::new()
+                .name("missed_poller".to_string())
+                .spawn(move || {
+                    loop {
+                        let stopping = shutdown_clone.load(Ordering::Relaxed);
+                        let ts = get_clock_value(libc::CLOCK_BOOTTIME);
+                        {
+                            let mut rec = missed_recorder.missed_events_recorder.lock().unwrap();
+                            for &class in &classes {
+                                let count = dump_missed_events(&missed_map, class);
+                                rec.record_event(MissedEvent { ts, class, count });
+                            }
+                        }
+                        if stopping {
+                            // This sample ran with the flag already observed:
+                            // the rings are quiesced by the time the flag is
+                            // set, so it carries the settled totals.
+                            break;
+                        }
+                        // Wait out the poll interval in slices, re-checking
+                        // the shutdown flag, so the final sample (and the
+                        // join behind it) isn't delayed by up to a full
+                        // interval after stop.
+                        let mut slept = 0;
+                        while slept < MISSED_EVENTS_POLL_INTERVAL_MS
+                            && !shutdown_clone.load(Ordering::Relaxed)
+                        {
+                            thread::sleep(Duration::from_millis(MISSED_EVENTS_SHUTDOWN_CHECK_MS));
+                            slept += MISSED_EVENTS_SHUTDOWN_CHECK_MS;
+                        }
+                    }
+                    0
+                })?
+        };
+
         // Start TPU profiling thread if enabled.
         // The XLA ProfilerService requires a fixed capture duration upfront, so
         // --tpu-profile is incompatible with indefinite tracing (duration == 0).
@@ -3714,6 +3814,7 @@ pub fn systing(
         let handles = ThreadHandles {
             ringbuf_threads,
             sysinfo_thread,
+            missed_poller_thread,
             recorder_threads: recv_threads,
             discovery_thread,
             symbol_loader_thread: symbol_thread,

--- a/tests/missed_events.rs
+++ b/tests/missed_events.rs
@@ -1,0 +1,167 @@
+//! Integration test for the missed-events counter tracks.
+//!
+//! Records a short trace with the default recorders and verifies that the
+//! per-class "Missed <class> events" counter tracks are present, sampled at
+//! least twice (baseline plus the final post-quiesce sample), and
+//! monotonically non-decreasing (the values are cumulative totals) — and
+//! that classes whose subsystems are disabled in this run leave no tracks
+//! behind.
+//!
+//! Requires root/BPF privileges; run via:
+//! ```
+//! ./scripts/run-integration-tests.sh missed_events
+//! ```
+
+use systing::{systing, Config};
+use tempfile::TempDir;
+
+/// How long the traced workload (and therefore the recording) runs, in
+/// seconds. Long enough for the 1s missed-events poller to take several
+/// samples on top of the baseline and final ones.
+const RECORDING_SECS: u64 = 3;
+
+/// Classes polled on every run (their subsystems are always active).
+const ALWAYS_ON_TRACKS: [&str; 4] = [
+    "Missed sched/IRQ events",
+    "Missed stack events",
+    "Missed probe events",
+    "Missed cache events",
+];
+
+/// Classes whose subsystems are off in this run's config: no tracks allowed.
+const DISABLED_TRACKS: [&str; 5] = [
+    "Missed network events",
+    "Missed packet events",
+    "Missed poll events",
+    "Missed marker events",
+    "Missed memory events",
+];
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_missed_events_counter_tracks() {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let trace_path = dir.path().join("trace.pb");
+
+    // Busy workload so the recording has real event flow while the poller
+    // samples.
+    let run_cmd = vec![
+        "bash".to_string(),
+        "-c".to_string(),
+        format!("end=$((SECONDS+{RECORDING_SECS})); while [ $SECONDS -lt $end ]; do :; done"),
+    ];
+    let traced_child =
+        systing::traced_command::spawn_traced_child(&run_cmd).expect("Failed to spawn child");
+
+    eprintln!(
+        "Recording default trace (pid {}, ~{}s)...",
+        traced_child.pid, RECORDING_SECS
+    );
+
+    let config = Config {
+        parquet_only: true,
+        output_dir: dir.path().to_path_buf(),
+        output: trace_path,
+        ..Config::default()
+    };
+
+    let exit_code = systing(config, Some(traced_child)).expect("systing recording failed");
+    assert_eq!(exit_code, 0, "busy workload should exit with code 0");
+    eprintln!("Recording complete.\n");
+
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "missedevents")
+        .expect("DuckDB conversion failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+
+    // --- Check: every always-on class has exactly one sampled, monotonic track ---
+    for name in ALWAYS_ON_TRACKS {
+        eprintln!("  {name}...");
+        let (tracks, samples, monotonic_violations, min_value): (i64, i64, i64, f64) = conn
+            .query_row(
+                "WITH samples AS (
+                     SELECT c.value,
+                            LAG(c.value) OVER (ORDER BY c.ts) AS prev
+                     FROM counter c
+                     JOIN counter_track ct ON c.track_id = ct.id
+                     WHERE ct.name = ?
+                 )
+                 SELECT (SELECT COUNT(*) FROM counter_track WHERE name = ?),
+                        COUNT(*),
+                        COALESCE(SUM(CASE WHEN value < prev THEN 1 ELSE 0 END), 0),
+                        COALESCE(MIN(value), -1)
+                 FROM samples",
+                [name, name],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("Failed to query missed-events track");
+        assert_eq!(tracks, 1, "[{name}] expected exactly one track");
+        assert!(
+            samples >= 2,
+            "[{name}] expected at least baseline + final samples, got {samples}"
+        );
+        assert_eq!(
+            monotonic_violations, 0,
+            "[{name}] cumulative counter went backwards"
+        );
+        assert!(min_value >= 0.0, "[{name}] negative counter value");
+        eprintln!("    1 track, {samples} samples, monotonic");
+    }
+
+    // --- Check: disabled classes leave no tracks ---
+    for name in DISABLED_TRACKS {
+        let tracks: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM counter_track WHERE name = ?",
+                [name],
+                |row| row.get(0),
+            )
+            .expect("Failed to query disabled-class track");
+        assert_eq!(
+            tracks, 0,
+            "[{name}] class is disabled in this run but has a track"
+        );
+    }
+    eprintln!("  disabled classes: no tracks, as expected");
+
+    // --- Check: units stay inside the validated counter-unit vocabulary ---
+    let bad_units: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM counter_track
+             WHERE name LIKE 'Missed % events' AND (unit IS NULL OR unit <> 'count')",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query missed-events track units");
+    assert_eq!(
+        bad_units, 0,
+        "missed-events tracks must use unit='count' (validated vocabulary)"
+    );
+
+    // --- Check: counter_track IDs stay unique across all counter recorders ---
+    let duplicate_ids: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM (
+                 SELECT id FROM counter_track GROUP BY id HAVING COUNT(*) > 1
+             )",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query duplicate counter_track ids");
+    assert_eq!(duplicate_ids, 0, "counter_track has duplicate track ids");
+
+    // --- Check: every counter sample resolves to exactly one track ---
+    let orphans: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM counter c
+             LEFT JOIN counter_track ct ON c.track_id = ct.id
+             WHERE ct.id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .expect("Failed to query orphaned counter samples");
+    assert_eq!(
+        orphans, 0,
+        "counter rows reference missing counter_track ids"
+    );
+}


### PR DESCRIPTION
Follow-up to #139, implementing the in-trace loss counters declared there (Improvement 2).

## Problem

Event loss is only reported in the exit summary today. When a run does lose events (the situation #139 addressed), the summary tells you *how many* but not *when* — and for long or continuous recordings, "when" is the difference between "one burst during the incident window" and "steady bleed the whole run". The summary is also easy to lose entirely (scrollback, wrapper scripts, remote runs).

## Change

A dedicated poller thread samples the per-class `missed_events` BPF map once a second and streams the cumulative totals into `Missed <class> events` counter tracks:

- **`MissedEventsRecorder`** follows the `SysinfoRecorder` streaming shape exactly: lazily-created track per class, shared counter writer (the `counter`/`counter_track` parquet files stay single-writer), track IDs from the shared generator so they never collide with the perf-counter or CPU-frequency tracks.
- **Class gating matches the exit summary**: only classes whose subsystems are active this run are polled (sched/IRQ, stack, probe, cache always; network/packet/poll with networking; marker with markers; memory with memory tracing). Track naming matches the summary lines, so the trace and the printout name the same things.
- **The final sample carries the settled totals**: the poller takes one last sample after observing the shutdown flag, which is set only after tracing is disabled and the ringbuf consumer threads are joined — so the last track value equals the exit-summary number.
- **Continuous mode**: samples buffer in the flight-recorder ring like any other event, so the window rotation applies to loss counters too.
- `dump_missed_events` now takes the map (via `MapCore`) instead of the whole skeleton, so the poller can use a duplicated `MapHandle` while the exit summary keeps the same summing code.

Always-on by design: it's a handful of map lookups per second, and a flat zero track is itself useful signal — "this run lost nothing" becomes verifiable from the trace alone instead of an absence in scrollback.

## Why 1s / cumulative values

The map values are cumulative totals, so one-second steps localize a burst to the second while adding negligible trace volume (at most 9 counter rows/sec). Rendering the cumulative value (not deltas) means the counter graph shows loss as steps, monotonicity is a checkable property, and the final value is directly comparable to the summary printout.

## Validation

- Unit tests: parquet readback of streamed tracks (per-class track creation, exit-summary naming, cumulative values in ts order) and the continuous-mode ring path (buffer, drain, land).
- New integration test (`tests/missed_events.rs`, root/BPF, via `scripts/run-integration-tests.sh missed_events`): records a real trace, then asserts per-class track presence with ≥2 samples and monotonic values, disabled classes leave no tracks, track IDs stay unique across all counter recorders, and zero counter rows orphan their track.
- Full integration suite green in the same VM rig used for #139 (all six standard targets plus the new one) — results in a comment below.

Version: 1.10.10.
