### PR TITLE
version-bump: push with a deploy key to satisfy the main ruleset

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          # Push via a write deploy key: the main ruleset blocks direct
+          # pushes from the workflow token, and deploy keys carry the
+          # ruleset's bypass entry for this repo.
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
       - name: bump version and tag
         run: |
           set -euo pipefail


### PR DESCRIPTION
The workflow token cannot push to main ("Changes must be made through a pull request"), and github-actions is not offerable in this repo's ruleset bypass picker. Deploy keys ARE offerable: check out with the `RELEASE_DEPLOY_KEY` secret so the release commit and tag push over SSH under the deploy key identity, which carries the ruleset bypass.

Setup (repo-side, done once): a write deploy key added to the repo, its private half stored as the `RELEASE_DEPLOY_KEY` Actions secret, and "deploy keys" added to the main ruleset's bypass list.

This PR's own merge is the end-to-end test: the run should walk the version past the stray tags (v1.11.14/v1.11.15, orphaned by earlier ruleset-rejected runs) and land both the `release: v1.11.16` commit and its tag on main.
