### PR TITLE
Make --only-recorder network state-only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.11.5"
+version = "1.11.6"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/gopclntab"]
 
 [package]
 name = "systing"
-version = "1.11.5"
+version = "1.11.6"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ Use `--only-recorder` to disable all recorders and enable only the ones you spec
 # Only record syscalls (disable everything else)
 sudo ./target/debug/systing --only-recorder syscalls --duration 60
 
-# Only record network traffic (disable everything else)
+# Only record network connection state (disable everything else,
+# including the packet-level probes — see Network Traffic Recording)
 sudo ./target/debug/systing --only-recorder network --duration 60
 
 # Only record syscalls and cpu-stacks
@@ -136,12 +137,24 @@ The network recorder captures detailed network traffic information including:
 
 **Note:** Network recording is disabled by default to minimize overhead. Enable it explicitly when you need to analyze network performance.
 
+Network tracing is split across two recorders: `network` tracks TCP
+connection state (socket lifecycle and state transitions via
+`inet_sock_set_state`), and `network-packets` adds the per-packet and
+per-syscall probes listed below. `--add-recorder network` enables both,
+which is the usual shape for an investigation. `--only-recorder` enables
+exactly what you name, so `--only-recorder network` records connection
+state alone — useful when the packet-level event volume would be
+prohibitive, e.g. continuous or fleet-wide profiling.
+
 ```bash
-# Enable network recording
+# Enable network recording (connection state + packet-level)
 sudo ./target/debug/systing --add-recorder network --duration 60
 
-# Only record network traffic (disable everything else)
+# Connection state only — no packet-level probes
 sudo ./target/debug/systing --only-recorder network --duration 60
+
+# Full network tracing and nothing else
+sudo ./target/debug/systing --only-recorder network-packets --duration 60
 ```
 
 The network recorder instruments multiple points in the Linux network stack:

--- a/docs/USAGE.adoc
+++ b/docs/USAGE.adoc
@@ -192,7 +192,9 @@ Examples:
 # Only record syscalls, disable everything else
 # systing --only-recorder syscalls --duration 60
 
-# Only record network traffic, disable everything else
+# Only record network connection state, disable everything else
+# (the network-packets companion is not implied here; name it to get
+# packet-level tracing)
 # systing --only-recorder network --duration 60
 
 # Only record syscalls and cpu-stacks

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,7 +245,17 @@ impl From<Command> for Config {
     }
 }
 
