### PR TITLE
version-bump: skip versions whose tag already exists

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -39,6 +39,14 @@ jobs:
           else
             new="$maj.$min.$((pat+1))"
           fi
+          # Skip any version whose tag already exists — failed runs can
+          # leave stray tags (git pushes refs non-atomically, so a tag can
+          # land while the branch push is rejected). This makes retries
+          # and collisions self-healing without tag surgery.
+          while git rev-parse -q --verify "refs/tags/v$new" >/dev/null; do
+            IFS=. read -r maj min pat <<<"$new"
+            new="$maj.$min.$((pat+1))"
+          done
           sed -i "0,/^version = \"$cur\"$/s//version = \"$new\"/" Cargo.toml
           cargo update --workspace --offline 2>/dev/null || cargo update --workspace
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Fixes the version-bump workflow's tag-collision failure (runs 3 and 4 died at `fatal: tag 'v1.11.14' already exists`).

Root cause chain: the first two runs were rejected by the main ruleset at push time ("Changes must be made through a pull request"), but git pushes refs non-atomically in one connection, so the *tag* refs landed while the branch pushes were declined. Those stray tags (`v1.11.11`, `v1.11.14`, pointing at runner-local orphan commits) then collide with every later run's recomputation of the same version — the ladder can never advance.

Fix: after computing the next version, walk the patch number past any existing `v*` tag before committing to it. Retries and partial-push leftovers become self-healing; the stray tags turn into harmless orphans (deleting them is optional cosmetics, not a requirement).

Remaining leg to a working system (repo settings, not code): the main ruleset needs github-actions added to its bypass list so the workflow's `release:` commit can push. First successful fire after both legs will mint `v1.11.15` on the current tree.
