### PR TITLE
Bump blazesym to upstream 862c2cf5d424

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -677,16 +677,17 @@ dependencies = [
 
 [[package]]
 name = "blazesym"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ceccc54b9c3e60e5f36b0498908c8c0f87387229cb0e0e5d65a074e00a8ba4"
+version = "0.2.5"
+source = "git+https://github.com/libbpf/blazesym.git?rev=862c2cf5d424307456322d2c68fe86c591baece2#862c2cf5d424307456322d2c68fe86c591baece2"
 dependencies = [
  "cpp_demangle",
- "gimli 0.32.0",
+ "crc32fast",
+ "flate2",
+ "gimli 0.33.0",
  "libc",
  "memmap2 0.9.5",
- "miniz_oxide 0.9.1",
  "rustc-demangle",
+ "tempfile",
 ]
 
 [[package]]
@@ -1265,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "zlib-rs",
 ]
 
@@ -1420,11 +1421,12 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gimli"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap",
  "stable_deref_trait",
 ]
@@ -1491,6 +1493,12 @@ checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -2121,16 +2129,6 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bitfield = "0.19.0"
 # 0.2.x releases (where Sym::code_info became Option<Box<CodeInfo>>), so
 # `cargo install` without --locked picked an incompatible version. An exact pin
 # keeps fresh resolutions reproducible.
-blazesym = "=0.2.3"
+blazesym = { git = "https://github.com/libbpf/blazesym.git", rev = "862c2cf5d424307456322d2c68fe86c591baece2" }
 clap = { version = "4.5.20", features = ["derive"] }
 ctrlc = "3.4"
 dashmap = "6"

--- a/src/profile_export.rs
+++ b/src/profile_export.rs
@@ -151,7 +151,7 @@ impl ExportWriter {
 /// but swallows any I/O error, silently truncating the output.
 enum ExportSink {
     Plain(BufWriter<File>),
-    Gz(GzEncoder<BufWriter<File>>),
+    Gz(Box<GzEncoder<BufWriter<File>>>),
 }
 
 impl Write for ExportSink {
@@ -301,10 +301,10 @@ fn open_output(path: &Path) -> Result<ExportSink> {
         .and_then(|f| f.to_str())
         .is_some_and(|f| f.to_ascii_lowercase().ends_with(".gz"));
     if is_gz {
-        Ok(ExportSink::Gz(GzEncoder::new(
+        Ok(ExportSink::Gz(Box::new(GzEncoder::new(
             buffered,
             Compression::default(),
-        )))
+        ))))
     } else {
         Ok(ExportSink::Plain(buffered))
     }


### PR DESCRIPTION
Picks up libbpf/blazesym#1610 — sizeless `.dynsym` symbols no longer absorb every address up to the next symbol, so stripped cgo Go binaries stop resolving to confidently wrong names (stray dynamic-symbol anchors claiming whole Go text ranges) and fall through honestly to the gopclntab resolver instead.

Details in the commit message. Verification:
- `cargo test --workspace --no-default-features`: 414 passed / 0 failed
- `cargo clippy --workspace --no-default-features -- -D warnings`: clean (after boxing `ExportSink::Gz`, which upstream's zlib backend switch pushed over the `large_enum_variant` threshold via feature unification)
- `cargo fmt --all -- --check`: clean

Upstream MSRV is now 1.88. Once upstream tags 0.2.6 on crates.io this can move back to a registry version with no code change.
