### PR TITLE
frame labels: decompose JIT output by runtime and name residual classes

### DIFF
--- a/src/gvisor_guest.rs
+++ b/src/gvisor_guest.rs
@@ -97,6 +97,12 @@ pub struct GuestProcess {
     status: GuestStatus,
     #[serde(default)]
     maps: Vec<GuestMapping>,
+    /// JIT runtime detected among the guest's file mappings. The guest
+    /// view carries real paths, making it the authoritative signal for
+    /// classifying the guest's anonymous executable pages. Computed after
+    /// deserialization in [`parse_dump_response`].
+    #[serde(skip)]
+    jit_runtime: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -119,7 +125,11 @@ pub enum GuestAddr {
     },
     /// Runtime-injected region (`[usertrap]`): sandbox overhead.
     Runtime,
-    /// Guest-anonymous memory (JIT output, heap made executable, ...).
+    /// Guest-anonymous executable memory in a process running the tagged
+    /// JIT runtime: compiled output.
+    Jit(&'static str),
+    /// Guest-anonymous memory (heap, copied-up pages, executable pages of
+    /// an unrecognized runtime).
     Anon,
     /// Not mapped in the guest at all.
     Unmapped,
@@ -153,6 +163,12 @@ impl GuestProcess {
                 }
             }
             "[usertrap]" => GuestAddr::Runtime,
+            // Executable anonymous guest memory; bracketed pseudo-regions
+            // ([vdso], [vvar], ...) are runtime-provided, never JIT output.
+            path if m.perms.execute && !path.starts_with('[') => match self.jit_runtime {
+                Some(rt) => GuestAddr::Jit(rt),
+                None => GuestAddr::Anon,
+            },
             _ => GuestAddr::Anon,
         }
     }
@@ -337,7 +353,16 @@ fn parse_dump_response(buf: &[u8]) -> std::io::Result<Vec<GuestProcess>> {
     if !resp.success {
         return Err(std::io::Error::other(format!("urpc error: {}", resp.err)));
     }
-    Ok(resp.result)
+    let mut procs = resp.result;
+    for p in &mut procs {
+        p.jit_runtime = p
+            .maps
+            .iter()
+            .filter(|m| m.is_file())
+            .filter_map(|m| Path::new(&m.pathname).file_name().and_then(|f| f.to_str()))
+            .find_map(crate::sandbox_maps::detect_jit_runtime);
+    }
+    Ok(procs)
 }
 
 #[cfg(test)]
@@ -414,6 +439,71 @@ mod tests {
         assert_eq!(p.lookup(405504 + 0x100), GuestAddr::Runtime);
         assert_eq!(p.lookup(7426048 + 0x10), GuestAddr::Anon);
         assert_eq!(p.lookup(0xdead_0000_0000), GuestAddr::Unmapped);
+    }
+
+    /// Synthetic dump: one guest running a JIT runtime (node, detected via
+    /// its shared library), one plain guest with an anonymous executable
+    /// page but no recognized runtime.
+    const JIT_DUMP: &str = r#"{"success":true,"err":"","result":[{
+        "exe":"/usr/bin/node",
+        "clone_ts":1,
+        "status":{"comm":"node","pid":10},
+        "maps":[
+            {"address":{"Start":4194304,"End":8388608},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "offset":0,"pathname":"/usr/bin/node"},
+            {"address":{"Start":139264000000,"End":139264100000},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "offset":0,"pathname":"/usr/lib/libnode.so.115"},
+            {"address":{"Start":34359738368,"End":34359771136},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "offset":0,"pathname":""},
+            {"address":{"Start":68719476736,"End":68719509504},
+             "permissions":{"Read":true,"Write":true,"Execute":false},
+             "offset":0,"pathname":""},
+            {"address":{"Start":103079215104,"End":103079219200},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "offset":0,"pathname":"[vdso]"}
+        ]},{
+        "exe":"/usr/bin/plain",
+        "clone_ts":2,
+        "status":{"comm":"plain","pid":11},
+        "maps":[
+            {"address":{"Start":4194304,"End":8388608},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "offset":0,"pathname":"/usr/bin/plain"},
+            {"address":{"Start":34359738368,"End":34359771136},
+             "permissions":{"Read":true,"Write":false,"Execute":true},
+             "offset":0,"pathname":""}
+        ]}]}"#;
+
+    #[test]
+    fn test_guest_jit_classification() {
+        let procs = parse_dump_response(JIT_DUMP.as_bytes()).unwrap();
+        let node = &procs[0];
+        let plain = &procs[1];
+
+        // Anonymous executable pages of a JIT-runtime guest are its
+        // compiled output; non-executable anonymous stays guest memory.
+        assert_eq!(node.lookup(34359738368 + 0x100), GuestAddr::Jit("node"));
+        assert_eq!(node.lookup(68719476736 + 0x100), GuestAddr::Anon);
+        // File-backed text is unaffected by the runtime flag.
+        assert!(matches!(
+            node.lookup(4194304 + 0x100),
+            GuestAddr::File { .. }
+        ));
+
+        // Bracketed pseudo-regions are executable but never JIT output,
+        // even in a JIT-runtime guest.
+        assert_eq!(node.lookup(103079215104 + 0x100), GuestAddr::Anon);
+
+        // Without a recognized runtime an executable anonymous page stays
+        // unidentifiable guest memory.
+        assert_eq!(plain.lookup(34359738368 + 0x100), GuestAddr::Anon);
+
+        // The verbatim fixture's guest maps no runtime: nothing regresses.
+        let fixture = parse_dump_response(DUMP_FIXTURE.as_bytes()).unwrap();
+        assert_eq!(fixture[0].jit_runtime, None);
     }
 
     #[test]

