### PR TITLE
Extract Go symbolization into a publishable gopclntab crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           DUCKDB_LIB_DIR: "${{ github.workspace }}/libduckdb"
           DUCKDB_INCLUDE_DIR: "${{ github.workspace }}/libduckdb"
           LD_LIBRARY_PATH: "${{ github.workspace }}/libduckdb"
-        run: cargo test --no-default-features
+        run: cargo test --workspace --no-default-features
 
   fmt:
     name: Rustfmt
@@ -70,4 +70,4 @@ jobs:
           DUCKDB_LIB_DIR: "${{ github.workspace }}/libduckdb"
           DUCKDB_INCLUDE_DIR: "${{ github.workspace }}/libduckdb"
           LD_LIBRARY_PATH: "${{ github.workspace }}/libduckdb"
-        run: cargo clippy --no-default-features -- -D warnings
+        run: cargo clippy --workspace --no-default-features -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "gopclntab"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.7"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",
@@ -3443,6 +3450,7 @@ dependencies = [
  "dns-lookup",
  "duckdb",
  "flate2",
+ "gopclntab",
  "indicatif",
  "libbpf-cargo",
  "libbpf-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ dependencies = [
 name = "gopclntab"
 version = "0.1.0"
 dependencies = [
+ "object",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
+[workspace]
+members = [".", "crates/gopclntab"]
+
 [package]
 name = "systing"
-version = "1.10.7"
+version = "1.10.9"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"
@@ -30,6 +33,7 @@ dashmap = "6"
 debuginfod = { version = "0.2.1", features = ["fs-cache", "tracing"] }
 dns-lookup = "2.0"
 duckdb = "1.10504"
+gopclntab = { path = "crates/gopclntab", version = "0.1" }
 parquet = "54"
 arrow = "54"
 flate2 = "1.0"

--- a/crates/gopclntab/Cargo.toml
+++ b/crates/gopclntab/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["go", "golang", "pclntab", "symbolication", "profiling"]
 categories = ["development-tools::debugging", "parser-implementations"]
 
 [dependencies]
+# ELF access only: the read core plus the ELF format, nothing else
+# compiled in.
+object = { version = "0.36", default-features = false, features = ["read_core", "elf", "std"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/gopclntab/Cargo.toml
+++ b/crates/gopclntab/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gopclntab"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.89"
+authors = ["Josef Bacik <josef@toxicpanda.com>"]
+license = "MIT"
+description = "Parse the Go runtime's pclntab (.gopclntab) and resolve program counters to function names, including in fully stripped Go binaries"
+repository = "https://github.com/josefbacik/systing"
+readme = "README.md"
+keywords = ["go", "golang", "pclntab", "symbolication", "profiling"]
+categories = ["development-tools::debugging", "parser-implementations"]
+
+[dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/gopclntab/LICENSE
+++ b/crates/gopclntab/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Josef Bacik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/gopclntab/README.md
+++ b/crates/gopclntab/README.md
@@ -1,0 +1,53 @@
+# gopclntab
+
+Parse the Go runtime's function table (pclntab) and resolve program
+counters to function names — including in fully stripped Go binaries.
+
+Stripped Go binaries carry no ELF symbol table, but the Go runtime needs
+its pclntab at run time for tracebacks and garbage collection, so `strip`
+and `-ldflags="-s -w"` always leave the `.gopclntab` section behind.
+Symbolizers that only read `.symtab`/`.dynsym` render such binaries as
+hex; the pclntab has the real answer. This crate reads it.
+
+Built for and used by [systing](https://github.com/josefbacik/systing)'s
+continuous profiler, where it names frames from stripped Go infrastructure
+binaries (kubelet, etcd, kube-state-metrics and the like) that would
+otherwise be unreadable.
+
+## Scope
+
+- **Name-only resolution today**: pc → function name, entry address, and
+  size. The pclntab also encodes source locations and inline trees; those
+  are on the roadmap, not implemented.
+- **Layouts**: Go 1.16/1.17 and Go 1.18+ (through current), little-endian.
+  Go ≤ 1.15 tables and big-endian are rejected as unsupported.
+- **Zero dependencies**, `std` only.
+- **Untrusted input is the design point**: every offset is bounds-checked;
+  malformed tables produce errors or lookup misses, never panics. The test
+  suite includes truncation sweeps and corrupted-field cases, and the
+  parser is validated against binaries produced by the real Go toolchain.
+
+## Usage
+
+```rust,no_run
+// From an ELF on disk (bounded reads: headers + the table itself,
+// never the whole binary):
+let elf = gopclntab::ElfPclntab::from_path("/usr/bin/some-go-binary")?
+    .expect("not a Go binary");
+
+// Policy is yours: `has_symtab` reports whether the binary also has a
+// symbol table (profilers usually prefer symtab+DWARF when present).
+if !elf.has_symtab {
+    if let Some(func) = elf.table.find_func(0x4a6e40) {
+        println!("{} ({:#x}, {} bytes)", func.name, func.entry, func.size);
+    }
+}
+# Ok::<(), gopclntab::Error>(())
+```
+
+`GoPclntab::parse` accepts raw section bytes directly if you already have
+them, and `ElfPclntab::from_bytes` works on in-memory ELF images.
+
+## License
+
+MIT.

--- a/crates/gopclntab/README.md
+++ b/crates/gopclntab/README.md
@@ -21,7 +21,7 @@ otherwise be unreadable.
   are on the roadmap, not implemented.
 - **Layouts**: Go 1.16/1.17 and Go 1.18+ (through current), little-endian.
   Go ≤ 1.15 tables and big-endian are rejected as unsupported.
-- **Zero dependencies**, `std` only.
+- **One dependency**: the [`object`](https://crates.io/crates/object) crate (read core + ELF format only) for ELF section access.
 - **Untrusted input is the design point**: every offset is bounds-checked;
   malformed tables produce errors or lookup misses, never panics. The test
   suite includes truncation sweeps and corrupted-field cases, and the

--- a/crates/gopclntab/src/elf.rs
+++ b/crates/gopclntab/src/elf.rs
@@ -1,0 +1,313 @@
+//! Locate and extract `.gopclntab` from ELF binaries.
+//!
+//! Reads are targeted and bounded — ELF header, section headers, and the
+//! section-name string table first (a few KiB, explicitly capped), then
+//! exactly the pclntab byte range — so probing large binaries (Go binaries
+//! run to hundreds of MiB) never reads whole files.
+//!
+//! Only little-endian ELF64 is supported; anything else reports "not a
+//! candidate" (`Ok(None)`) rather than an error, as do binaries without a
+//! `.gopclntab` section. Policy is deliberately left to the caller: this
+//! module reports whether a symbol table is present ([`ElfPclntab::
+//! has_symtab`]) but does not decide whether the pclntab *should* be used
+//! — a profiler may only want it for stripped binaries, while other tools
+//! may always want it.
+
+use std::fs::File;
+use std::path::Path;
+
+use crate::Error;
+use crate::GoPclntab;
+
+/// Caps on metadata reads. A binary whose metadata exceeds these is
+/// skipped (`Ok(None)`), not mis-parsed; a `.gopclntab` larger than the
+/// cap is reported as malformed (real tables in very large binaries run
+/// to tens of MiB).
+const MAX_SECTION_HEADERS: u64 = 4096;
+const MAX_SHSTRTAB_SIZE: u64 = 1 << 20;
+const MAX_PCLNTAB_SIZE: u64 = 1 << 30;
+
+const SHT_SYMTAB: u32 = 2;
+
+/// A `.gopclntab` extracted from an ELF binary, with the context a caller
+/// needs to decide how to use it.
+#[derive(Debug)]
+pub struct ElfPclntab {
+    /// The parsed function table.
+    pub table: GoPclntab,
+    /// Whether the binary also carries a `.symtab`. Symbolizers typically
+    /// prefer the symbol table (and its associated DWARF) when present —
+    /// the pclntab is most valuable when this is `false`, i.e. the binary
+    /// is stripped.
+    pub has_symtab: bool,
+}
+
+/// A bounded random-access byte source: implemented for files (pread) and
+/// in-memory slices.
+trait ReadAt {
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()>;
+}
+
+impl ReadAt for File {
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+        std::os::unix::fs::FileExt::read_exact_at(self, buf, offset)
+    }
+}
+
+impl ReadAt for &[u8] {
+    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+        let start = usize::try_from(offset).ok().filter(|start| {
+            start
+                .checked_add(buf.len())
+                .is_some_and(|end| end <= self.len())
+        });
+        match start {
+            Some(start) => {
+                buf.copy_from_slice(&self[start..start + buf.len()]);
+                Ok(())
+            }
+            None => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof)),
+        }
+    }
+}
+
+impl ElfPclntab {
+    /// Extract and parse `.gopclntab` from the ELF file at `path`.
+    ///
+    /// Returns `Ok(None)` when the file is not a candidate: not a
+    /// little-endian ELF64, no section headers, or no `.gopclntab`
+    /// section. Returns an error for I/O failures and for tables that
+    /// exist but do not parse.
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
+        let file = File::open(path)?;
+        Self::from_read_at(&file)
+    }
+
+    /// Extract and parse `.gopclntab` from an in-memory ELF image.
+    ///
+    /// Same semantics as [`ElfPclntab::from_path`].
+    pub fn from_bytes(data: &[u8]) -> Result<Option<Self>, Error> {
+        Self::from_read_at(&data)
+    }
+
+    fn from_read_at<R: ReadAt>(source: &R) -> Result<Option<Self>, Error> {
+        let mut ehdr = [0u8; 64];
+        if source.read_exact_at(&mut ehdr, 0).is_err() {
+            return Ok(None);
+        }
+        // \x7fELF, 64-bit (class 2), little-endian (data 1).
+        if ehdr[..4] != [0x7f, b'E', b'L', b'F'] || ehdr[4] != 2 || ehdr[5] != 1 {
+            return Ok(None);
+        }
+        let e_shoff = u64::from_le_bytes(ehdr[0x28..0x30].try_into().unwrap());
+        let e_shentsize = u64::from(u16::from_le_bytes(ehdr[0x3a..0x3c].try_into().unwrap()));
+        let e_shnum = u64::from(u16::from_le_bytes(ehdr[0x3c..0x3e].try_into().unwrap()));
+        let e_shstrndx = usize::from(u16::from_le_bytes(ehdr[0x3e..0x40].try_into().unwrap()));
+        // e_shnum == 0 covers both section-header-stripped binaries and
+        // the >= SHN_LORESERVE escape hatch; neither occurs for Go
+        // release builds, so skipping is the fail-safe answer.
+        if e_shentsize != 64 || e_shnum == 0 || e_shnum > MAX_SECTION_HEADERS {
+            return Ok(None);
+        }
+
+        let mut shdrs = vec![0u8; (e_shnum * 64) as usize];
+        if source.read_exact_at(&mut shdrs, e_shoff).is_err() {
+            return Ok(None);
+        }
+        // Elf64_Shdr field offsets: sh_name +0 (u32), sh_type +4 (u32),
+        // sh_addr +16, sh_offset +24, sh_size +32 (u64s).
+        let shdr = |i: usize| shdrs.get(i * 64..(i + 1) * 64);
+        let shdr_u32 =
+            |s: &[u8], off: usize| u32::from_le_bytes(s[off..off + 4].try_into().unwrap());
+        let shdr_u64 =
+            |s: &[u8], off: usize| u64::from_le_bytes(s[off..off + 8].try_into().unwrap());
+
+        let Some(shstr) = shdr(e_shstrndx) else {
+            return Ok(None);
+        };
+        let shstr_off = shdr_u64(shstr, 24);
+        let shstr_size = shdr_u64(shstr, 32);
+        if shstr_size > MAX_SHSTRTAB_SIZE {
+            return Ok(None);
+        }
+        let mut shstrtab = vec![0u8; shstr_size as usize];
+        if source.read_exact_at(&mut shstrtab, shstr_off).is_err() {
+            return Ok(None);
+        }
+        let section_name = |s: &[u8]| -> &[u8] {
+            let name_off = shdr_u32(s, 0) as usize;
+            let rest = shstrtab.get(name_off..).unwrap_or(&[]);
+            &rest[..rest.iter().position(|b| *b == 0).unwrap_or(rest.len())]
+        };
+
+        let mut has_symtab = false;
+        let mut pclntab_range = None;
+        let mut text_vaddr = None;
+        for i in 0..e_shnum as usize {
+            let Some(s) = shdr(i) else {
+                return Ok(None);
+            };
+            if shdr_u32(s, 4) == SHT_SYMTAB {
+                has_symtab = true;
+            }
+            match section_name(s) {
+                b".gopclntab" => pclntab_range = Some((shdr_u64(s, 24), shdr_u64(s, 32))),
+                b".text" => text_vaddr = Some(shdr_u64(s, 16)),
+                _ => {}
+            }
+        }
+        let Some((offset, size)) = pclntab_range else {
+            return Ok(None);
+        };
+        if size > MAX_PCLNTAB_SIZE {
+            return Err(Error::Malformed(format!(
+                ".gopclntab implausibly large ({size} bytes)"
+            )));
+        }
+
+        let mut data = vec![0u8; size as usize];
+        source
+            .read_exact_at(&mut data, offset)
+            .map_err(|_| Error::Malformed("short read of .gopclntab".to_string()))?;
+        let table = GoPclntab::parse(data, text_vaddr)?;
+        Ok(Some(Self { table, has_symtab }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use std::process::Command;
+
+    /// Build the same tiny program stripped and unstripped, and validate
+    /// the whole ELF path against the real Go toolchain: extraction,
+    /// symtab detection, full-table resolution, and the `main.*` names.
+    /// Skips (with a notice) when no `go` binary is on PATH.
+    #[test]
+    fn resolves_real_go_binaries() {
+        if Command::new("go").arg("version").output().is_err() {
+            eprintln!("skipping: no go toolchain on PATH");
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("main.go");
+        let mut f = std::fs::File::create(&src).unwrap();
+        f.write_all(
+            b"package main\n\nfunc main() {\n\tprintln(helper())\n}\n\n//go:noinline\nfunc helper() int {\n\treturn 42\n}\n",
+        )
+        .unwrap();
+        drop(f);
+
+        // File-mode build (no module) with -trimpath: the embedded module
+        // path is the synthetic "command-line-arguments" and no local
+        // filesystem paths land in the binary's metadata.
+        let build = |out: &Path, ldflags: &str| {
+            let mut cmd = Command::new("go");
+            cmd.arg("build").arg("-trimpath");
+            if !ldflags.is_empty() {
+                cmd.arg(format!("-ldflags={ldflags}"));
+            }
+            let result = cmd
+                .arg("-o")
+                .arg(out)
+                .arg(&src)
+                .env("GOCACHE", out.parent().unwrap().join("gocache"))
+                .env("CGO_ENABLED", "0")
+                .output()
+                .unwrap();
+            assert!(
+                result.status.success(),
+                "go build failed: {}",
+                String::from_utf8_lossy(&result.stderr)
+            );
+        };
+
+        let stripped = dir.path().join("fixture-stripped");
+        build(&stripped, "-s -w");
+        let elf = ElfPclntab::from_path(&stripped)
+            .unwrap()
+            .expect("stripped fixture has no detectable .gopclntab");
+        assert!(!elf.has_symtab, "stripped fixture reports a symtab");
+        let tab = elf.table;
+        assert!(tab.func_count() > 100, "implausibly small function table");
+
+        // Sweep every function entry: each must resolve back to itself,
+        // and main.main / main.helper must both be present by name.
+        let mut seen_main = false;
+        let mut seen_helper = false;
+        for i in 0..tab.func_count() {
+            let entry = tab.func_entry(i).unwrap();
+            let func = tab
+                .find_func(entry)
+                .unwrap_or_else(|| panic!("entry {entry:#x} (functab slot {i}) failed to resolve"));
+            assert_eq!(func.entry, entry);
+            seen_main |= func.name == "main.main";
+            seen_helper |= func.name == "main.helper";
+        }
+        assert!(seen_main, "main.main not found in pclntab");
+        assert!(seen_helper, "main.helper not found in pclntab");
+
+        // The unstripped twin: same table, but the symtab is reported so
+        // callers preferring symtab+DWARF can decline.
+        let unstripped = dir.path().join("fixture-unstripped");
+        build(&unstripped, "");
+        let elf = ElfPclntab::from_path(&unstripped)
+            .unwrap()
+            .expect("unstripped fixture has no detectable .gopclntab");
+        assert!(elf.has_symtab, "unstripped fixture reports no symtab");
+        assert!(elf.table.func_count() > 100);
+
+        // The bytes-based entry point agrees with the file-based one.
+        let bytes = std::fs::read(&stripped).unwrap();
+        let elf = ElfPclntab::from_bytes(&bytes).unwrap().unwrap();
+        assert!(!elf.has_symtab);
+        assert_eq!(elf.table.func_count(), tab.func_count());
+    }
+
+    /// Parse the pclntab of an arbitrary Go ELF supplied via
+    /// `GOPCLNTAB_TEST_BINARY` — handy for vetting against real release
+    /// binaries (kubelet, etcd, kube-state-metrics). Skips when unset.
+    #[test]
+    fn resolves_binary_from_env() {
+        let Some(path) = std::env::var_os("GOPCLNTAB_TEST_BINARY") else {
+            return;
+        };
+        let elf = ElfPclntab::from_path(Path::new(&path))
+            .unwrap()
+            .expect("binary has no detectable .gopclntab");
+        let tab = elf.table;
+        assert!(tab.func_count() > 0);
+        let mut named = 0usize;
+        for i in 0..tab.func_count() {
+            if let Some(func) = tab.find_func(tab.func_entry(i).unwrap()) {
+                assert!(!func.name.is_empty());
+                named += 1;
+            }
+        }
+        eprintln!(
+            "resolved {named}/{} functions from {} (symtab: {})",
+            tab.func_count(),
+            Path::new(&path).display(),
+            elf.has_symtab,
+        );
+        assert_eq!(named, tab.func_count());
+    }
+
+    #[test]
+    fn non_elf_and_truncated_inputs_are_not_candidates() {
+        assert!(ElfPclntab::from_bytes(b"").unwrap().is_none());
+        assert!(ElfPclntab::from_bytes(b"not an elf at all")
+            .unwrap()
+            .is_none());
+        // Valid magic, wrong class (32-bit).
+        let mut ehdr = vec![0u8; 64];
+        ehdr[..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        ehdr[4] = 1;
+        ehdr[5] = 1;
+        assert!(ElfPclntab::from_bytes(&ehdr).unwrap().is_none());
+        // 64-bit LE but no section headers.
+        ehdr[4] = 2;
+        assert!(ElfPclntab::from_bytes(&ehdr).unwrap().is_none());
+    }
+}

--- a/crates/gopclntab/src/elf.rs
+++ b/crates/gopclntab/src/elf.rs
@@ -1,33 +1,32 @@
 //! Locate and extract `.gopclntab` from ELF binaries.
 //!
-//! Reads are targeted and bounded — ELF header, section headers, and the
-//! section-name string table first (a few KiB, explicitly capped), then
-//! exactly the pclntab byte range — so probing large binaries (Go binaries
-//! run to hundreds of MiB) never reads whole files.
+//! ELF parsing is delegated to the [`object`] crate; reads are targeted —
+//! headers and the sections consulted, then exactly the pclntab byte
+//! range — so probing large binaries (Go binaries run to hundreds of MiB)
+//! never reads whole files.
 //!
-//! Only little-endian ELF64 is supported; anything else reports "not a
-//! candidate" (`Ok(None)`) rather than an error, as do binaries without a
-//! `.gopclntab` section. Policy is deliberately left to the caller: this
-//! module reports whether a symbol table is present ([`ElfPclntab::
-//! has_symtab`]) but does not decide whether the pclntab *should* be used
-//! — a profiler may only want it for stripped binaries, while other tools
-//! may always want it.
+//! Binaries that are not ELF, or have no `.gopclntab` section, report
+//! "not a candidate" (`Ok(None)`) rather than an error. Section metadata
+//! is validated against the input's actual size, so the only inputs
+//! rejected as malformed are ones whose headers are inconsistent with the
+//! bytes on disk — there is no size threshold a large-but-valid binary
+//! could trip over.
+//!
+//! Policy is deliberately left to the caller: this module reports whether
+//! a symbol table is present ([`ElfPclntab::has_symtab`]) but does not
+//! decide whether the pclntab *should* be used — a profiler may only want
+//! it for stripped binaries, while other tools may always want it.
 
 use std::fs::File;
 use std::path::Path;
 
+use object::read::ReadCache;
+use object::read::ReadRef;
+use object::Object;
+use object::ObjectSection;
+
 use crate::Error;
 use crate::GoPclntab;
-
-/// Caps on metadata reads. A binary whose metadata exceeds these is
-/// skipped (`Ok(None)`), not mis-parsed; a `.gopclntab` larger than the
-/// cap is reported as malformed (real tables in very large binaries run
-/// to tens of MiB).
-const MAX_SECTION_HEADERS: u64 = 4096;
-const MAX_SHSTRTAB_SIZE: u64 = 1 << 20;
-const MAX_PCLNTAB_SIZE: u64 = 1 << 30;
-
-const SHT_SYMTAB: u32 = 2;
 
 /// A `.gopclntab` extracted from an ELF binary, with the context a caller
 /// needs to decide how to use it.
@@ -42,133 +41,67 @@ pub struct ElfPclntab {
     pub has_symtab: bool,
 }
 
-/// A bounded random-access byte source: implemented for files (pread) and
-/// in-memory slices.
-trait ReadAt {
-    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()>;
-}
-
-impl ReadAt for File {
-    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
-        std::os::unix::fs::FileExt::read_exact_at(self, buf, offset)
-    }
-}
-
-impl ReadAt for &[u8] {
-    fn read_exact_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
-        let start = usize::try_from(offset).ok().filter(|start| {
-            start
-                .checked_add(buf.len())
-                .is_some_and(|end| end <= self.len())
-        });
-        match start {
-            Some(start) => {
-                buf.copy_from_slice(&self[start..start + buf.len()]);
-                Ok(())
-            }
-            None => Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof)),
-        }
-    }
-}
-
 impl ElfPclntab {
     /// Extract and parse `.gopclntab` from the ELF file at `path`.
     ///
-    /// Returns `Ok(None)` when the file is not a candidate: not a
-    /// little-endian ELF64, no section headers, or no `.gopclntab`
-    /// section. Returns an error for I/O failures and for tables that
-    /// exist but do not parse.
+    /// Returns `Ok(None)` when the file is not a candidate: not an ELF, or
+    /// no `.gopclntab` section. Returns an error for I/O failures and for
+    /// tables that exist but do not parse.
     pub fn from_path(path: impl AsRef<Path>) -> Result<Option<Self>, Error> {
         let file = File::open(path)?;
-        Self::from_read_at(&file)
+        // ReadCache reads the byte ranges object asks for, not the whole
+        // file.
+        let cache = ReadCache::new(file);
+        Self::from_read_ref(&cache)
     }
 
     /// Extract and parse `.gopclntab` from an in-memory ELF image.
     ///
     /// Same semantics as [`ElfPclntab::from_path`].
     pub fn from_bytes(data: &[u8]) -> Result<Option<Self>, Error> {
-        Self::from_read_at(&data)
+        Self::from_read_ref(data)
     }
 
-    fn from_read_at<R: ReadAt>(source: &R) -> Result<Option<Self>, Error> {
-        let mut ehdr = [0u8; 64];
-        if source.read_exact_at(&mut ehdr, 0).is_err() {
-            return Ok(None);
-        }
-        // \x7fELF, 64-bit (class 2), little-endian (data 1).
-        if ehdr[..4] != [0x7f, b'E', b'L', b'F'] || ehdr[4] != 2 || ehdr[5] != 1 {
-            return Ok(None);
-        }
-        let e_shoff = u64::from_le_bytes(ehdr[0x28..0x30].try_into().unwrap());
-        let e_shentsize = u64::from(u16::from_le_bytes(ehdr[0x3a..0x3c].try_into().unwrap()));
-        let e_shnum = u64::from(u16::from_le_bytes(ehdr[0x3c..0x3e].try_into().unwrap()));
-        let e_shstrndx = usize::from(u16::from_le_bytes(ehdr[0x3e..0x40].try_into().unwrap()));
-        // e_shnum == 0 covers both section-header-stripped binaries and
-        // the >= SHN_LORESERVE escape hatch; neither occurs for Go
-        // release builds, so skipping is the fail-safe answer.
-        if e_shentsize != 64 || e_shnum == 0 || e_shnum > MAX_SECTION_HEADERS {
-            return Ok(None);
-        }
-
-        let mut shdrs = vec![0u8; (e_shnum * 64) as usize];
-        if source.read_exact_at(&mut shdrs, e_shoff).is_err() {
-            return Ok(None);
-        }
-        // Elf64_Shdr field offsets: sh_name +0 (u32), sh_type +4 (u32),
-        // sh_addr +16, sh_offset +24, sh_size +32 (u64s).
-        let shdr = |i: usize| shdrs.get(i * 64..(i + 1) * 64);
-        let shdr_u32 =
-            |s: &[u8], off: usize| u32::from_le_bytes(s[off..off + 4].try_into().unwrap());
-        let shdr_u64 =
-            |s: &[u8], off: usize| u64::from_le_bytes(s[off..off + 8].try_into().unwrap());
-
-        let Some(shstr) = shdr(e_shstrndx) else {
+    fn from_read_ref<'data, R: ReadRef<'data>>(source: R) -> Result<Option<Self>, Error> {
+        let Ok(elf) = object::File::parse(source) else {
+            // Not an object file this build recognizes (only the ELF
+            // format is compiled in): not a candidate.
             return Ok(None);
         };
-        let shstr_off = shdr_u64(shstr, 24);
-        let shstr_size = shdr_u64(shstr, 32);
-        if shstr_size > MAX_SHSTRTAB_SIZE {
-            return Ok(None);
-        }
-        let mut shstrtab = vec![0u8; shstr_size as usize];
-        if source.read_exact_at(&mut shstrtab, shstr_off).is_err() {
-            return Ok(None);
-        }
-        let section_name = |s: &[u8]| -> &[u8] {
-            let name_off = shdr_u32(s, 0) as usize;
-            let rest = shstrtab.get(name_off..).unwrap_or(&[]);
-            &rest[..rest.iter().position(|b| *b == 0).unwrap_or(rest.len())]
-        };
 
-        let mut has_symtab = false;
-        let mut pclntab_range = None;
-        let mut text_vaddr = None;
-        for i in 0..e_shnum as usize {
-            let Some(s) = shdr(i) else {
-                return Ok(None);
-            };
-            if shdr_u32(s, 4) == SHT_SYMTAB {
-                has_symtab = true;
-            }
-            match section_name(s) {
-                b".gopclntab" => pclntab_range = Some((shdr_u64(s, 24), shdr_u64(s, 32))),
-                b".text" => text_vaddr = Some(shdr_u64(s, 16)),
-                _ => {}
-            }
-        }
-        let Some((offset, size)) = pclntab_range else {
+        let Some(section) = elf.section_by_name(".gopclntab") else {
             return Ok(None);
         };
-        if size > MAX_PCLNTAB_SIZE {
+        // Resolving the section's (offset, size) before reading lets the
+        // metadata be validated against the input's real length: a section
+        // header claiming bytes past end-of-input is inconsistent with the
+        // file itself, which is the only "too large" this module rejects.
+        let range = section
+            .compressed_file_range()
+            .map_err(|_| Error::Malformed(".gopclntab has no file range".to_string()))?;
+        if range.format != object::CompressionFormat::None {
+            return Err(Error::Unsupported(
+                "compressed .gopclntab section".to_string(),
+            ));
+        }
+        let input_len = source.len().unwrap_or(u64::MAX);
+        if range
+            .offset
+            .checked_add(range.uncompressed_size)
+            .is_none_or(|end| end > input_len)
+        {
             return Err(Error::Malformed(format!(
-                ".gopclntab implausibly large ({size} bytes)"
+                ".gopclntab claims {} bytes at offset {} but the input is {} bytes",
+                range.uncompressed_size, range.offset, input_len
             )));
         }
+        let data = section
+            .uncompressed_data()
+            .map_err(|_| Error::Malformed("short read of .gopclntab".to_string()))?
+            .into_owned();
 
-        let mut data = vec![0u8; size as usize];
-        source
-            .read_exact_at(&mut data, offset)
-            .map_err(|_| Error::Malformed("short read of .gopclntab".to_string()))?;
+        let has_symtab = elf.symbol_table().is_some();
+        let text_vaddr = elf.section_by_name(".text").map(|text| text.address());
         let table = GoPclntab::parse(data, text_vaddr)?;
         Ok(Some(Self { table, has_symtab }))
     }
@@ -263,6 +196,33 @@ mod tests {
         let elf = ElfPclntab::from_bytes(&bytes).unwrap().unwrap();
         assert!(!elf.has_symtab);
         assert_eq!(elf.table.func_count(), tab.func_count());
+
+        // Corrupt the section header so .gopclntab claims to extend past
+        // end-of-file: the only "too large" that gets rejected is metadata
+        // inconsistent with the input itself.
+        let corrupt = corrupt_gopclntab_size(&bytes);
+        assert!(matches!(
+            ElfPclntab::from_bytes(&corrupt),
+            Err(Error::Malformed(_))
+        ));
+    }
+
+    /// Flip the `sh_size` of `.gopclntab` to a value larger than the file.
+    /// object's read API is read-only, so the edit pokes the ELF64
+    /// section-header layout directly (stable ABI; fine for a test).
+    fn corrupt_gopclntab_size(elf: &[u8]) -> Vec<u8> {
+        use object::read::elf::ElfFile64;
+        let parsed: ElfFile64 = ElfFile64::parse(elf).unwrap();
+        let section = parsed.section_by_name(".gopclntab").unwrap();
+        let index = section.index().0;
+
+        let mut out = elf.to_vec();
+        let e_shoff = u64::from_le_bytes(elf[0x28..0x30].try_into().unwrap()) as usize;
+        let e_shentsize = u16::from_le_bytes(elf[0x3a..0x3c].try_into().unwrap()) as usize;
+        // sh_size lives at +0x20 within an Elf64_Shdr.
+        let sh_size_at = e_shoff + index * e_shentsize + 0x20;
+        out[sh_size_at..sh_size_at + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+        out
     }
 
     /// Parse the pclntab of an arbitrary Go ELF supplied via
@@ -300,14 +260,12 @@ mod tests {
         assert!(ElfPclntab::from_bytes(b"not an elf at all")
             .unwrap()
             .is_none());
-        // Valid magic, wrong class (32-bit).
+        // A bare ELF header with nothing behind it must not become a
+        // candidate (and must not panic).
         let mut ehdr = vec![0u8; 64];
         ehdr[..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
-        ehdr[4] = 1;
-        ehdr[5] = 1;
-        assert!(ElfPclntab::from_bytes(&ehdr).unwrap().is_none());
-        // 64-bit LE but no section headers.
         ehdr[4] = 2;
-        assert!(ElfPclntab::from_bytes(&ehdr).unwrap().is_none());
+        ehdr[5] = 1;
+        assert!(matches!(ElfPclntab::from_bytes(&ehdr), Ok(None)));
     }
 }

--- a/crates/gopclntab/src/error.rs
+++ b/crates/gopclntab/src/error.rs
@@ -1,0 +1,45 @@
+use std::fmt;
+
+/// Errors produced while locating or parsing a pclntab.
+///
+/// The distinction matters to callers deciding whether to fall back:
+/// [`Error::Unsupported`] means the input is (or may be) a real pclntab in
+/// a layout this crate does not read; [`Error::Malformed`] means the input
+/// claims to be a pclntab but is structurally inconsistent.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// An I/O error while reading from a file.
+    Io(std::io::Error),
+    /// A recognized-but-unsupported table: Go 1.2–1.15 layouts, big-endian
+    /// tables, or unknown magic values.
+    Unsupported(String),
+    /// A structurally invalid table: truncated data, out-of-bounds
+    /// offsets, or implausible sizes.
+    Malformed(String),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::Io(err) => write!(f, "i/o error: {err}"),
+            Error::Unsupported(what) => write!(f, "unsupported pclntab: {what}"),
+            Error::Malformed(what) => write!(f, "malformed pclntab: {what}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::Io(err)
+    }
+}

--- a/crates/gopclntab/src/lib.rs
+++ b/crates/gopclntab/src/lib.rs
@@ -1,56 +1,53 @@
-//! Fallback symbolization for stripped Go binaries via `.gopclntab`.
+//! Parse the Go runtime's function table (pclntab) and resolve program
+//! counters to function names.
 //!
-//! Stripped Go binaries carry no ELF symbol table, but the Go runtime needs
-//! its function table (pclntab) at run time for tracebacks and GC, so
-//! `strip` and `-ldflags="-s -w"` always leave `.gopclntab` behind. blazesym
-//! only reads `.symtab`/`.dynsym`, which has two failure modes on such
-//! binaries:
+//! Stripped Go binaries carry no ELF symbol table, but the Go runtime
+//! needs its pclntab at run time for tracebacks and garbage collection, so
+//! `strip` and `-ldflags="-s -w"` always leave the `.gopclntab` section
+//! behind. Symbolizers that only read `.symtab`/`.dynsym` render such
+//! binaries as hex (or worse, misattribute addresses to the few surviving
+//! dynamic symbols of a cgo build); the pclntab has the real answer.
 //!
-//! * fully stripped (e.g. upstream kube-state-metrics, etcd, cilium-agent
-//!   release builds): every user frame renders as bare hex;
-//! * stripped cgo builds that retain a handful of dynamic symbols (e.g.
-//!   COS/boringcrypto kubelet builds): blazesym's nearest-symbol match
-//!   attributes whole Go text ranges to whichever C/asm symbol happens to
-//!   precede them, producing confidently *wrong* names.
+//! # Scope
 //!
-//! [`try_gopclntab_resolver`] probes a process member for exactly that
-//! shape — no `.symtab`, `.gopclntab` present — and returns a resolver that
-//! answers name lookups from the pclntab instead. Binaries with a real
-//! symbol table never take this path, so the richer symtab+DWARF resolution
-//! (source locations, inlined functions) is unaffected.
+//! Name-only resolution: given a virtual address, find the covering Go
+//! function's name, entry address, and size. Source locations and inline
+//! expansion (which the pclntab also encodes) are not read yet.
 //!
-//! Only function names are resolved here (no file/line, no inline
-//! expansion): that is the difference between an unreadable profile and a
-//! readable one, and pclntab line tables can be layered on later if wanted.
+//! Layouts for Go 1.16/1.17 (`ver116`) and Go 1.18+ (`ver118`; the Go
+//! 1.20 magic shares the layout) are supported, little-endian. The Go
+//! 1.2–1.15 layout and big-endian tables are rejected with
+//! [`Error::Unsupported`].
+//!
+//! Robustness is a design requirement: the input is untrusted (arbitrary
+//! binaries found on a system), so every offset is bounds-checked and
+//! malformed tables produce an [`Error`] or a lookup miss, never a panic.
+//!
+//! # Example
+//!
+//! ```no_run
+//! let elf = gopclntab::ElfPclntab::from_path("/usr/bin/some-go-binary")?
+//!     .expect("not a Go binary");
+//! // Symbol-table-less binary: the pclntab is the only symbolization
+//! // source. (Binaries with a symbol table have richer options.)
+//! assert!(!elf.has_symtab);
+//! if let Some(func) = elf.table.find_func(0x4a6e40) {
+//!     println!("{} ({:#x}, {} bytes)", func.name, func.entry, func.size);
+//! }
+//! # Ok::<(), gopclntab::Error>(())
+//! ```
 //!
 //! Format reference: `go/src/debug/gosym/pclntab.go` and
-//! `go/src/internal/abi/symtab.go`. Layouts for Go 1.16/1.17 (`ver116`) and
-//! Go 1.18+ (`ver118`; the Go 1.20 magic shares the layout) are supported.
-//! The Go 1.2–1.15 layout and big-endian tables are rejected, in which case
-//! symbolization behaves exactly as before this module existed.
+//! `go/src/internal/abi/symtab.go`.
 
-use std::ffi::OsString;
-use std::fmt;
-use std::fs::File;
-use std::os::unix::fs::FileExt as _;
-use std::path::Path;
+mod elf;
+mod error;
 
-use anyhow::bail;
-use anyhow::Context;
-use anyhow::Result;
+pub use elf::ElfPclntab;
+pub use error::Error;
 
-use blazesym::helper::ElfResolver;
-use blazesym::symbolize::FindSymOpts;
-use blazesym::symbolize::Reason;
-use blazesym::symbolize::Resolve;
-use blazesym::symbolize::ResolvedSym;
-use blazesym::symbolize::SrcLang;
-use blazesym::symbolize::Symbolize;
-use blazesym::symbolize::TranslateFileOffset;
-use blazesym::Addr;
-
-/// Go 1.2 through 1.15. Predates every Go release still in support; not
-/// worth carrying the layout. Recognized only to be rejected explicitly.
+/// Go 1.2 through 1.15. Predates every Go release still in support;
+/// recognized only to be rejected explicitly.
 const GO12_MAGIC: u32 = 0xFFFF_FFFB;
 /// Go 1.16 and 1.17.
 const GO116_MAGIC: u32 = 0xFFFF_FFFA;
@@ -71,9 +68,9 @@ enum PclnVersion {
     V118,
 }
 
-/// A parsed `.gopclntab` section, exposing pc -> function-name lookups.
+/// A parsed pclntab, exposing pc -> function-name lookups.
 ///
-/// Owns the raw section bytes; the functab within them is already sorted by
+/// Owns the raw table bytes; the functab within them is already sorted by
 /// entry address, so lookups binary-search the raw table directly and
 /// parsing amounts to header validation.
 pub struct GoPclntab {
@@ -82,14 +79,14 @@ pub struct GoPclntab {
     ptrsize: usize,
     nfunctab: usize,
     /// Virtual address of the start of text, the base for V118 entry
-    /// offsets. Taken from the `.text` section header (matching what the Go
-    /// runtime relocates against) with the pclntab header value as
-    /// fallback. Unused for V116.
+    /// offsets. Callers should prefer the `.text` section address
+    /// (matching what the Go runtime relocates against); the pclntab
+    /// header value is the fallback. Unused for V116.
     text_start: u64,
     /// Offset of the function-name string table within `data`.
     funcnametab: usize,
-    /// Offset of the funcdata region within `data`; `funcoff` values in the
-    /// functab are relative to this.
+    /// Offset of the funcdata region within `data`; `funcoff` values in
+    /// the functab are relative to this.
     funcdata: usize,
     /// Offset of the functab (pairs of entry/funcoff) within `data`.
     functab: usize,
@@ -97,8 +94,8 @@ pub struct GoPclntab {
     functab_field: usize,
 }
 
-impl fmt::Debug for GoPclntab {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Debug for GoPclntab {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GoPclntab")
             .field("version", &self.version)
             .field("nfunctab", &self.nfunctab)
@@ -120,42 +117,46 @@ pub struct GoFunc<'tab> {
 }
 
 impl GoPclntab {
-    /// Parse a `.gopclntab` section.
+    /// Parse a pclntab from its raw bytes (e.g. the contents of the
+    /// `.gopclntab` ELF section).
     ///
     /// `text_vaddr` is the virtual address of the binary's `.text` section
     /// when known; Go's own tooling prefers it over the header's stored
-    /// value (which may be unrelocated in edge cases) and so do we.
-    ///
-    /// Every offset is bounds-checked here or read via checked accessors:
-    /// malformed input must produce an error, never a panic, because this
-    /// runs against arbitrary binaries found on the system.
-    pub fn parse(data: Vec<u8>, text_vaddr: Option<u64>) -> Result<Self> {
+    /// value (which may be unrelocated in edge cases) and so does this
+    /// crate. [`ElfPclntab`] supplies it automatically.
+    pub fn parse(data: Vec<u8>, text_vaddr: Option<u64>) -> Result<Self, Error> {
         if data.len() < HEADER_PREFIX_LEN {
-            bail!("pclntab too short for header: {} bytes", data.len());
+            return Err(Error::Malformed(format!(
+                "too short for header: {} bytes",
+                data.len()
+            )));
         }
         let magic = u32::from_le_bytes(data[0..4].try_into().unwrap());
         let version = match magic {
             GO118_MAGIC | GO120_MAGIC => PclnVersion::V118,
             GO116_MAGIC => PclnVersion::V116,
-            GO12_MAGIC => bail!("Go <= 1.15 pclntab layout is not supported"),
+            GO12_MAGIC => return Err(Error::Unsupported("Go <= 1.15 pclntab layout".to_string())),
             // The magics are chosen so a byte-swapped read never matches:
-            // an unknown value covers both corruption and big-endian tables.
-            other => bail!("unrecognized pclntab magic {other:#x}"),
+            // an unknown value covers both corruption and big-endian
+            // tables.
+            other => return Err(Error::Unsupported(format!("magic {other:#x}"))),
         };
         let ptrsize = data[7] as usize;
         if ptrsize != 4 && ptrsize != 8 {
-            bail!("unsupported pclntab ptrsize {ptrsize}");
+            return Err(Error::Unsupported(format!("ptrsize {ptrsize}")));
         }
 
-        let word = |idx: usize| -> Result<u64> {
+        let word = |idx: usize| -> Result<u64, Error> {
             let off = HEADER_PREFIX_LEN + idx * ptrsize;
             read_uint(&data, off, ptrsize)
-                .with_context(|| format!("pclntab header word {idx} out of bounds"))
+                .ok_or_else(|| Error::Malformed(format!("header word {idx} out of bounds")))
         };
-        let tab_offset = |idx: usize, what: &str| -> Result<usize> {
+        let tab_offset = |idx: usize, what: &str| -> Result<usize, Error> {
             let off = word(idx)?;
-            let off = usize::try_from(off).ok().filter(|o| *o <= data.len());
-            off.with_context(|| format!("pclntab {what} offset out of bounds"))
+            usize::try_from(off)
+                .ok()
+                .filter(|off| *off <= data.len())
+                .ok_or_else(|| Error::Malformed(format!("{what} offset out of bounds")))
         };
 
         let (nfunctab, text_start, funcnametab, funcdata) = match version {
@@ -172,7 +173,8 @@ impl GoPclntab {
                 tab_offset(6, "funcdata")?,
             ),
         };
-        let nfunctab = usize::try_from(nfunctab).context("pclntab nfunc overflows usize")?;
+        let nfunctab = usize::try_from(nfunctab)
+            .map_err(|_| Error::Malformed("nfunc overflows usize".to_string()))?;
         let functab = funcdata;
         let functab_field = match version {
             PclnVersion::V118 => 4,
@@ -185,15 +187,15 @@ impl GoPclntab {
             .checked_mul(2)
             .and_then(|n| n.checked_add(1))
             .and_then(|n| n.checked_mul(functab_field))
-            .context("pclntab functab size overflows")?;
+            .ok_or_else(|| Error::Malformed("functab size overflows".to_string()))?;
         if functab
             .checked_add(functab_size)
             .is_none_or(|end| end > data.len())
         {
-            bail!(
-                "pclntab functab ({nfunctab} functions) exceeds section size {}",
+            return Err(Error::Malformed(format!(
+                "functab ({nfunctab} functions) exceeds table size {}",
                 data.len()
-            );
+            )));
         }
 
         Ok(Self {
@@ -214,16 +216,26 @@ impl GoPclntab {
         self.nfunctab
     }
 
+    /// The virtual entry address of functab slot `i`, `i < func_count()`.
+    /// Useful for enumerating the table; [`GoPclntab::find_func`] on the
+    /// returned address resolves the same slot.
+    pub fn func_entry(&self, i: usize) -> Option<u64> {
+        if i >= self.nfunctab {
+            return None;
+        }
+        self.entry_vaddr(i)
+    }
+
     /// Read functab word `idx` (words are laid out as
     /// `entry0, funcoff0, entry1, funcoff1, ..., entryN` with the trailing
     /// sentinel entry). Bounds were validated at parse time, but a miss is
     /// still an honest `None` rather than a panic: this data ultimately
-    /// comes from arbitrary binaries found on the system.
+    /// comes from untrusted binaries.
     fn functab_word(&self, idx: usize) -> Option<u64> {
         let off = self
             .functab
             .checked_add(idx.checked_mul(self.functab_field)?)?;
-        read_uint(&self.data, off, self.functab_field).ok()
+        read_uint(&self.data, off, self.functab_field)
     }
 
     /// The entry value (offset for V118, absolute address for V116) of
@@ -245,8 +257,7 @@ impl GoPclntab {
     ///
     /// Returns `None` for addresses outside the table's text range — which
     /// for cgo binaries legitimately includes the C/asm portions of text:
-    /// those are not Go functions and the caller's fallback rendering
-    /// (contextual `unknown` labels) is the honest answer there.
+    /// those are not Go functions and have no entry here.
     pub fn find_func(&self, pc: u64) -> Option<GoFunc<'_>> {
         if self.nfunctab == 0 {
             return None;
@@ -263,11 +274,11 @@ impl GoPclntab {
         if key >= self.entry_value(self.nfunctab)? {
             return None;
         }
-        // partition_point returns the first slot whose entry exceeds `key`;
-        // the covering function is the slot before it. Entries are sorted
-        // by construction (the linker emits them in address order); a
-        // corrupt out-of-bounds read partitions as "exceeds" and can only
-        // shift the search toward a miss.
+        // partition_point returns the first slot whose entry exceeds
+        // `key`; the covering function is the slot before it. Entries are
+        // sorted by construction (the linker emits them in address order);
+        // a corrupt out-of-bounds read partitions as "exceeds" and can
+        // only shift the search toward a miss.
         let upper = partition_point(self.nfunctab + 1, |i| {
             self.entry_value(i).is_some_and(|entry| entry <= key)
         });
@@ -293,7 +304,7 @@ impl GoPclntab {
             .funcdata
             .checked_add(funcoff)?
             .checked_add(entry_width)?;
-        let nameoff = usize::try_from(read_uint(&self.data, nameoff_pos, 4).ok()?).ok()?;
+        let nameoff = usize::try_from(read_uint(&self.data, nameoff_pos, 4)?).ok()?;
         let name_start = self.funcnametab.checked_add(nameoff)?;
         let rest = self.data.get(name_start..)?;
         let len = rest.iter().position(|b| *b == 0)?;
@@ -302,15 +313,12 @@ impl GoPclntab {
 }
 
 /// Little-endian unsigned read of `width` (4 or 8) bytes at `off`.
-fn read_uint(data: &[u8], off: usize, width: usize) -> Result<u64> {
-    let bytes = off
-        .checked_add(width)
-        .and_then(|end| data.get(off..end))
-        .with_context(|| format!("read of {width} bytes at {off} out of bounds"))?;
-    Ok(match width {
+fn read_uint(data: &[u8], off: usize, width: usize) -> Option<u64> {
+    let bytes = off.checked_add(width).and_then(|end| data.get(off..end))?;
+    Some(match width {
         4 => u64::from(u32::from_le_bytes(bytes.try_into().unwrap())),
         8 => u64::from_le_bytes(bytes.try_into().unwrap()),
-        _ => bail!("unsupported read width {width}"),
+        _ => return None,
     })
 }
 
@@ -329,178 +337,6 @@ fn partition_point(n: usize, pred: impl Fn(usize) -> bool) -> usize {
         }
     }
     lo
-}
-
-/// A [`Resolve`] implementation answering symbol lookups from a Go
-/// binary's pclntab.
-///
-/// File-offset translation (needed by the process symbolization flow to
-/// map memory offsets into ELF virtual addresses before calling
-/// [`Symbolize::find_sym`]) is delegated to a regular [`ElfResolver`] over
-/// the same file, which reads it from the program headers.
-#[derive(Debug)]
-pub struct GoPclntabResolver {
-    pclntab: GoPclntab,
-    elf: ElfResolver,
-    /// Reporting name for the module, from the mapping's symbolic path.
-    module: OsString,
-}
-
-impl Symbolize for GoPclntabResolver {
-    fn find_sym(
-        &self,
-        addr: Addr,
-        _opts: &FindSymOpts,
-    ) -> blazesym::Result<std::result::Result<ResolvedSym<'_>, Reason>> {
-        match self.pclntab.find_func(addr) {
-            Some(func) => Ok(Ok(ResolvedSym {
-                name: func.name,
-                module: Some(self.module.as_os_str()),
-                addr: func.entry,
-                size: usize::try_from(func.size).ok(),
-                // Go is not a variant blazesym knows; Unknown also keeps
-                // the demangler away from names that are not mangled.
-                lang: SrcLang::Unknown,
-                code_info: None,
-                inlined: Box::new([]),
-                _non_exhaustive: (),
-            })),
-            None => Ok(Err(Reason::UnknownAddr)),
-        }
-    }
-}
-
-impl TranslateFileOffset for GoPclntabResolver {
-    fn file_offset_to_virt_offset(&self, file_offset: u64) -> blazesym::Result<Option<Addr>> {
-        self.elf.file_offset_to_virt_offset(file_offset)
-    }
-}
-
-/// Probe a process member for the stripped-Go shape and build a resolver
-/// for it.
-///
-/// Returns `Some` only when the ELF at `maps_file` has *no* `.symtab` but
-/// does have a parseable `.gopclntab` — the case the default ELF resolver
-/// renders as hex or misattributes from stray dynamic symbols. Binaries
-/// with a symbol table keep the default (richer) path. Any error along the
-/// way returns `None`, deliberately: this probe must never make
-/// symbolization worse than it was without it.
-pub fn try_gopclntab_resolver(maps_file: &Path, symbolic_path: &Path) -> Option<Box<dyn Resolve>> {
-    let pclntab = match read_pclntab_from_stripped_elf(maps_file) {
-        Ok(Some(tab)) => tab,
-        Ok(None) => return None,
-        Err(err) => {
-            tracing::debug!(
-                "ignoring unusable .gopclntab in {}: {err:#}",
-                symbolic_path.display()
-            );
-            return None;
-        }
-    };
-    let elf = ElfResolver::open(maps_file).ok()?;
-    let module = symbolic_path
-        .file_name()
-        .unwrap_or(symbolic_path.as_os_str())
-        .to_os_string();
-    tracing::debug!(
-        "using .gopclntab symbolization for stripped Go binary {} ({} functions)",
-        symbolic_path.display(),
-        pclntab.func_count()
-    );
-    Some(Box::new(GoPclntabResolver {
-        pclntab,
-        elf,
-        module,
-    }))
-}
-
-/// Section-header size caps. Every symbol-table-less member of every
-/// profiled process gets probed, so reads must stay bounded and targeted:
-/// ELF + section headers + shstrtab first (a few KiB), then exactly the
-/// pclntab byte range for the binaries that have one. A binary whose
-/// metadata exceeds these caps is skipped, not mis-parsed.
-const MAX_SECTION_HEADERS: u64 = 4096;
-const MAX_SHSTRTAB_SIZE: u64 = 1 << 20;
-const MAX_PCLNTAB_SIZE: u64 = 1 << 30;
-
-/// Read and parse `.gopclntab` from the ELF at `path`, returning
-/// `Ok(None)` when the binary is not the stripped-Go shape this module
-/// exists for: not a little-endian ELF64, has a `.symtab` (the default
-/// symtab+DWARF path is strictly better), or has no `.gopclntab`.
-fn read_pclntab_from_stripped_elf(path: &Path) -> Result<Option<GoPclntab>> {
-    let file = File::open(path)?;
-
-    let mut ehdr = [0u8; 64];
-    if file.read_exact_at(&mut ehdr, 0).is_err() {
-        return Ok(None);
-    }
-    // \x7fELF, 64-bit (class 2), little-endian (data 1). Anything else is
-    // simply not a candidate.
-    if ehdr[..4] != [0x7f, b'E', b'L', b'F'] || ehdr[4] != 2 || ehdr[5] != 1 {
-        return Ok(None);
-    }
-    let e_shoff = u64::from_le_bytes(ehdr[0x28..0x30].try_into().unwrap());
-    let e_shentsize = u64::from(u16::from_le_bytes(ehdr[0x3a..0x3c].try_into().unwrap()));
-    let e_shnum = u64::from(u16::from_le_bytes(ehdr[0x3c..0x3e].try_into().unwrap()));
-    let e_shstrndx = usize::from(u16::from_le_bytes(ehdr[0x3e..0x40].try_into().unwrap()));
-    // e_shnum == 0 covers both section-header-stripped binaries and the
-    // >= SHN_LORESERVE escape hatch; neither occurs for the Go release
-    // builds this targets, so skipping is the fail-safe answer.
-    if e_shentsize != 64 || e_shnum == 0 || e_shnum > MAX_SECTION_HEADERS {
-        return Ok(None);
-    }
-
-    let mut shdrs = vec![0u8; (e_shnum * 64) as usize];
-    if file.read_exact_at(&mut shdrs, e_shoff).is_err() {
-        return Ok(None);
-    }
-    // Elf64_Shdr field offsets: sh_name +0 (u32), sh_type +4 (u32),
-    // sh_addr +16, sh_offset +24, sh_size +32 (u64s).
-    let shdr = |i: usize| shdrs.get(i * 64..(i + 1) * 64);
-    let shdr_u32 = |s: &[u8], off: usize| u32::from_le_bytes(s[off..off + 4].try_into().unwrap());
-    let shdr_u64 = |s: &[u8], off: usize| u64::from_le_bytes(s[off..off + 8].try_into().unwrap());
-
-    let shstr = shdr(e_shstrndx).context("shstrndx out of range")?;
-    let shstr_off = shdr_u64(shstr, 24);
-    let shstr_size = shdr_u64(shstr, 32);
-    if shstr_size > MAX_SHSTRTAB_SIZE {
-        return Ok(None);
-    }
-    let mut shstrtab = vec![0u8; shstr_size as usize];
-    if file.read_exact_at(&mut shstrtab, shstr_off).is_err() {
-        return Ok(None);
-    }
-    let section_name = |s: &[u8]| -> &[u8] {
-        let name_off = shdr_u32(s, 0) as usize;
-        let rest = shstrtab.get(name_off..).unwrap_or(&[]);
-        &rest[..rest.iter().position(|b| *b == 0).unwrap_or(rest.len())]
-    };
-
-    const SHT_SYMTAB: u32 = 2;
-    let mut pclntab_range = None;
-    let mut text_vaddr = None;
-    for i in 0..e_shnum as usize {
-        let s = shdr(i).context("section header out of range")?;
-        if shdr_u32(s, 4) == SHT_SYMTAB {
-            return Ok(None);
-        }
-        match section_name(s) {
-            b".gopclntab" => pclntab_range = Some((shdr_u64(s, 24), shdr_u64(s, 32))),
-            b".text" => text_vaddr = Some(shdr_u64(s, 16)),
-            _ => {}
-        }
-    }
-    let Some((offset, size)) = pclntab_range else {
-        return Ok(None);
-    };
-    if size > MAX_PCLNTAB_SIZE {
-        bail!(".gopclntab implausibly large ({size} bytes)");
-    }
-
-    let mut data = vec![0u8; size as usize];
-    file.read_exact_at(&mut data, offset)
-        .context("short read of .gopclntab")?;
-    GoPclntab::parse(data, text_vaddr).map(Some)
 }
 
 #[cfg(test)]
@@ -628,7 +464,7 @@ mod tests {
             out
         }
 
-        fn parse(&self) -> Result<GoPclntab> {
+        fn parse(&self) -> Result<GoPclntab, Error> {
             GoPclntab::parse(self.build(), Some(self.text_start))
         }
     }
@@ -677,6 +513,16 @@ mod tests {
     }
 
     #[test]
+    fn func_entry_enumeration_round_trips() {
+        let tab = sample_v118();
+        for i in 0..tab.func_count() {
+            let entry = tab.func_entry(i).unwrap();
+            assert_eq!(tab.find_func(entry).unwrap().entry, entry);
+        }
+        assert_eq!(tab.func_entry(tab.func_count()), None);
+    }
+
+    #[test]
     fn v116_absolute_entries() {
         let tab = TabBuilder::v116()
             .func(0x40_1000, "runtime.gcBgMarkWorker")
@@ -721,29 +567,38 @@ mod tests {
             .func(0x0, "main.main")
             .end(0x100);
         builder.magic = GO12_MAGIC;
-        assert!(builder.parse().is_err());
+        assert!(matches!(builder.parse(), Err(Error::Unsupported(_))));
         builder.magic = 0xDEAD_BEEF;
-        assert!(builder.parse().is_err());
+        assert!(matches!(builder.parse(), Err(Error::Unsupported(_))));
         // Big-endian table: the LE read of a BE magic matches nothing.
         builder.magic = GO120_MAGIC.swap_bytes();
-        assert!(builder.parse().is_err());
+        assert!(matches!(builder.parse(), Err(Error::Unsupported(_))));
     }
 
     #[test]
     fn rejects_malformed_input_without_panicking() {
         // Too short for the header prefix.
-        assert!(GoPclntab::parse(vec![0xF1, 0xFF, 0xFF], None).is_err());
+        assert!(matches!(
+            GoPclntab::parse(vec![0xF1, 0xFF, 0xFF], None),
+            Err(Error::Malformed(_))
+        ));
         // Valid prefix, missing header words.
         let mut short = GO120_MAGIC.to_le_bytes().to_vec();
         short.extend_from_slice(&[0, 0, 1, 8]);
-        assert!(GoPclntab::parse(short, None).is_err());
+        assert!(matches!(
+            GoPclntab::parse(short, None),
+            Err(Error::Malformed(_))
+        ));
         // Bad ptrsize.
         let mut bad_ptr = GO120_MAGIC.to_le_bytes().to_vec();
         bad_ptr.extend_from_slice(&[0, 0, 1, 3]);
         bad_ptr.extend_from_slice(&[0u8; 64]);
-        assert!(GoPclntab::parse(bad_ptr, None).is_err());
+        assert!(matches!(
+            GoPclntab::parse(bad_ptr, None),
+            Err(Error::Unsupported(_))
+        ));
         // nfunc so large the functab cannot fit in the section.
-        let mut builder = TabBuilder::v118(0x40_0000)
+        let builder = TabBuilder::v118(0x40_0000)
             .func(0x0, "main.main")
             .end(0x100);
         let mut bytes = builder.build();
@@ -751,7 +606,6 @@ mod tests {
         assert!(GoPclntab::parse(bytes, None).is_err());
         // Truncations at every length must error or lose the function, but
         // never panic.
-        builder.magic = GO120_MAGIC;
         let full = builder.build();
         for len in 0..full.len() {
             let tab = GoPclntab::parse(full[..len].to_vec(), Some(0x40_0000));
@@ -773,111 +627,6 @@ mod tests {
         bytes[len - 4..].copy_from_slice(&u32::MAX.to_le_bytes());
         let tab = GoPclntab::parse(bytes, Some(0x40_0000)).unwrap();
         assert_eq!(tab.find_func(0x40_0000), None);
-    }
-
-    /// Parse the pclntab of a binary produced by the real Go toolchain,
-    /// stripped the way release images are, and resolve its functions.
-    /// Skips (with a notice) when no `go` binary is on PATH, mirroring how
-    /// the pystacks tests skip without a usable Python.
-    #[test]
-    fn resolves_real_stripped_go_binary() {
-        use std::io::Write as _;
-        use std::process::Command;
-
-        if Command::new("go").arg("version").output().is_err() {
-            eprintln!("skipping: no go toolchain on PATH");
-            return;
-        }
-        let dir = tempfile::tempdir().unwrap();
-        let src = dir.path().join("main.go");
-        let mut f = File::create(&src).unwrap();
-        f.write_all(
-            b"package main\n\nfunc main() {\n\tprintln(helper())\n}\n\n//go:noinline\nfunc helper() int {\n\treturn 42\n}\n",
-        )
-        .unwrap();
-        drop(f);
-        // File-mode build (no module) with -trimpath: the embedded module
-        // path is the synthetic "command-line-arguments" and no local
-        // filesystem paths land in the binary's metadata.
-        let bin = dir.path().join("fixture");
-        let out = Command::new("go")
-            .args(["build", "-trimpath", "-ldflags=-s -w", "-o"])
-            .arg(&bin)
-            .arg(&src)
-            .env("GOCACHE", dir.path().join("gocache"))
-            .env("CGO_ENABLED", "0")
-            .output()
-            .unwrap();
-        assert!(
-            out.status.success(),
-            "go build failed: {}",
-            String::from_utf8_lossy(&out.stderr)
-        );
-
-        // The production probe must classify the fixture as stripped-Go.
-        let tab = read_pclntab_from_stripped_elf(&bin)
-            .unwrap()
-            .expect("fixture not detected as a stripped Go binary");
-        assert!(tab.func_count() > 100, "implausibly small function table");
-
-        // Sweep every function entry: each must resolve back to itself,
-        // and main.main / main.helper must both be present by name.
-        let mut seen_main = false;
-        let mut seen_helper = false;
-        for i in 0..tab.func_count() {
-            let entry = tab.entry_vaddr(i).unwrap();
-            let func = tab
-                .find_func(entry)
-                .unwrap_or_else(|| panic!("entry {entry:#x} (functab slot {i}) failed to resolve"));
-            assert_eq!(func.entry, entry);
-            seen_main |= func.name == "main.main";
-            seen_helper |= func.name == "main.helper";
-        }
-        assert!(seen_main, "main.main not found in pclntab");
-        assert!(seen_helper, "main.helper not found in pclntab");
-
-        // An unstripped build of the same source must be declined: the
-        // symtab+DWARF path is richer and the probe must not shadow it.
-        let unstripped = dir.path().join("fixture-unstripped");
-        let out = Command::new("go")
-            .args(["build", "-trimpath", "-o"])
-            .arg(&unstripped)
-            .arg(&src)
-            .env("GOCACHE", dir.path().join("gocache"))
-            .env("CGO_ENABLED", "0")
-            .output()
-            .unwrap();
-        assert!(out.status.success());
-        assert!(read_pclntab_from_stripped_elf(&unstripped)
-            .unwrap()
-            .is_none());
-    }
-
-    /// Parse the pclntab of an arbitrary Go ELF supplied via
-    /// `GOPCLNTAB_TEST_BINARY` — handy for vetting against real release
-    /// binaries (kubelet, etcd, kube-state-metrics). Skips when unset.
-    #[test]
-    fn resolves_binary_from_env() {
-        let Some(path) = std::env::var_os("GOPCLNTAB_TEST_BINARY") else {
-            return;
-        };
-        let tab = read_pclntab_from_stripped_elf(Path::new(&path))
-            .unwrap()
-            .expect("binary not detected as stripped Go");
-        assert!(tab.func_count() > 0);
-        let mut named = 0usize;
-        for i in 0..tab.func_count() {
-            if let Some(func) = tab.find_func(tab.entry_vaddr(i).unwrap()) {
-                assert!(!func.name.is_empty());
-                named += 1;
-            }
-        }
-        eprintln!(
-            "resolved {named}/{} functions from {}",
-            tab.func_count(),
-            Path::new(&path).display()
-        );
-        assert_eq!(named, tab.func_count());
     }
 
     #[test]

--- a/src/gopclntab_resolver.rs
+++ b/src/gopclntab_resolver.rs
@@ -1,0 +1,123 @@
+//! blazesym integration for the [`gopclntab`] crate: symbolize stripped Go
+//! binaries from the Go runtime's function table.
+//!
+//! The parsing and ELF mechanics live in the workspace's `gopclntab`
+//! crate (published for reuse); this module supplies systing's two pieces
+//! on top:
+//!
+//! * the **activation policy** — a process member is claimed only when it
+//!   has no ELF symbol table but does carry a parseable `.gopclntab`
+//!   (i.e. a stripped Go binary). Binaries with a symbol table keep the
+//!   richer symtab+DWARF path, and blazesym's nearest-symbol matching
+//!   against sparse cgo dynamic symbols (which produces confidently wrong
+//!   names on e.g. COS/boringcrypto kubelet builds) is bypassed entirely
+//!   when the resolver is active;
+//! * the **[`Resolve`] implementation** wiring pc lookups into blazesym's
+//!   process symbolization flow.
+//!
+//! Only function names are resolved (no file/line, no inline expansion):
+//! that is the difference between an unreadable profile and a readable
+//! one. Addresses outside the table (the C/asm portions of cgo text)
+//! return unknown and render through the existing contextual labels.
+
+use std::ffi::OsString;
+use std::path::Path;
+
+use blazesym::helper::ElfResolver;
+use blazesym::symbolize::FindSymOpts;
+use blazesym::symbolize::Reason;
+use blazesym::symbolize::Resolve;
+use blazesym::symbolize::ResolvedSym;
+use blazesym::symbolize::SrcLang;
+use blazesym::symbolize::Symbolize;
+use blazesym::symbolize::TranslateFileOffset;
+use blazesym::Addr;
+
+use gopclntab::ElfPclntab;
+use gopclntab::GoPclntab;
+
+/// A [`Resolve`] implementation answering symbol lookups from a Go
+/// binary's pclntab.
+///
+/// File-offset translation (needed by the process symbolization flow to
+/// map memory offsets into ELF virtual addresses before calling
+/// [`Symbolize::find_sym`]) is delegated to a regular [`ElfResolver`] over
+/// the same file, which reads it from the program headers.
+#[derive(Debug)]
+pub struct GoPclntabResolver {
+    pclntab: GoPclntab,
+    elf: ElfResolver,
+    /// Reporting name for the module, from the mapping's symbolic path.
+    module: OsString,
+}
+
+impl Symbolize for GoPclntabResolver {
+    fn find_sym(
+        &self,
+        addr: Addr,
+        _opts: &FindSymOpts,
+    ) -> blazesym::Result<std::result::Result<ResolvedSym<'_>, Reason>> {
+        match self.pclntab.find_func(addr) {
+            Some(func) => Ok(Ok(ResolvedSym {
+                name: func.name,
+                module: Some(self.module.as_os_str()),
+                addr: func.entry,
+                size: usize::try_from(func.size).ok(),
+                // Go is not a variant blazesym knows; Unknown also keeps
+                // the demangler away from names that are not mangled.
+                lang: SrcLang::Unknown,
+                code_info: None,
+                inlined: Box::new([]),
+                _non_exhaustive: (),
+            })),
+            None => Ok(Err(Reason::UnknownAddr)),
+        }
+    }
+}
+
+impl TranslateFileOffset for GoPclntabResolver {
+    fn file_offset_to_virt_offset(&self, file_offset: u64) -> blazesym::Result<Option<Addr>> {
+        self.elf.file_offset_to_virt_offset(file_offset)
+    }
+}
+
+/// Probe a process member for the stripped-Go shape and build a resolver
+/// for it.
+///
+/// Returns `Some` only when the ELF at `maps_file` has *no* `.symtab` but
+/// does have a parseable `.gopclntab` — the case the default ELF resolver
+/// renders as hex or misattributes from stray dynamic symbols. Binaries
+/// with a symbol table keep the default (richer) path. Any error along
+/// the way returns `None`, deliberately: this probe must never make
+/// symbolization worse than it was without it.
+pub fn try_gopclntab_resolver(maps_file: &Path, symbolic_path: &Path) -> Option<Box<dyn Resolve>> {
+    let elf = match ElfPclntab::from_path(maps_file) {
+        Ok(Some(elf)) => elf,
+        Ok(None) => return None,
+        Err(err) => {
+            tracing::debug!(
+                "ignoring unusable .gopclntab in {}: {err}",
+                symbolic_path.display()
+            );
+            return None;
+        }
+    };
+    if elf.has_symtab {
+        return None;
+    }
+    let resolver = ElfResolver::open(maps_file).ok()?;
+    let module = symbolic_path
+        .file_name()
+        .unwrap_or(symbolic_path.as_os_str())
+        .to_os_string();
+    tracing::debug!(
+        "using .gopclntab symbolization for stripped Go binary {} ({} functions)",
+        symbolic_path.display(),
+        elf.table.func_count()
+    );
+    Some(Box::new(GoPclntabResolver {
+        pclntab: elf.table,
+        elf: resolver,
+        module,
+    }))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod validation;
 
 // Tracing modules (previously in binary only)
 pub mod events;
-pub mod gopclntab;
+pub mod gopclntab_resolver;
 pub mod gvisor_guest;
 pub mod marker_recorder;
 pub mod memory_recorder;

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -544,7 +544,7 @@ pub struct StackRecorder {
     /// When set (default), process members that have no ELF symbol table
     /// but carry a `.gopclntab` — stripped Go binaries — are symbolized
     /// from the Go runtime's function table instead of rendering as hex.
-    /// See [`crate::gopclntab`].
+    /// See [`crate::gopclntab_resolver`].
     gopclntab: bool,
 }
 
@@ -638,7 +638,7 @@ impl StackRecorder {
                 }
                 if gopclntab {
                     if let ProcessMemberType::Path(path) = info.member_entry {
-                        if let Some(resolver) = crate::gopclntab::try_gopclntab_resolver(
+                        if let Some(resolver) = crate::gopclntab_resolver::try_gopclntab_resolver(
                             &path.maps_file,
                             &path.symbolic_path,
                         ) {


### PR DESCRIPTION
## What

The Go symbolization added in #140 moves into `crates/gopclntab`, a zero-dependency workspace member, so other projects can resolve function names in stripped Go binaries without pulling in a profiler. The crate is publishable as-is (`cargo publish --dry-run` passes; LICENSE/README/keywords included) — actual publication stays a maintainer action.

## API split

- **Crate (`gopclntab`)** — mechanics only, `std`-only, zero dependencies, no profiler types in the surface:
  - `GoPclntab::parse(bytes, text_vaddr)` + `find_func(pc) -> GoFunc{name, entry, size}` + `func_count`/`func_entry` over raw table bytes;
  - `ElfPclntab::from_path`/`from_bytes` — bounded ELF reads (headers + the table itself, never whole binaries) that also report `has_symtab`;
  - a real error taxonomy: `Error::Unsupported` (Go ≤1.15 layouts, big-endian, unknown magics) vs `Error::Malformed` (truncation, out-of-bounds offsets) — callers can distinguish "not for me" from "broken". `anyhow` stays out of the public surface.
  - **Policy is deliberately the caller's**: the ELF layer reports whether a symbol table exists rather than deciding what to prefer. A profiler wants the pclntab only for stripped binaries; other tools may always want it.
- **systing (`src/gopclntab_resolver.rs`, renamed to avoid shadowing the crate)** — the blazesym `Resolve` implementation and the stripped-Go activation policy (no `.symtab` AND parseable `.gopclntab`), unchanged in behavior.

## Workspace CI

`cargo test`/`cargo clippy` were single-crate; a workspace would have silently narrowed CI to the root crate. Both gain `--workspace` (`cargo fmt --all` already was workspace-wide). Verified locally with the workflow's commands:

- `cargo test --workspace`: both members demonstrably run — `gopclntab` lib suite **14 passed** (including the Go-toolchain fixture test: stripped build fully resolves, unstripped twin reports its symtab; and a doc-test), systing lib suite **378 passed** (the 12 moved tests now live with the crate; totals reconcile exactly).
- `cargo clippy --workspace --no-default-features -- -D warnings`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo doc -p gopclntab --no-deps`: no warnings. `cargo publish --dry-run`: packages and compiles standalone.

Real-binary validation through the crate path: kube-state-metrics v2.14.0 resolves 70846/70846 functions (`GOPCLNTAB_TEST_BINARY` hook).

## Behavior

None changed: the extraction is code motion plus API re-surfacing. The end-to-end integration test (records a live stripped Go workload and requires its frames to resolve) passes on this branch, as does the full integration suite.

---
*Version note: 1.10.8 is taken by another in-flight PR.*
