### PR TITLE
Normalize stack storage to uniform root-to-leaf order (schema v12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.10.11"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/gopclntab"]
 
 [package]
 name = "systing"
-version = "1.10.11"
+version = "1.11.0"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -211,3 +211,47 @@ strings there) — the normalization happens at DuckDB import time.
   (`trace_id, id, frame_names, depth, leaf_name`). Ad-hoc queries can use it as
   a drop-in replacement; for hot paths join `frame` directly, since the view
   re-aggregates names per row.
+
+## Schema Version 12 (systing 1.11.0) — 2026-07-09
+
+Stack frame ordering is now uniform. Recorded stacks are a concatenation of
+three segments — python, user, kernel — and through v11 the segments disagreed
+on direction: the BPF unwinder's user and kernel segments were reversed to
+root-to-leaf at capture, while the python segment kept pystacks' leaf-first
+buffer order. `leaf_name` took the first entry of the combined array, which is
+the python leaf when python frames are present but the ROOT frame for
+native-only stacks. (The v11 entry's claim that ordering was "leaf-to-root"
+described the reader's assumption, not the data: native segments have been
+root-to-leaf since capture-time reversal was introduced.)
+
+No table shapes change. The version bump marks the data-semantics change so
+tools can distinguish uniformly-ordered databases.
+
+### Changed semantics
+- `stack.frame_ids` (and `frame_names` in parquet / the `stack_frames` view):
+  the python segment is now stored root-to-leaf like the user and kernel
+  segments, making the whole array one coherent root-to-leaf sequence
+  (outermost caller first, innermost executing frame last). Segment layout is
+  unchanged: python (outermost), then user, then kernel. v11 and older
+  databases keep the mixed order they were written with — the python segment
+  cannot be re-ordered after the fact without classifying frames by name
+  (note for anyone attempting that: root-side markers — `<module>`, threading
+  bootstraps, and on CPython 3.12+ an `<interpreter trampoline>` frame that
+  sits beyond `<module>` — fall in the run's root-side half, not necessarily
+  at its literal end); native-only stacks are identical either way. Importing an older trace into
+  a v12 database does not re-order it either. `_traces.systing_version` is
+  the per-trace discriminator, with one caveat: it is stamped at
+  parquet-to-DuckDB conversion time with the converting binary's version
+  (then preserved across database-to-database imports), so it names the
+  recorder only when recording and conversion happen in the same run — true
+  for the normal pipeline, not for a retained parquet directory converted
+  later by a newer binary. Embedding the recorder's version in the parquet
+  directory itself is planned follow-up.
+- `stack.leaf_name` now holds the name of the innermost executing frame (the
+  last array entry). Through v11 it held the first entry — the root frame for
+  native-only stacks, despite the column name.
+- `systing analyze flamegraph` (and the MCP flamegraph tool) previously
+  reversed the array on output under the leaf-to-root assumption, emitting
+  inverted folded stacks for native frames. It now emits storage order, which
+  is correct for all schema versions' native segments; python segments in
+  pre-v12 databases remain leaf-first within the blend.