--- a/src/sandbox_maps.rs
+++ b/src/sandbox_maps.rs
@@ -24,8 +24,9 @@
 //! not, "what is the most specific label we can attach instead of raw hex?".
 //! The labels reuse systing's existing miss format (`unknown (<module>)
 //! <0xADDR>`), so downstream consumers see a module-shaped string:
-//! `[gvisor:runtime]`, `[jit:<runtime>]`, or the real module basename when
-//! only the symbol lookup failed.
+//! `[gvisor:runtime]`, `[jit:<runtime>]`, `[anon:exec]`, `[anon]`,
+//! `[unmapped]`, or the real module basename when only the symbol lookup
+//! failed.
 
 use std::fs;
 use std::path::PathBuf;
@@ -90,15 +91,52 @@ pub struct ProcessMaps {
 const GVISOR_MEMFDS: &[&str] = &["runsc-memory", "systrap-memory"];
 
 /// Module basenames whose presence marks a process as running a JIT runtime;
-/// anonymous executable guest pages in such a process are labeled
-/// `[jit:<tag>]`. Deliberately short and conservative.
+/// anonymous executable pages in such a process are labeled `[jit:<tag>]`,
+/// and so are sampled addresses that are no longer mapped by the time maps
+/// are read (JIT runtimes recycle code pages faster than a recording tick).
+/// Deliberately short and conservative; matching requires a version or
+/// extension boundary after the prefix (see [`runtime_matches`]).
 const JIT_RUNTIMES: &[(&str, &str)] = &[
-    ("node", "node"),
-    ("libnode", "node"),
+    ("beam.smp", "beam"),
+    ("bun", "bun"),
+    ("deno", "deno"),
+    ("libcoreclr", "dotnet"),
+    ("libjulia", "julia"),
     ("libjvm", "jvm"),
+    ("libluajit", "lua"),
+    ("libnode", "node"),
+    ("libpypy", "pypy"),
     ("libpython3", "python"),
+    ("libruby", "ruby"),
     ("libv8", "v8"),
+    ("node", "node"),
+    ("nodejs", "node"),
+    ("pypy", "pypy"),
+    ("python3", "python"),
+    ("ruby", "ruby"),
 ];
+
+/// Whether a module basename belongs to a runtime prefix: exact match, or
+/// the prefix followed by a version/extension boundary — "node" matches
+/// "node" and "node22", "libnode.so.115", but not "node_exporter".
+fn runtime_matches(base: &str, prefix: &str) -> bool {
+    match base.strip_prefix(prefix) {
+        Some("") => true,
+        Some(rest) => {
+            let c = rest.as_bytes()[0];
+            c == b'.' || c == b'-' || c.is_ascii_digit()
+        }
+        None => false,
+    }
+}
+
+/// The JIT runtime tag for a mapped-module basename, if any.
+pub(crate) fn detect_jit_runtime(base: &str) -> Option<&'static str> {
+    JIT_RUNTIMES
+        .iter()
+        .find(|(prefix, _)| runtime_matches(base, prefix))
+        .map(|(_, tag)| *tag)
+}
 
 impl ProcessMaps {
     /// Read and analyze `/proc/<tgid>/maps`. Returns `None` when the process
@@ -138,10 +176,8 @@ impl ProcessMaps {
                 }
                 Backing::File(path) => {
                     if let Some(base) = path.file_name().and_then(|f| f.to_str()) {
-                        for (prefix, tag) in JIT_RUNTIMES {
-                            if base.starts_with(prefix) {
-                                pm.jit_runtime = Some(tag);
-                            }
+                        if let Some(tag) = detect_jit_runtime(base) {
+                            pm.jit_runtime = Some(tag);
                         }
                     }
                     let (lo, hi) = pm.file_span.unwrap_or((u64::MAX, 0));
@@ -231,9 +267,10 @@ impl ProcessMaps {
     }
 
     /// Most specific module-slot label for an address that did not
-    /// symbolize. Returns `None` when nothing better than raw hex is known
-    /// (non-sandbox process with a plain unreadable mapping, unmapped
-    /// address, ...).
+    /// symbolize. Returns `None` only for bracketed pseudo-entries
+    /// (`[vdso]`, `[stack]`, ...) — those are the symbolizer's business;
+    /// everything else gets at least a class name, so raw hex from a live
+    /// process means the maps themselves were unreadable.
     ///
     /// gVisor classification leans on which backing object a mapping uses:
     /// ALL guest-created memory is served from the `runsc-memory` pool, the
@@ -276,11 +313,32 @@ impl ProcessMaps {
                 Some("[gvisor:runtime]".to_string())
             }
             // Non-gVisor JIT runtimes: anonymous executable pages are JIT
-            // output with the same confidence as in the sandboxed case.
+            // output with the same confidence as in the sandboxed case;
+            // without a recognized runtime the page is still nameable as
+            // what it observably is.
             Some((Backing::Memfd(_), true)) | Some((Backing::Anon, true)) => {
-                self.jit_runtime.map(|rt| format!("[jit:{rt}]"))
+                Some(match self.jit_runtime {
+                    Some(rt) => format!("[jit:{rt}]"),
+                    None => "[anon:exec]".to_string(),
+                })
             }
-            _ => None,
+            // Non-executable anonymous memory: heap, arenas, or a W^X
+            // code page caught in its writable phase. A PC here is either
+            // recycled code or unwind garbage — name the class without
+            // claiming a runtime.
+            Some((Backing::Memfd(_), false)) | Some((Backing::Anon, false)) => {
+                Some("[anon]".to_string())
+            }
+            // Bracketed pseudo-entries stay with the symbolizer.
+            Some((Backing::Special(_), _)) => None,
+            // In no current mapping at all. JIT runtimes allocate and free
+            // code pages faster than a recording tick, so in a process
+            // running one this is almost always reclaimed JIT code; the
+            // maps snapshot postdates the sample. Otherwise unknowable.
+            None => Some(match self.jit_runtime {
+                Some(rt) => format!("[jit:{rt}]"),
+                None => "[unmapped]".to_string(),
+            }),
         }
     }
 }