-fn enable_recorder(opts: &mut Command, recorder_name: &str, enable: bool) {
+/// How a recorder name was selected on the command line. `--add-recorder`
+/// also enables the companion recorders a name defaults to (network brings
+/// in packet-level tracing); `--only-recorder` enables exactly the named
+/// recorders.
+#[derive(Clone, Copy, PartialEq)]
+enum Selection {
+    WithCompanions,
+    Exact,
+}
+
+fn enable_recorder(opts: &mut Command, recorder_name: &str, enable: bool, selection: Selection) {
     match recorder_name {
         "syscalls" => opts.syscalls = enable,
         "sched" => opts.no_sched = !enable,
@@ -256,10 +266,14 @@ fn enable_recorder(opts: &mut Command, recorder_name: &str, enable: bool) {
         "cpu-stacks" => opts.no_cpu_stack_traces = !enable,
         "network" => {
             opts.network = enable;
-            // Network and packet-level tracing are coupled: enabling network also
-            // enables packets by default, disabling network also disables packets.
-            // Users can override with --only-recorder network to get state-only.
-            opts.network_packets = enable;
+            // --add-recorder network also enables packet-level tracing (the
+            // common investigation shape), while --only-recorder network is
+            // state-only: TCP connection/state tracking without the
+            // per-packet kprobes. Disabling network always disables packets,
+            // which cannot run without it.
+            if selection == Selection::WithCompanions || !enable {
+                opts.network_packets = enable;
+            }
         }
         "network-packets" => {
             opts.network_packets = enable;
@@ -304,17 +318,19 @@ fn process_recorder_options(opts: &mut Command) -> Result<()> {
         opts.tpu_profile = false;
         opts.tpu_metrics = false;
 
-        // Then enable only the specified recorders
+        // Then enable exactly the specified recorders — no companion
+        // defaults, so `--only-recorder network` yields state-only tracing.
         let recorders = opts.only_recorder.clone();
         for recorder_name in &recorders {
-            enable_recorder(opts, recorder_name, true);
+            enable_recorder(opts, recorder_name, true, Selection::Exact);
         }
     }
 
-    // Process --add-recorder to enable additional recorders
+    // Process --add-recorder to enable additional recorders, with their
+    // companion defaults (network brings in network-packets).
     let recorders = opts.add_recorder.clone();
     for recorder_name in &recorders {
-        enable_recorder(opts, recorder_name, true);
+        enable_recorder(opts, recorder_name, true, Selection::WithCompanions);
     }
     Ok(())
 }
@@ -502,4 +518,99 @@ fn main() -> Result<()> {
         process::exit(exit_code);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opts_from(args: &[&str]) -> Command {
+        let mut opts = Command::parse_from(std::iter::once("systing").chain(args.iter().copied()));
+        process_recorder_options(&mut opts).expect("valid recorder names");
+        opts
+    }
+
+    #[test]
+    fn only_recorder_network_is_state_only() {
+        let opts = opts_from(&["--only-recorder", "network"]);
+        assert!(opts.network);
+        assert!(
+            !opts.network_packets,
+            "--only-recorder network must not enable packet-level tracing"
+        );
+        // Everything outside the named recorder stays off.
+        assert!(opts.no_sched);
+        assert!(opts.no_cpu_stack_traces);
+        assert!(!opts.memory);
+    }
+
+    #[test]
+    fn only_recorder_network_packets_enables_base_network() {
+        let opts = opts_from(&["--only-recorder", "network-packets"]);
+        assert!(
+            opts.network,
+            "packet probes require the base network recorder"
+        );
+        assert!(opts.network_packets);
+    }
+
+    #[test]
+    fn only_recorder_network_order_independent() {
+        for args in [
+            [
+                "--only-recorder",
+                "network",
+                "--only-recorder",
+                "network-packets",
+            ],
+            [
+                "--only-recorder",
+                "network-packets",
+                "--only-recorder",
+                "network",
+            ],
+        ] {
+            let opts = opts_from(&args);
+            assert!(opts.network);
+            assert!(opts.network_packets);
+        }
+    }
+
+    #[test]
+    fn add_recorder_network_keeps_packet_companion() {
+        let opts = opts_from(&["--add-recorder", "network"]);
+        assert!(opts.network);
+        assert!(
+            opts.network_packets,
+            "--add-recorder network keeps enabling packet tracing by default"
+        );
+        // Default recorders stay on in add mode.
+        assert!(!opts.no_sched);
+        assert!(!opts.no_cpu_stack_traces);
+    }
+
+    #[test]
+    fn add_recorder_network_packets_enables_base_network() {
+        let opts = opts_from(&["--add-recorder", "network-packets"]);
+        assert!(opts.network);
+        assert!(opts.network_packets);
+    }
+
+    #[test]
+    fn no_recorder_flags_leave_network_off() {
+        let opts = opts_from(&[]);
+        assert!(!opts.network);
+        assert!(!opts.network_packets);
+    }
+
+    #[test]
+    fn only_recorder_memory_alloc_enables_base_memory() {
+        let opts = opts_from(&["--only-recorder", "memory-alloc"]);
+        assert!(
+            opts.memory,
+            "memory-alloc shares the memory ringbuf/consumer"
+        );
+        assert!(opts.memory_alloc);
+        assert!(!opts.network);
+    }
 }


### PR DESCRIPTION
`--only-recorder network` was documented as recording "only network traffic", and the code comment in `enable_recorder` promised state-only capture was available that way — but the coupling made it unreachable: naming `network` on any CLI path also enabled `network-packets`, so every invocation got the full per-packet instrumentation. The library mode works (`Config { network: true, network_packets: false }` — `test_e2e_network_suite` exercises exactly that and relies on only the state probes being loaded); the CLI just couldn't express it.

This splits the selection semantics instead of the recorders:

| invocation | before | after |
|---|---|---|
| `--add-recorder network` | state + packets | state + packets (unchanged) |
| `--only-recorder network` | state + packets | **state only** |
| `--only-recorder network-packets` | state + packets | state + packets (`network` is a required base, still pulled in) |
| disabling `network` | disables both | disables both (unchanged) |

Motivation: per-packet event volume is traffic-bound — measured ~90K events/s on a busy node pushing ~1.5GB/s — fine for a bounded investigation, prohibitive for continuous or fleet-wide profiling. Connection-state tracking alone is ~2 orders of magnitude cheaper on the same node (state transitions only) and is the shape an always-on profile wants.

**Semantics call for you — two reasonable shapes, both small:**
- **A (this PR): companions are `--add-recorder` behavior.** `--add-recorder network` keeps enabling packets (the usual investigation shape); `--only-recorder` means exactly what you name. Consequence: zero behavior change for existing add-mode invocations; state-only becomes reachable.
- **B: never couple.** `network` never implies `network-packets`; packet users always name it explicitly. Consequence: strictest one-name-one-recorder rule, but `--add-recorder network` alone stops collecting packet data — a behavior change for existing usage.

I lean **A** — it keeps the documented investigation ergonomics intact and only changes the path that was broken. Flipping to B is a three-line change to the same structure if you'd rather.

Note for API consumers driving systing programmatically: a request that passed only `network` and relied on implicitly getting packet tracing should name `network-packets` too (order doesn't matter).

Covered by CLI-layer tests through the real parse path: state-only, dependency pull-in, order independence, add-mode companion, defaults-off, and the analogous `memory`/`memory-alloc` base dependency. README and USAGE.adoc updated to describe the two tiers.
