### PR TITLE
Add a network-syscalls recorder tier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3438,7 +3438,7 @@ dependencies = [
 
 [[package]]
 name = "systing"
-version = "1.11.10"
+version = "1.11.13"
 dependencies = [
  "anyhow",
  "arrow 54.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/gopclntab"]
 
 [package]
 name = "systing"
-version = "1.11.10"
+version = "1.11.13"
 edition = "2021"
 # Floor set by safe (no-unsafe) std::arch::x86_64::__cpuid in detect_hypervisor.
 rust-version = "1.89"

--- a/README.md
+++ b/README.md
@@ -137,14 +137,20 @@ The network recorder captures detailed network traffic information including:
 
 **Note:** Network recording is disabled by default to minimize overhead. Enable it explicitly when you need to analyze network performance.
 
-Network tracing is split across two recorders: `network` tracks TCP
-connection state (socket lifecycle and state transitions via
-`inet_sock_set_state`), and `network-packets` adds the per-packet and
-per-syscall probes listed below. `--add-recorder network` enables both,
-which is the usual shape for an investigation. `--only-recorder` enables
-exactly what you name, so `--only-recorder network` records connection
-state alone — useful when the packet-level event volume would be
-prohibitive, e.g. continuous or fleet-wide profiling.
+Network tracing is split across three recorders, ordered by event volume:
+`network` tracks TCP connection state (socket lifecycle and state
+transitions via `inet_sock_set_state`); `network-syscalls` adds per-syscall
+send/receive accounting plus the low-frequency diagnostics (retransmit
+timer, zero-window probes, sndbuf stalls, packet drops) — bytes, stalls and
+drops per connection at syscall-rate cost; and `network-packets` adds the
+per-packet and per-poll probes (transmit/receive path, qdisc, epoll), whose
+event volume is bounded by traffic rather than by anything you control.
+`--add-recorder network` enables state + packets, the usual shape for an
+investigation. `--only-recorder` enables exactly what you name (each tier
+pulls in the base `network` recorder it requires), so `--only-recorder
+network` is state-only and `--only-recorder network-syscalls` is the shape
+for continuous or fleet-wide profiling, where per-packet volume is
+prohibitive but per-connection throughput still matters.
 
 ```bash
 # Enable network recording (connection state + packet-level)
@@ -152,6 +158,9 @@ sudo ./target/debug/systing --add-recorder network --duration 60
 
 # Connection state only — no packet-level probes
 sudo ./target/debug/systing --only-recorder network --duration 60
+
+# Connection state + syscall accounting + retransmit/drop/stall diagnostics
+sudo ./target/debug/systing --only-recorder network-syscalls --duration 60
 
 # Full network tracing and nothing else
 sudo ./target/debug/systing --only-recorder network-packets --duration 60

--- a/docs/USAGE.adoc
+++ b/docs/USAGE.adoc
@@ -54,7 +54,9 @@ Available recorders:
 * `syscalls` - Syscall tracing (disabled by default)
 * `sleep-stacks` - Sleep stack traces (enabled by default)
 * `cpu-stacks` - CPU perf stack traces (enabled by default)
-* `network` - Network traffic recording (disabled by default) - Captures TCP/UDP send/receive operations, packet-level latency tracking, and queue management through multiple kernel instrumentation points
+* `network` - Network connection state tracking (disabled by default) - Socket lifecycle and TCP state transitions
+* `network-syscalls` - Network syscall-level tracing (disabled by default) - Per-syscall send/receive accounting plus retransmit/drop/stall diagnostics, without the per-packet probes
+* `network-packets` - Network packet-level tracing (disabled by default) - Per-packet and per-poll probes: transmit/receive path, qdisc latency, epoll
 * `pystacks` - Python stack tracing (disabled by default)
 
 Examples:
@@ -196,6 +198,10 @@ Examples:
 # (the network-packets companion is not implied here; name it to get
 # packet-level tracing)
 # systing --only-recorder network --duration 60
+
+# Network syscall accounting + retransmit/drop/stall diagnostics without
+# the per-packet probes (pulls in the base network recorder)
+# systing --only-recorder network-syscalls --duration 60
 
 # Only record syscalls and cpu-stacks
 # systing --only-recorder syscalls --only-recorder cpu-stacks --duration 60

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,9 @@ struct Command {
     // Network packet-level probes (set by recorder management, not a CLI flag)
     #[arg(skip)]
     network_packets: bool,
+    // Network syscall-level probes (set by recorder management, not a CLI flag)
+    #[arg(skip)]
+    network_syscalls: bool,
     // Marker recording enabled state (set by recorder management, not a CLI flag)
     #[arg(skip)]
     markers: bool,
@@ -226,6 +229,7 @@ impl From<Command> for Config {
             memory_alloc_symbol_prefix: cmd.memory_alloc_symbol_prefix,
             network: cmd.network,
             network_packets: cmd.network_packets,
+            network_syscalls: cmd.network_syscalls,
             resolve_addresses: cmd.resolve_addresses,
             tpu_profile: cmd.tpu_profile,
             tpu_service_addr: cmd.tpu_service_addr,
@@ -274,11 +278,25 @@ fn enable_recorder(opts: &mut Command, recorder_name: &str, enable: bool, select
             if selection == Selection::WithCompanions || !enable {
                 opts.network_packets = enable;
             }
+            // The syscalls tier also cannot run without the base recorder,
+            // but it is never a companion default — only the disable cascades.
+            if !enable {
+                opts.network_syscalls = false;
+            }
         }
         "network-packets" => {
             opts.network_packets = enable;
             // Packet probes require the network infrastructure (ringbufs, consumers),
             // so enabling network-packets also enables the base network recorder.
+            if enable {
+                opts.network = true;
+            }
+        }
+        "network-syscalls" => {
+            opts.network_syscalls = enable;
+            // Syscall probes require the network infrastructure (ringbufs,
+            // consumers), so enabling network-syscalls also enables the base
+            // network recorder.
             if enable {
                 opts.network = true;
             }
@@ -314,6 +332,7 @@ fn process_recorder_options(opts: &mut Command) -> Result<()> {
         opts.memory_alloc = false;
         opts.network = false;
         opts.network_packets = false;
+        opts.network_syscalls = false;
         opts.markers = false;
         opts.tpu_profile = false;
         opts.tpu_metrics = false;
@@ -612,5 +631,50 @@ mod tests {
         );
         assert!(opts.memory_alloc);
         assert!(!opts.network);
+    }
+
+    #[test]
+    fn only_recorder_network_syscalls_omits_packets() {
+        let opts = opts_from(&["--only-recorder", "network-syscalls"]);
+        assert!(
+            opts.network,
+            "syscall probes require the base network recorder"
+        );
+        assert!(opts.network_syscalls);
+        assert!(
+            !opts.network_packets,
+            "network-syscalls must not enable per-packet tracing"
+        );
+    }
+
+    #[test]
+    fn add_recorder_network_syscalls_omits_packets() {
+        let opts = opts_from(&["--add-recorder", "network-syscalls"]);
+        assert!(opts.network);
+        assert!(opts.network_syscalls);
+        assert!(!opts.network_packets);
+    }
+
+    #[test]
+    fn add_recorder_network_does_not_imply_syscalls_tier() {
+        let opts = opts_from(&["--add-recorder", "network"]);
+        assert!(opts.network_packets, "packets stay the add-mode companion");
+        assert!(
+            !opts.network_syscalls,
+            "the syscalls tier is never implied; name it"
+        );
+    }
+
+    #[test]
+    fn only_recorder_syscalls_and_packets_tiers_union() {
+        let opts = opts_from(&[
+            "--only-recorder",
+            "network-syscalls",
+            "--only-recorder",
+            "network-packets",
+        ]);
+        assert!(opts.network);
+        assert!(opts.network_syscalls);
+        assert!(opts.network_packets);
     }
 }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -266,6 +266,28 @@ const NETWORK_PACKETS_BPF_PROGRAMS: &[&str] = &[
     "tracepoint__qdisc__qdisc_dequeue",
 ];
 
+/// The syscall-level subset of network tracing: per-syscall send/recv
+/// accounting plus the low-frequency diagnostics (retransmit timer,
+/// zero-window probes, sndbuf stalls, drops) — without the per-packet and
+/// per-poll probes, whose event volume is traffic-bound. `skb_recv_udp_exit`
+/// emits no events itself: it fills the pending UDP recv entry with the peer
+/// address, without which `handle_recvmsg_exit` drops every UDP recv record.
+const NETWORK_SYSCALLS_BPF_PROGRAMS: &[&str] = &[
+    "tcp_sendmsg_entry",
+    "tcp_sendmsg_exit",
+    "udp_sendmsg_entry",
+    "udp_sendmsg_exit",
+    "tcp_recvmsg_entry",
+    "tcp_recvmsg_exit",
+    "udp_recvmsg_entry",
+    "udp_recvmsg_exit",
+    "skb_recv_udp_exit",
+    "tcp_send_probe0_entry",
+    "tcp_retransmit_timer_entry",
+    "sk_stream_wait_memory_entry",
+    "tracepoint__skb__kfree_skb",
+];
+
 // Marker recording reuses the syscall tracepoints.
 const MARKER_BPF_PROGRAMS: &[&str] = SYSCALL_BPF_PROGRAMS;
 
@@ -322,6 +344,15 @@ pub fn get_available_recorders() -> Vec<RecorderInfo> {
             default_enabled: false,
             bpf_programs: NETWORK_BPF_PROGRAMS,
             ringbuf_families: &["packet_ringbufs"],
+        },
+        RecorderInfo {
+            name: "network-syscalls",
+            description: "Network syscall-level tracing (send/recv bytes, retransmits, drops, stalls) without per-packet probes",
+            default_enabled: false,
+            bpf_programs: NETWORK_SYSCALLS_BPF_PROGRAMS,
+            // Syscall records land in network_ringbufs; the diagnostics
+            // (retransmits, probe0, stalls, drops) are packet_events.
+            ringbuf_families: &["network_ringbufs", "packet_ringbufs"],
         },
         RecorderInfo {
             name: "network-packets",
@@ -401,6 +432,7 @@ fn is_recorder_enabled(name: &str, opts: &Config) -> bool {
         "memory" => opts.memory,
         "memory-alloc" => opts.memory_alloc,
         "network" => opts.network,
+        "network-syscalls" => opts.network_syscalls,
         "network-packets" => opts.network_packets,
         "markers" => opts.markers,
         "tpu" => opts.tpu_profile,
@@ -590,6 +622,10 @@ pub struct Config {
     /// Enable network packet-level probes (sendmsg, recvmsg, transmit, qdisc, drops).
     /// Automatically enabled when "network" is enabled via `--add-recorder`.
     pub network_packets: bool,
+    /// Enable network syscall-level probes: per-syscall send/recv accounting
+    /// plus retransmit/drop/stall diagnostics, without the per-packet probes.
+    /// Never enabled implicitly; name it.
+    pub network_syscalls: bool,
     /// Resolve network IP addresses to hostnames via DNS
     pub resolve_addresses: bool,
     /// Enable TPU profiling
@@ -656,6 +692,7 @@ impl Default for Config {
             memory_alloc_symbol_prefix: None,
             network: false,
             network_packets: false,
+            network_syscalls: false,
             resolve_addresses: false,
             tpu_profile: false,
             tpu_service_addr: None,


### PR DESCRIPTION
Between `network` (connection state only — no byte accounting) and `network-packets` (per-packet probes whose event volume is bounded by traffic) there was no middle: to get bytes, stalls or drops per connection you had to take the full per-packet firehose. This adds `network-syscalls`: per-syscall send/receive accounting plus the low-frequency diagnostics (retransmit timer, zero-window probes, sndbuf stalls, packet drops), without the per-packet and per-poll probes.

Measured on a busy node (~1.5GB/s, the same capture behind #149's motivation): full packet tier ≈ 88K events/s, the syscall+diagnostics subset ≈ 29K events/s, state alone ≈ 0.3K events/s — this tier delivers per-connection throughput and health at roughly a third of the packet tier's event rate, and the excluded probes (transmit/receive path, qdisc, epoll) are exactly the ones that fire per packet or per poll.

The implementation is declarative: a new `RecorderInfo` listing the 13-program subset (the existing autoload gating does the rest — no BPF changes), a `network_syscalls` config bool, and the CLI arm. One non-obvious inclusion, documented on the program list: `skb_recv_udp_exit` emits no events but fills the pending UDP recv entry with the peer address — without it `handle_recvmsg_exit` drops every UDP recv record, so leaving it out would silently blank UDP receive accounting in this tier.

Selection semantics follow #149: `network-syscalls` pulls in the base `network` recorder it requires (a dependency, under both `--add-recorder` and `--only-recorder`) and is never enabled implicitly — `--add-recorder network` still means state + packets, unchanged. Ringbuf families: syscall records land in `network_ringbufs`, the diagnostics are `packet_event`s, and `epoll_ringbufs` stays off in this tier.

Covered by CLI-layer tests through the real parse path (tier isolation, base pull-in, never-implied, tier union). README and USAGE.adoc updated; the enumerated recorder list in USAGE.adoc had drifted from the registry (several recorders missing) — I completed the network trio there and left the full refresh alone in case you'd rather batch it separately.

Version: 1.11.13 — renumbered above 1.11.10, which landed first via #153; .11 and .12 are claimed by #150 and #151 (open); whichever lands later reconciles, same as the recent ladder.