@@ -436,8 +494,8 @@ mod tests {
         );
         // Known module, failed symbol lookup: module basename.
         assert_eq!(pm.label_for(0x400100).as_deref(), Some("guestbox"));
-        // Unmapped address: nothing better than hex.
-        assert_eq!(pm.label_for(0xdead0000), None);
+        // Unmapped address in a non-JIT process: named as such.
+        assert_eq!(pm.label_for(0xdead0000).as_deref(), Some("[unmapped]"));
 
         // Guest-anon exec page inside the image span of a JIT-runtime
         // process labels as JIT output.
@@ -467,14 +525,52 @@ mod tests {
 7f0000000000-7f0000100000 rwxp 00000000 00:00 0 ";
         let pmp = ProcessMaps::parse(2, plain_jit, "java");
         assert_eq!(pmp.label_for(0x7f0000000100).as_deref(), Some("[jit:jvm]"));
-        // ...but a plain anon page in a non-JIT, non-gVisor process stays
-        // unlabeled (hex), preserving historical output.
+        // An unmapped address in the same process: reclaimed JIT code —
+        // pages are recycled between the sample and the maps read.
+        assert_eq!(pmp.label_for(0xdead0000).as_deref(), Some("[jit:jvm]"));
+
+        // Non-JIT, non-gVisor process: anon pages are named by observable
+        // class instead of falling back to hex.
         let pm_none = ProcessMaps::parse(
             3,
-            "400000-500000 r-xp 00000000 08:01 42 /usr/bin/foo\n7f0000000000-7f0000001000 rw-p 00000000 00:00 0 ",
+            "400000-500000 r-xp 00000000 08:01 42 /usr/bin/foo\n\
+             7f0000000000-7f0000001000 rw-p 00000000 00:00 0 \n\
+             7f0000100000-7f0000101000 rwxp 00000000 00:00 0 ",
             "foo",
         );
-        assert_eq!(pm_none.label_for(0x7f0000000100), None);
+        assert_eq!(pm_none.label_for(0x7f0000000100).as_deref(), Some("[anon]"));
+        assert_eq!(
+            pm_none.label_for(0x7f0000100100).as_deref(),
+            Some("[anon:exec]")
+        );
+    }
+
+    #[test]
+    fn test_runtime_matching() {
+        // Exact names and versioned/suffixed forms match.
+        assert_eq!(detect_jit_runtime("node"), Some("node"));
+        assert_eq!(detect_jit_runtime("node22"), Some("node"));
+        assert_eq!(detect_jit_runtime("nodejs"), Some("node"));
+        assert_eq!(detect_jit_runtime("libnode.so.115"), Some("node"));
+        assert_eq!(detect_jit_runtime("libjvm.so"), Some("jvm"));
+        assert_eq!(detect_jit_runtime("libpython3.14.so.1.0"), Some("python"));
+        // Statically linked interpreters carry the runtime in the exe name.
+        assert_eq!(detect_jit_runtime("python3.14"), Some("python"));
+        assert_eq!(detect_jit_runtime("ruby3.2"), Some("ruby"));
+        assert_eq!(detect_jit_runtime("libruby.so.3.2"), Some("ruby"));
+        assert_eq!(detect_jit_runtime("libcoreclr.so"), Some("dotnet"));
+        assert_eq!(detect_jit_runtime("beam.smp"), Some("beam"));
+        assert_eq!(detect_jit_runtime("libluajit-5.1.so.2"), Some("lua"));
+        assert_eq!(detect_jit_runtime("libjulia.so.1"), Some("julia"));
+        assert_eq!(detect_jit_runtime("deno"), Some("deno"));
+        assert_eq!(detect_jit_runtime("bun"), Some("bun"));
+        assert_eq!(detect_jit_runtime("libpypy3.9-c.so"), Some("pypy"));
+        // The boundary requirement rejects lookalike module names.
+        assert_eq!(detect_jit_runtime("node_exporter"), None);
+        assert_eq!(detect_jit_runtime("bundler"), None);
+        assert_eq!(detect_jit_runtime("denoise"), None);
+        assert_eq!(detect_jit_runtime("rubyfmt"), None);
+        assert_eq!(detect_jit_runtime("libfoo.so"), None);
     }
 
     #[test]
