### PR TITLE
build.rs: use the target multiarch include dir when cross-compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,8 +12,53 @@ const SRC: [&str; 1] = ["src/bpf/systing_system.bpf.c"];
 /// under `/usr/include/<triplet>/` (e.g. `/usr/include/x86_64-linux-gnu/`).
 /// On Fedora/RHEL they're directly in `/usr/include/asm/`.
 ///
-/// Returns a `-I/usr/include/<triplet>` string if needed, or None.
+/// When cross-compiling, the triplet must be the TARGET's, not the build
+/// host's: the BPF objects are compiled with the target's `-D__<arch>__`
+/// define, and host libc headers plus a foreign arch define fall over in
+/// arch-conditional glibc internals. Concretely, compiling for aarch64 on
+/// an x86_64 host, x86's `gnu/stubs.h` hits `#include <gnu/stubs-32.h>`
+/// (absent on a 64-bit-only install) because under `-target bpf` neither
+/// `__x86_64__` nor `__i386__` is defined.
+///
+/// Returns a `-I<dir>` string if needed, or None.
 fn detect_multiarch_include() -> Option<String> {
+    // Cross build: prefer the target's header locations. On Debian/Ubuntu
+    // these are /usr/include/<triplet> (multiarch, from libc6-dev:<arch>)
+    // or /usr/<triplet>/include (cross-toolchain sysroot, shipped alongside
+    // gcc-<triplet>). If neither exists, warn and return None rather than
+    // silently offering the HOST's headers — setups with a real sysroot
+    // pass their own include flags.
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
+    if target_arch != env::consts::ARCH {
+        // get_arch_config() already restricts supported targets to these two.
+        let triplet = match target_arch.as_str() {
+            "x86_64" => "x86_64-linux-gnu",
+            "aarch64" => "aarch64-linux-gnu",
+            _ => return None,
+        };
+        let candidates = [
+            format!("/usr/include/{triplet}"),
+            format!("/usr/{triplet}/include"),
+        ];
+        for dir in &candidates {
+            if Path::new(dir).exists() {
+                return Some(format!("-I{dir}"));
+            }
+        }
+        let deb_arch = if target_arch == "aarch64" {
+            "arm64"
+        } else {
+            "amd64"
+        };
+        println!(
+            "cargo:warning=cross-compiling for {target_arch} but neither {} nor {} exists; \
+             BPF compilation may fail or pick up host libc headers \
+             (on Debian/Ubuntu: apt install libc6-dev:{deb_arch} or the {triplet} cross toolchain)",
+            candidates[0], candidates[1],
+        );
+        return None;
+    }
+
     // Check that both asm/ and bits/ headers are available directly.
     // On some CI environments (GitHub Actions), /usr/include/asm is symlinked
     // to asm-generic but bits/wordsize.h still lives under the multiarch path.


### PR DESCRIPTION
Cross-compiling systing (e.g. `cargo build --target aarch64-unknown-linux-gnu` on an x86_64 host) fails while compiling the pystacks BPF object:

```
/usr/include/x86_64-linux-gnu/gnu/stubs.h:7:11: fatal error: 'gnu/stubs-32.h' file not found
```

`detect_multiarch_include()` derives the multiarch triplet from the build HOST (`dpkg-architecture` / `cc -dumpmachine`), so a cross build passes the host's `-I/usr/include/x86_64-linux-gnu` alongside the TARGET's `-D__aarch64__`. Under `-target bpf`, clang defines neither `__x86_64__` nor `__i386__`, so glibc's x86 `stubs.h` takes its 32-bit branch and demands a header that doesn't exist on 64-bit-only installs. Native builds never see this: there the arch define matches the host headers.

**Fix**: when `CARGO_CFG_TARGET_ARCH` differs from the host arch, resolve the include dir from the target triplet instead — preferring `/usr/include/<triplet>` (Debian multiarch, `libc6-dev:<arch>`), then `/usr/<triplet>/include` (cross-toolchain sysroot) — and emit a cargo warning naming the missing package when neither exists, rather than silently offering host headers. The native path is unchanged.

**Verification**
- x86_64 native: `cargo check`, `cargo clippy --all-targets`, `cargo fmt --check` all clean (native path unchanged).
- x86_64 → aarch64 cross, clean `ubuntu:24.04` with `gcc-aarch64-linux-gnu` + `libc6-dev:arm64`, no extra env: `cargo check --target aarch64-unknown-linux-gnu` **fails at the base commit** with the stubs error above and **passes with this patch** — both BPF objects compile against the aarch64 headers.

Version: patch bump to 1.11.8 (1.11.6 and 1.11.7 are claimed by #149 and #150, currently in flight).

**Note for cross builders**: libbpf-cargo's skeleton generation also requires the `rustfmt` component (rustup's `minimal` profile omits it) — independent of this change, but you'll hit it on the same path.
