### PR TITLE
Bump version and tag on merge instead of in PRs

### DIFF
--- a/.claude/agents/rust-bpf-code-reviewer.md
+++ b/.claude/agents/rust-bpf-code-reviewer.md
@@ -74,8 +74,8 @@ When changes touch the database schema (`src/duckdb.rs` `create_schema()`, `src/
 
 1. **SCHEMA_CHANGES.md updated**: Every schema change must have a corresponding entry in `SCHEMA_CHANGES.md` describing what changed
 2. **SCHEMA_VERSION incremented**: The `SCHEMA_VERSION` constant in `src/duckdb.rs` must be incremented for any schema change
-3. **Minor version bump**: Schema changes require a **minor** version bump in `Cargo.toml` (e.g., 1.0.0 → 1.1.0)
-4. **Patch version bump**: Non-schema changes require a **patch** version bump in `Cargo.toml` (e.g., 1.0.0 → 1.0.1)
+3. **No version edits in PRs**: `version` in `Cargo.toml` (and the matching `Cargo.lock` entry) must NOT be modified by a PR — the version-bump workflow bumps and tags on every merge to main. Flag any PR that touches it as a **Critical Issue**.
+4. **Minor-bump signal for schema changes**: a schema change must carry `[bump minor]` in the PR title so the merge workflow performs a minor (not patch) bump. A schema change without the token is a **Critical Issue**.
 
 Flag any schema change that is missing these updates as a **Critical Issue**.
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,49 @@
+name: version-bump
+
+on:
+  push:
+    branches: [main]
+
+# Serialize bump jobs so merge bursts can't race each other's push.
+concurrency:
+  group: version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    # Loop guard: our own bump commits start with "release:" and are
+    # skipped, so the workflow cannot trigger itself.
+    if: ${{ !startsWith(github.event.head_commit.message, 'release:') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+      - name: bump version and tag
+        run: |
+          set -euo pipefail
+          # A queued run may start after a newer bump already landed;
+          # rebase onto the live tip before computing the next version.
+          git pull --rebase origin main
+          cur=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
+          IFS=. read -r maj min pat <<<"$cur"
+          # Schema changes request a minor bump with "[bump minor]" in
+          # the PR title; the squash/merge commit message carries it.
+          # Read the TRIGGERING commit (pinned sha), not HEAD — after the
+          # rebase above, HEAD may be a newer run's release commit.
+          if git log -1 --format=%B '${{ github.event.head_commit.id }}' | grep -q '\[bump minor\]'; then
+            new="$maj.$((min+1)).0"
+          else
+            new="$maj.$min.$((pat+1))"
+          fi
+          sed -i "0,/^version = \"$cur\"$/s//version = \"$new\"/" Cargo.toml
+          cargo update --workspace --offline 2>/dev/null || cargo update --workspace
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "release: v$new"
+          # Annotated tag: --follow-tags only pushes annotated tags.
+          git tag -a "v$new" -m "v$new"
+          git push origin main --follow-tags


### PR DESCRIPTION
**Move version bumps out of PRs and into a bump-on-merge workflow.**

Every PR currently edits `version` in Cargo.toml, so any two open PRs conflict on that line and a merge burst needs serial rebases. This PR removes that coupling: PRs stop touching the version entirely, and a small workflow bumps + tags on every merge to main.

Mechanics:
- **Patch bump per merge** (`1.11.x -> 1.11.x+1`), annotated tag `vX.Y.Z`. Version keeps mapping 1:1 to merged content.
- **Minor bumps** (schema changes): the PR carries `[bump minor]` in its title; the squash/merge commit message delivers it to the workflow. SCHEMA_VERSION / SCHEMA_CHANGES.md requirements are unchanged.
- **No self-trigger**: bump commits are prefixed `release:` and the workflow skips them.
- **No burst races**: a concurrency group serializes bump jobs, each run rebases onto the live tip before computing, and the `[bump minor]` check reads the *triggering* commit by pinned sha (not HEAD, which may already be a newer release commit).

Tradeoff considered: batch-debounced bumps (one bump per burst) would produce fewer tags but break the version-to-content mapping that build identification relies on; per-merge keeps that property and tag noise is cheap at this merge cadence.

The in-repo reviewer checklist is updated in the same PR: the "must bump version" criteria become "must NOT touch version" (workflow owns it), with the `[bump minor]` title token replacing the manual minor-bump rule for schema changes.

Suggested merge order for the open ladder: #150 / #151 / #152 first (their version edits are valid under current rules and already sequence cleanly), then this PR — after which no open PR needs a de-version rebase.