@@ -484,7 +580,11 @@ mod tests {
             format_unresolved(0x64100, Some(&pm)),
             "unknown ([gvisor:runtime]) <0x64100>"
         );
-        assert_eq!(format_unresolved(0xdead0000, Some(&pm)), "0xdead0000");
+        assert_eq!(
+            format_unresolved(0xdead0000, Some(&pm)),
+            "unknown ([unmapped]) <0xdead0000>"
+        );
+        // No maps at all (unreadable /proc): hex is all that is left.
         assert_eq!(format_unresolved(0x1234, None), "0x1234");
     }
 

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -1003,6 +1003,9 @@ impl StackRecorder {
                 GuestAddr::Runtime => {
                     return format!("unknown ([gvisor:runtime]) <{addr:#x}>");
                 }
+                GuestAddr::Jit(rt) => {
+                    return format!("unknown ([jit:{rt}]) <{addr:#x}>");
+                }
                 GuestAddr::Anon => {
                     return format!("unknown ([gvisor:guest]) <{addr:#x}>");
                 }


### PR DESCRIPTION
Frame labels today decompose gVisor mechanics well, but the biggest unresolved class on JIT-heavy workloads — the runtime's own compiled output — is only partially attributed, for four reasons this PR fixes together:

1. **The guest-maps chain never JIT-classifies.** For a correlated sandbox process the guest view answers first, and it renders every anonymous guest page `[gvisor:guest]` — so the JIT output of a sandboxed node/JVM/python service is lumped into generic guest memory even though the guest's own maps name `libnode.so`/`libjvm.so` with real paths and carry per-mapping exec permissions. On a gVisor-based cluster we operate, sandbox-family stacks still render >50% raw hex after the label deployment while `[jit:*]` accounts for only a few percent; this gap is the main term.
2. **Reclaimed JIT pages fall through every view to bare hex.** Maps (host) and the sandbox snapshot (guest) are read once per symbolization pass, after the sampling window; JIT runtimes allocate and free code pages faster than that. A sampled page that was recycled before the read is in *no* view, and today renders as raw hex — on V8-heavy processes this is the dominant residual.
3. **The runtime table is narrow and its matching is loose.** Only node/libnode, libjvm, libpython3 and libv8 are recognized; `starts_with` matching also lets `node_exporter` mark a process as a node runtime (dormant today only because Go emits no anonymous executable pages).
4. **What remains has no name.** An anonymous executable page in a process with no recognized runtime, a non-executable anonymous page, and an unmapped address all render identically as hex, though they are observably different things.

**Changes**

- `gvisor_guest`: detect the JIT runtime from the guest's file mappings at snapshot parse (`GuestProcess.jit_runtime`), and classify anonymous *executable* guest pages of such a process as `GuestAddr::Jit(<rt>)` → `[jit:<rt>]`. Non-executable and unrecognized-runtime anonymous pages stay `[gvisor:guest]`.
- `sandbox_maps`: unmapped addresses now label — `[jit:<rt>]` when the process runs a recognized JIT runtime (see the note below), `[unmapped]` otherwise. Anonymous pages in non-sandbox processes name their observable class when no runtime is recognized: `[anon:exec]` (executable) / `[anon]` (not). Bracketed pseudo-entries (`[vdso]`, `[stack]`) are untouched. Net: raw hex from a live process now means "maps unreadable" and nothing else.
- Runtime table: add ruby/libruby, libcoreclr (dotnet), beam.smp, libluajit (lua), libjulia, deno, bun, pypy/libpypy, nodejs, and `python3` for statically linked interpreters whose runtime lives in the exe. Matching now requires a version/extension boundary after the prefix — `node` matches `node`, `node22`, `libnode.so.115`, but no longer `node_exporter`.

**Labeling-semantics note for review — `[jit:<rt>]` now includes an inference.** Previously the tag was only applied to *observed* anonymous executable pages. This PR also applies it to *unmapped* addresses in a process running a recognized JIT runtime, on the argument that page recycling between sample and maps-read is overwhelmingly the mechanism that produces them there (and for a correlated sandbox stub it is the only mechanism — everything actually mapped gets some label). The cost: a garbage frame from an unwind glitch in such a process is now labeled `[jit:<rt>]` rather than hex, so the tag is no longer a page-table-verified fact. If you want the two distinguishable downstream, the alternative is a distinct tag for the inferred case — `[jit:<rt>:reclaimed]` — which is a one-line change; the PR ships the merged form because flamegraph consumers aggregate by runtime and splitting the tag halves both bars, but it's a semantics call worth making consciously.

**Vocabulary after this PR** (all behind the existing `--no-frame-labels` flag, rendered in the established `unknown (<label>) <0xADDR>` miss format): module basename, `[gvisor:runtime]`, `[gvisor:guest]`, `[jit:<rt>]` (rt ∈ node, jvm, python, v8, ruby, dotnet, beam, lua, julia, deno, bun, pypy), `[anon:exec]`, `[anon]`, `[unmapped]`, `[exited]`.

**Verification**: full lib tests including new units for the boundary matcher (positive forms and the `node_exporter`/`bundler`/`denoise` rejections), guest JIT classification (JIT guest / plain guest / vdso exclusion / verbatim-fixture regression), and every new `label_for` arm; `cargo fmt --check` and `clippy --all-targets` clean; `gvisor_record` and `trace_validation` integration targets green in a BPF-capable VM (virtme-ng, the repo's v6.12 vmtest kernel). No version change per the new merge-workflow convention; non-schema, so no `[bump minor]` marker.
