### PR TITLE
Add --symbolize-names-only to bound symbolization memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.10"
+version = "1.10.11"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/gopclntab"]
 
 [package]
 name = "systing"
-version = "1.10.10"
+version = "1.10.11"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,16 @@ struct Command {
     /// to symbol-table-only resolution, which renders them as hex)
     #[arg(long)]
     no_gopclntab: bool,
+    /// Resolve user-space symbols from ELF symbol tables only: skips DWARF
+    /// debug info, source line info, inlined-function resolution, and
+    /// debuginfod. Function names are unchanged for binaries that carry a
+    /// symbol table; frames lose their "[file:line]" suffix and inlined
+    /// frames collapse into their caller. Bounds symbolization memory on
+    /// hosts running many freshly-built debug binaries (CI), where parsed
+    /// debug info — cached per binary with no eviction — otherwise reaches
+    /// GiBs.
+    #[arg(long)]
+    symbolize_names_only: bool,
     /// Disable scheduler event tracing (sched_* tracepoints and scheduler event recorder)
     #[arg(long)]
     no_sched: bool,
@@ -200,6 +210,7 @@ impl From<Command> for Config {
             no_frame_labels: cmd.no_frame_labels,
             no_gvisor_guest_maps: cmd.no_gvisor_guest_maps,
             no_gopclntab: cmd.no_gopclntab,
+            symbolize_names_only: cmd.symbolize_names_only,
             no_sched: cmd.no_sched,
             no_irq: cmd.no_irq,
             syscalls: cmd.syscalls,

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -546,6 +546,18 @@ pub struct StackRecorder {
     /// from the Go runtime's function table instead of rendering as hex.
     /// See [`crate::gopclntab_resolver`].
     gopclntab: bool,
+    /// When set, resolve user-space symbols from ELF symbol tables only:
+    /// no DWARF debug info, source line info, inlined-function resolution,
+    /// or debuginfod fetches. Function names are unchanged for binaries
+    /// that carry a symbol table (and `.gopclntab` handling for stripped
+    /// Go binaries is unaffected); frames lose their "[file:line]" suffix
+    /// and inlined frames collapse into their caller. This bounds
+    /// symbolization memory: blazesym retains parsed debug info per binary
+    /// with no eviction, and one freshly-built `-g` binary can hold
+    /// hundreds of MiB resident, so a host running many of them (a CI node
+    /// mid-build) accumulates past any fixed budget — while the
+    /// symbol-table path costs a few MiB per binary for identical names.
+    names_only: bool,
 }
 
 impl ThreadAwareRecorder for StackRecorder {
@@ -575,6 +587,7 @@ impl StackRecorder {
             frame_labels: true,
             gvisor_guest_maps: true,
             gopclntab: true,
+            names_only: false,
         }
     }
 
@@ -586,6 +599,12 @@ impl StackRecorder {
     /// Disable `.gopclntab`-based symbolization of stripped Go binaries.
     pub fn set_gopclntab(&mut self, enabled: bool) {
         self.gopclntab = enabled;
+    }
+
+    /// Restrict user-space symbolization to ELF symbol tables (see the
+    /// `names_only` field docs for what is kept and what is lost).
+    pub fn set_names_only(&mut self, enabled: bool) {
+        self.names_only = enabled;
     }
 
     /// Disable querying gVisor control sockets for guest maps.
@@ -618,12 +637,21 @@ impl StackRecorder {
 
     /// Create a symbolizer with the configured process dispatcher.
     fn create_symbolizer(&self) -> Symbolizer {
-        let debuginfod = self.process_dispatcher.clone();
+        // names_only drops debuginfod: its purpose is fetching debug info,
+        // which names-only symbolization would then ignore. gopclntab stays —
+        // it provides function names for stripped Go binaries at
+        // symbol-table-like cost.
+        let debuginfod = if self.names_only {
+            None
+        } else {
+            self.process_dispatcher.clone()
+        };
         let gopclntab = self.gopclntab;
+        let code_info = !self.names_only;
         if debuginfod.is_none() && !gopclntab {
             return Symbolizer::builder()
-                .enable_code_info(true)
-                .enable_inlined_fns(true)
+                .enable_code_info(code_info)
+                .enable_inlined_fns(code_info)
                 .build();
         }
         // Dispatch order: debuginfod first (fetched debug info beats
@@ -649,8 +677,8 @@ impl StackRecorder {
                 Ok(None)
             };
         Symbolizer::builder()
-            .enable_code_info(true)
-            .enable_inlined_fns(true)
+            .enable_code_info(code_info)
+            .enable_inlined_fns(code_info)
             .set_process_dispatcher(dispatcher)
             .build()
     }
@@ -714,6 +742,20 @@ impl StackRecorder {
         );
         pb.set_message("Symbolizing stacks");
 
+        // Phase-boundary RSS notes: together with the rebuild note below,
+        // these attribute a memory blowup (or an OOM kill's last words) to
+        // the exited-process pass vs. the live-process symbolization pass
+        // without any tooling on the host.
+        let phase_rss = |phase: &str| {
+            if let Some(anon) = current_anon_rss_bytes() {
+                eprintln!(
+                    "Note: symbolization {phase}: anon RSS {} MiB ({total} unique stacks)",
+                    anon >> 20
+                );
+            }
+        };
+        phase_rss("start");
+
         let mut symbolizer = self.create_symbolizer();
 
         // Create kernel source once - it's shared across all processes
@@ -773,6 +815,7 @@ impl StackRecorder {
             })?;
         }
         drop(tgid_alive);
+        phase_rss("exited-process pass done");
 
         // Pass 2: symbolize live processes one re-spill bucket at a time, and
         // within each bucket one tgid at a time. blazesym accumulates parsed
@@ -838,7 +881,10 @@ impl StackRecorder {
                 let _ = symbolizer.cache(&cache::Cache::from(cache::Process::new(
                     (tgid as u32).into(),
                 )));
-                let proc_src = Source::Process(Process::new(Pid::from(tgid as u32)));
+                let mut proc_source = Process::new(Pid::from(tgid as u32));
+                // See the `names_only` field for the tradeoff.
+                proc_source.debug_syms = !self.names_only;
+                let proc_src = Source::Process(proc_source);
                 // One maps analysis per process, powering island bridging and
                 // frame labels for its whole group. `None` (process raced to
                 // exit, unreadable maps) degrades to plain symbolization.
@@ -887,6 +933,7 @@ impl StackRecorder {
         }
 
         pb.finish_with_message("Stack symbolization complete");
+        phase_rss("done");
 
         Ok(())
     }
@@ -912,7 +959,9 @@ impl StackRecorder {
         }
 
         if let Some(bridge) = ctx.maps.and_then(|m| m.bridge_for(addr)) {
-            let elf_src = Source::Elf(Elf::new(&bridge.map_files_path));
+            let mut bridge_elf = Elf::new(&bridge.map_files_path);
+            bridge_elf.debug_syms = !self.names_only;
+            let elf_src = Source::Elf(bridge_elf);
             if let Some(sym) = symbolizer
                 .symbolize_single(&elf_src, Input::FileOffset(bridge.file_offset))
                 .ok()
@@ -1581,5 +1630,61 @@ mod tests {
             .find(|s| s.id == plain_id)
             .expect("plain stack");
         assert_eq!(plain.frame_names[0], format!("0x{dead_addr:x}"));
+    }
+
+    /// Names-only mode must still resolve live-process symbols — the ELF
+    /// symbol table carries the same function names DWARF does — while the
+    /// dead-process path is unchanged.
+    #[test]
+    fn test_finish_inner_names_only_still_resolves_live() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        rec.set_names_only(true);
+        rec.set_spill_dir(dir.path());
+
+        let self_tgid = std::process::id() as i32;
+        let live_addr = marker_fn as fn() -> u64 as usize as u64;
+        let live_id = rec.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![live_addr],
+                py_stack: vec![],
+            },
+            self_tgid,
+        );
+        let dead_tgid = i32::MAX - 1;
+        let dead_addr = 0x1234_5678u64;
+        let dead_id = rec.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![dead_addr],
+                py_stack: vec![],
+            },
+            dead_tgid,
+        );
+
+        let mut collector = crate::record::InMemoryCollector::new();
+        rec.finish_inner(&mut collector).unwrap();
+        let stacks = &collector.data().stacks;
+
+        let live = stacks.iter().find(|s| s.id == live_id).expect("live stack");
+        let frame = &live.frame_names[0];
+        assert!(
+            !frame.starts_with("0x") && frame.contains('('),
+            "names-only live frame should still resolve from the symbol \
+             table (or carry a module label), got: {frame}"
+        );
+        // The test binary carries full DWARF, so a "[file:line]" suffix
+        // here would mean names-only silently stopped disabling code info.
+        assert!(
+            !frame.contains(".rs:"),
+            "names-only frame must not carry source location info, got: {frame}"
+        );
+
+        let dead = stacks.iter().find(|s| s.id == dead_id).expect("dead stack");
+        assert_eq!(
+            dead.frame_names[0],
+            format!("unknown ([exited]) <{dead_addr:#x}>")
+        );
     }
 }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -558,6 +558,9 @@ pub struct Config {
     pub no_gvisor_guest_maps: bool,
     /// Do not symbolize stripped Go binaries from their `.gopclntab`
     pub no_gopclntab: bool,
+    /// Resolve user-space symbols from ELF symbol tables only (no DWARF
+    /// debug info, line info, inlined functions, or debuginfod)
+    pub symbolize_names_only: bool,
     /// Disable scheduler tracing
     pub no_sched: bool,
     /// Disable IRQ/softirq tracing
@@ -638,6 +641,7 @@ impl Default for Config {
             no_frame_labels: false,
             no_gvisor_guest_maps: false,
             no_gopclntab: false,
+            symbolize_names_only: false,
             no_sched: false,
             no_irq: false,
             syscalls: false,
@@ -1430,6 +1434,15 @@ fn configure_recorder(opts: &Config, recorder: &Arc<SessionRecorder>) {
     }
     if opts.no_gopclntab {
         recorder.stack_recorder.lock().unwrap().set_gopclntab(false);
+    }
+    if opts.symbolize_names_only {
+        recorder.stack_recorder.lock().unwrap().set_names_only(true);
+        if opts.enable_debuginfod {
+            eprintln!(
+                "Note: --symbolize-names-only ignores debuginfod (it exists \
+                 to fetch the debug info names-only symbolization skips)"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Whole-system captures on hosts running many freshly-built debug binaries (CI nodes mid-build) can blow their memory limit during end-of-trace symbolization and get killed at the finish line: blazesym retains parsed debug info per binary with no eviction, and with code-info + inlined-fn resolution one `-g` binary holds hundreds of MiB. The RSS valve can't fully contain it — growth between checks is unbounded (a large parse happens inside one symbolize call), and the anti-thrash floor deliberately stops rebuilding when `malloc_trim` can't return fragmented arenas. Notably this term is invariant to sample rate: one sample into a fresh binary costs the same parse as ten thousand, so lowering the sampling frequency doesn't help.

Measured with blazesym 0.2.3 on systing's own debug build (839 MiB of `.debug_*`), 2000 addresses spread across `.text`:

| config | resident |
|---|---|
| code-info + inlined fns (current) | 464 MiB |
| DWARF names only | 220 MiB |
| symbol-table names only | **4.3 MiB** |

Across three such binaries: 928 MiB → 10 MiB, **byte-identical function name strings**, ~10× faster. Symbol tables carry the same names DWARF does; DWARF funds `[file:line]` suffixes and inline expansion, which aggregate flame-graph pipelines never render.

**Change:**
- `--symbolize-names-only`: user-space symbols resolve from ELF symbol tables only — `Process` and bridged-`Elf` sources get `debug_syms = false`, code-info/inlined-fns off, debuginfod skipped (with a note when both flags are set). `.gopclntab` handling for stripped Go binaries is unaffected (it provides names at symbol-table-like cost). Default behavior unchanged: interactive traces keep full fidelity. This is also what earns continuous profiling back on the host pools where it had to be disabled to stop the kills — with the symbolization term bounded, those hosts can be re-enabled rather than left dark.
- Anon-RSS notes at symbolization phase boundaries (start / after exited-process pass / done), so a memory blowup or an OOM kill's last stderr line attributes to the exited-process pass vs the live-process pass without host tooling.

**Testing:** `cargo test --lib` 381/381; new end-to-end test (`test_finish_inner_names_only_still_resolves_live`) self-symbolizes via `/proc/self` and asserts the live frame resolves *and* carries no `[file:line]` suffix (the test binary has full DWARF, so a suffix means the flag silently stopped working); dead-process path asserted unchanged. Clippy clean.

Version: 1.10.11.