--- a/src/analyze/flamegraph.rs
+++ b/src/analyze/flamegraph.rs
@@ -302,8 +302,9 @@ fn build_flamegraph_query(
 
 /// Format a chr(31)-separated string of frame ids into folded stack format.
 ///
-/// Frame ids are stored leaf-to-root in the database, so they are reversed
-/// to root-to-leaf order for flamegraph convention (root;child;...;leaf).
+/// Frame ids are stored root-to-leaf in the database (see `Stack` in
+/// stack_recorder.rs), which is already the flamegraph folded convention
+/// (root;child;...;leaf) — emit in storage order.
 fn format_folded_stack(trace_id: &str, frames_str: &str, frames: &FrameTable) -> String {
     if frames_str.is_empty() {
         return String::new();
@@ -311,10 +312,8 @@ fn format_folded_stack(trace_id: &str, frames_str: &str, frames: &FrameTable) ->
 
     let trace_frames = frames.get(trace_id);
 
-    // Reverse from leaf-to-root (storage order) to root-to-leaf (flamegraph convention)
     let formatted: Vec<String> = frames_str
         .split('\x1F')
-        .rev()
         .map(|id_str| {
             let name = id_str
                 .parse::<usize>()
@@ -413,10 +412,10 @@ mod tests {
     }
 
     #[test]
-    fn test_format_folded_stack_reversal() {
-        // frame_ids stored leaf-to-root: "0\x1F1\x1F2"
-        // Should output root-to-leaf: "root;mid;leaf"
-        let frames = frame_map(&["leaf (app) <0x1>", "mid (app) <0x2>", "root (app) <0x3>"]);
+    fn test_format_folded_stack_storage_order() {
+        // frame_ids stored root-to-leaf: "0\x1F1\x1F2" emits in storage
+        // order, which is already the folded convention root;mid;leaf.
+        let frames = frame_map(&["root (app) <0x1>", "mid (app) <0x2>", "leaf (app) <0x3>"]);
         let result = format_folded_stack("t", "0\x1F1\x1F2", &frames);
         assert_eq!(result, "root [app];mid [app];leaf [app]");
     }

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -133,7 +133,7 @@ pub struct TraceImportMapping {
 }
 
 /// Current schema version. See SCHEMA_CHANGES.md for history.
-pub const SCHEMA_VERSION: u32 = 11;
+pub const SCHEMA_VERSION: u32 = 12;
 
 /// All data tables in the DuckDB schema (excludes the `_traces` metadata table).
 pub const DATA_TABLES: &[&str] = &[
@@ -379,6 +379,9 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
         );
 
         -- Query-friendly stack tables.
+        -- frame_ids are ordered root-to-leaf (outermost caller first; schema
+        -- v12 — earlier traces stored the python segment leaf-first, see
+        -- SCHEMA_CHANGES.md) and leaf_name names the last (innermost) frame.
         -- frame_ids are dense per-trace integers into the frame table; this is
         -- normalized because DuckDB does not compress strings inside list
         -- columns, so a VARCHAR[] of frame names blows up to tens of MB. The

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -733,7 +733,9 @@ network activity, and performance counters. Traces are stored in DuckDB database
 # Key tables and their contents
 - stack_sample: Stack trace samples with timestamps (ts in nanoseconds). \
   stack_event_type: 0=uninterruptible-sleep, 1=cpu, 2=interruptible-sleep.
-- stack: Flattened stack frames (frame_ids BIGINT[], leaf-to-root order). \
+- stack: Flattened stack frames (frame_ids BIGINT[], root-to-leaf order: \
+  outermost caller first, innermost executing frame last; leaf_name is the \
+  last frame's name). \
   Join to frame on (trace_id, id) for names, or use the stack_frames view \
   which exposes a frame_names VARCHAR[] column directly.
 - frame: Interned frame strings (id, name) referenced by stack.frame_ids.

--- a/src/parquet_to_perfetto.rs
+++ b/src/parquet_to_perfetto.rs
@@ -2546,7 +2546,9 @@ fn get_trace_start_timestamp(input_dir: &Path) -> u64 {
 
 /// Helper struct for stack records from stack.parquet
 struct StackData {
-    /// Frame names in leaf-to-root order.
+    /// Frame names in root-to-leaf order (storage order), which matches
+    /// perfetto's `Callstack.frame_ids` convention ("bottom frame first") —
+    /// pass through without reversing.
     /// Each name contains embedded module and location info in format:
     /// `function_name (module_name [file:line]) <0xaddr>`
     frame_names: Vec<String>,

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -34,7 +34,13 @@ type ProcessDispatcher = Box<
 >;
 use debuginfod::{BuildId, CachingClient, Client};
 
-// Stack structure representing kernel, user, and Python stacks
+// Stack structure representing kernel, user, and Python stacks.
+//
+// Direction invariant: every segment is stored ROOT-TO-LEAF (outermost
+// caller first, innermost/executing frame last). The BPF unwinder and
+// pystacks both deliver frames leaf-first; `Stack::new` reverses each
+// segment so `frame_ids`, folded output, and exports all read one
+// coherent direction.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Stack {
     pub(crate) kernel_stack: Vec<u64>,
@@ -68,12 +74,19 @@ fn filter_and_reverse_kernel_stack(addrs: &[u64]) -> Vec<u64> {
         .collect()
 }
 
+/// Reverses the python stack to get root-to-leaf order. pystacks fills its
+/// buffer leaf-first (the executing frame is read first, then the walk
+/// follows the frame chain outward), mirroring the BPF unwinder direction.
+fn reverse_py_stack(frames: &[PyAddr]) -> Vec<PyAddr> {
+    frames.iter().rev().cloned().collect()
+}
+
 impl Stack {
     pub fn new(kernel_stack: &[u64], user_stack: &[u64], py_stack: &[PyAddr]) -> Self {
         Self {
             kernel_stack: filter_and_reverse_kernel_stack(kernel_stack),
             user_stack: filter_and_reverse_user_stack(user_stack),
-            py_stack: py_stack.to_vec(),
+            py_stack: reverse_py_stack(py_stack),
         }
     }
 }
@@ -415,7 +428,9 @@ fn emit_stack_record(
     if frame_names.is_empty() {
         return Ok(());
     }
-    let leaf_name = frame_names.first().cloned().unwrap_or_default();
+    // Frames are stored root-to-leaf; the leaf (innermost executing frame)
+    // is the last entry.
+    let leaf_name = frame_names.last().cloned().unwrap_or_default();
     let depth = frame_names.len().min(i32::MAX as usize) as i32;
     collector.add_stack(StackRecord {
         id: stack_id,
@@ -1297,6 +1312,43 @@ mod tests {
 
         // Empty stack
         assert_eq!(filter_and_reverse_kernel_stack(&[]), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn test_stack_new_reverses_py_stack() {
+        use crate::pystacks::types::StackWalkerFrame;
+        // pystacks delivers frames leaf-first; Stack stores every segment
+        // root-to-leaf, so construction must reverse the python segment too.
+        let py = |symbol_id: u64| PyAddr {
+            addr: StackWalkerFrame {
+                symbol_id,
+                inst_idx: 0,
+                pad_: 0,
+            },
+        };
+        let stack = Stack::new(&[], &[], &[py(1), py(2), py(3)]);
+        assert_eq!(stack.py_stack, vec![py(3), py(2), py(1)]);
+
+        // Empty python stack stays empty.
+        assert!(Stack::new(&[], &[], &[]).py_stack.is_empty());
+    }
+
+    #[test]
+    fn test_emit_stack_record_leaf_name_is_last_frame() {
+        use crate::record::collector::InMemoryCollector;
+        // Frames arrive root-to-leaf; leaf_name must be the innermost
+        // (executing) frame — the LAST entry, not the first.
+        let mut collector = InMemoryCollector::new();
+        emit_stack_record(
+            &mut collector,
+            7,
+            vec!["root".to_string(), "mid".to_string(), "leaf".to_string()],
+        )
+        .unwrap();
+        let stacks = &collector.data().stacks;
+        assert_eq!(stacks.len(), 1);
+        assert_eq!(stacks[0].leaf_name, "leaf");
+        assert_eq!(stacks[0].depth, 3);
     }
 
     #[test]

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -242,9 +242,10 @@ pub struct InstantArgRecord {
 ///
 /// # Fields
 /// - `id`: Unique stack ID
-/// - `frame_names`: Function names from leaf to root (with embedded module/location info)
+/// - `frame_names`: Function names from root to leaf (with embedded module/location info)
 /// - `depth`: Number of frames in the stack
-/// - `leaf_name`: Leaf function name (redundant but enables fast filtering)
+/// - `leaf_name`: Innermost (executing) frame's name — the last entry of
+///   `frame_names` (redundant but enables fast filtering)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct StackRecord {
     pub id: i64,


### PR DESCRIPTION
## Summary

Recorded stacks are a concatenation of three segments — python, user,
kernel — and through schema v11 the segments disagreed on direction. The
BPF unwinder delivers frames leaf-first and
`filter_and_reverse_{user,kernel}_stack` reverse those segments to
root-to-leaf at capture, but the python segment kept pystacks' leaf-first
buffer order. So `frame_ids` was `[py leaf→root][user root→leaf][kernel
root→leaf]` — not one coherent sequence, and the readers disagreed about
which direction they were getting:

- `leaf_name` took the combined array's **first** entry: the python leaf
  when python frames are present, but the **root** frame for native-only
  stacks — despite the column name.
- `systing analyze flamegraph` (and the MCP `flamegraph` tool) reversed
  the array under a leaf-to-root assumption, emitting **inverted folded
  lines** (`leaf;…;root`) for native stacks, and scrambling blended
  python stacks either way (no single reverse can fix a mixed-direction
  array).
- The perfetto exporter passed the array through — correct for native
  segments (`Callstack.frame_ids` is "Bottom frame first" per the proto),
  but **inverted python segments** in .pb output.

## Fix

Normalize once, at the single construction point both recorders share:
`Stack::new` now reverses the python segment too, so every segment is
stored root-to-leaf and `frame_ids`, folded output, and exports all read
one coherent direction. `leaf_name` comes from the **last** frame (the
innermost, executing one), and `format_folded_stack` emits storage order
— which is already the folded convention — instead of reversing.

Schema version bumps to 12 to mark the data-semantics change (no table
shapes change); `SCHEMA_CHANGES.md` documents the details, including
what happens to pre-v12 databases.

## Compatibility

- **Native-only stacks are byte-identical** in storage either way — the
  user/kernel segments were already root-to-leaf. For those, this PR
  only fixes the readers: folded output from *old* databases comes out
  right-side-up too.
- **Pre-v12 python segments stay leaf-first** in old databases — they
  can't be re-ordered after the fact without classifying frames by
  name. `_traces.systing_version` is the per-trace discriminator, with a
  caveat documented in SCHEMA_CHANGES.md: it is stamped at
  parquet-to-DuckDB conversion time with the converting binary's
  version, so it names the recorder only when recording and conversion
  happen in the same run (the normal pipeline). Embedding the recorder's
  version in the parquet directory itself is planned follow-up.
- Perfetto .pb exports become fully spec-correct (python segments were
  the violation).

## Verification

- `cargo test --lib`: 379 passed / 0 failed. The old
  `test_format_folded_stack_reversal` fixture is itself a demonstration
  of the bug: storage has been root-first for native frames since
  capture-time reversal was introduced, so the reverse-on-output it
  asserted produced `leaf;…;root` on real data. Replaced by
  `test_format_folded_stack_storage_order`, plus new tests pinning the
  construction invariant (`test_stack_new_reverses_py_stack`) and the
  leaf_name semantics (`test_emit_stack_record_leaf_name_is_last_frame`).
- `cargo clippy` clean in both the CI configuration
  (`--no-default-features -- -D warnings`) and `--all-targets`;
  `cargo fmt --check` clean.
- Frame-order convention for the perfetto export checked against the
  vendored proto (`perfetto_protos-0.48.1`,
  `protos/perfetto/trace/profiling/profile_common.proto`: "Frames of
  this callstack. Bottom frame first.").
- Swept the other order-sensitive consumers: the spill
  serializer/deserializer round-trips the normalized order (no
  re-reverse), symbolization and the DuckDB import/merge SQL are
  order-preserving (`ORDER BY u.idx`), and the memory recorder shares
  `Stack::new` so it inherits the invariant.

## Known adjacent issue (deliberately not in this PR)

`systing-util`'s perfetto **.pb import** (`get_or_create_callsite`)
builds its callsite tree assuming leaf-first `Callstack.frame_ids`
input, so spec-compliant .pbs — including systing's own exports — import
with inverted parent chains, and its `depth` numbering is inverted under
either assumption. That path reads .pb files, not parquet/DuckDB, so
nothing here changes its behavior; it needs its own fix and will be
reported separately.
