### PR TITLE
gopclntab: find the table in sectionless PIE binaries

### DIFF
--- a/crates/gopclntab/src/elf.rs
+++ b/crates/gopclntab/src/elf.rs
@@ -1,16 +1,26 @@
-//! Locate and extract `.gopclntab` from ELF binaries.
+//! Locate and extract the pclntab from ELF binaries.
 //!
 //! ELF parsing is delegated to the [`object`] crate; reads are targeted —
 //! headers and the sections consulted, then exactly the pclntab byte
 //! range — so probing large binaries (Go binaries run to hundreds of MiB)
-//! never reads whole files.
+//! never reads whole files. The exception is the sectionless fallback
+//! below, which must read the data sections it scans.
 //!
-//! Binaries that are not ELF, or have no `.gopclntab` section, report
-//! "not a candidate" (`Ok(None)`) rather than an error. Section metadata
-//! is validated against the input's actual size, so the only inputs
-//! rejected as malformed are ones whose headers are inconsistent with the
-//! bytes on disk — there is no size threshold a large-but-valid binary
-//! could trip over.
+//! The table is located by section name first — `.gopclntab`, then the
+//! `.data.rel.ro.gopclntab` name some PIE links use. When neither
+//! exists, non-executable data sections are scanned for a validating
+//! pclntab header: distro external-linking PIE builds (observed on
+//! Amazon Linux 2023's containerd packages across go1.20–go1.23) merge
+//! the table anonymously into `.data.rel.ro`, and the header is its only
+//! remaining identification. See [`GoPclntab::scan`].
+//!
+//! Binaries that are not ELF, or in which no table can be located,
+//! report "not a candidate" (`Ok(None)`) rather than an error. Section
+//! metadata is validated against the input's actual size, so the only
+//! inputs rejected as malformed are ones whose headers are inconsistent
+//! with the bytes on disk — there is no size threshold a large-but-valid
+//! binary could trip over (the scan's own budget caps work done, not
+//! input size).
 //!
 //! Policy is deliberately left to the caller: this module reports whether
 //! a symbol table is present ([`ElfPclntab::has_symtab`]) but does not
@@ -69,42 +79,90 @@ impl ElfPclntab {
             return Ok(None);
         };
 
-        let Some(section) = elf.section_by_name(".gopclntab") else {
-            return Ok(None);
-        };
-        // Resolving the section's (offset, size) before reading lets the
-        // metadata be validated against the input's real length: a section
-        // header claiming bytes past end-of-input is inconsistent with the
-        // file itself, which is the only "too large" this module rejects.
-        let range = section
-            .compressed_file_range()
-            .map_err(|_| Error::Malformed(".gopclntab has no file range".to_string()))?;
-        if range.format != object::CompressionFormat::None {
-            return Err(Error::Unsupported(
-                "compressed .gopclntab section".to_string(),
-            ));
-        }
-        let input_len = source.len().unwrap_or(u64::MAX);
-        if range
-            .offset
-            .checked_add(range.uncompressed_size)
-            .is_none_or(|end| end > input_len)
-        {
-            return Err(Error::Malformed(format!(
-                ".gopclntab claims {} bytes at offset {} but the input is {} bytes",
-                range.uncompressed_size, range.offset, input_len
-            )));
-        }
-        let data = section
-            .uncompressed_data()
-            .map_err(|_| Error::Malformed("short read of .gopclntab".to_string()))?
-            .into_owned();
-
         let has_symtab = elf.symbol_table().is_some();
         let text_vaddr = elf.section_by_name(".text").map(|text| text.address());
-        let table = GoPclntab::parse(data, text_vaddr)?;
-        Ok(Some(Self { table, has_symtab }))
+        let input_len = source.len().unwrap_or(u64::MAX);
+
+        // The dedicated section, under both names Go links emit.
+        for name in [".gopclntab", ".data.rel.ro.gopclntab"] {
+            let Some(section) = elf.section_by_name(name) else {
+                continue;
+            };
+            let data = read_named_section(&section, input_len, name)?;
+            let table = GoPclntab::parse(data, text_vaddr)?;
+            return Ok(Some(Self { table, has_symtab }));
+        }
+
+        // No dedicated section: scan non-executable data sections for a
+        // validating header, likeliest homes first. Failures here are
+        // "not a candidate", not errors — this path is discovery, and
+        // sections that cannot be read or hold no table are simply
+        // skipped. The budget bounds total work on adversarial inputs;
+        // real binaries put the table within the first few dozen MiB of
+        // `.data.rel.ro` or `.rodata`.
+        const SCAN_BUDGET: u64 = 1 << 30;
+        let mut budget = SCAN_BUDGET;
+        let mut sections: Vec<_> = elf
+            .sections()
+            .filter(|s| {
+                matches!(
+                    s.kind(),
+                    object::SectionKind::Data | object::SectionKind::ReadOnlyData
+                )
+            })
+            .collect();
+        sections.sort_by_key(|s| match s.name() {
+            Ok(".data.rel.ro") => 0,
+            Ok(".rodata") => 1,
+            _ => 2,
+        });
+        for section in sections {
+            if section.size() == 0 || section.size() > budget {
+                continue;
+            }
+            // A section claiming bytes past end-of-input cannot be read;
+            // uncompressed_data fails and the section is skipped.
+            let Ok(data) = section.uncompressed_data() else {
+                continue;
+            };
+            budget = budget.saturating_sub(data.len() as u64);
+            if let Some(table) = GoPclntab::scan(&data, text_vaddr) {
+                return Ok(Some(Self { table, has_symtab }));
+            }
+        }
+        Ok(None)
     }
+}
+
+/// Read a named pclntab section's bytes, validating its metadata against
+/// the input's real length first: a section header claiming bytes past
+/// end-of-input is inconsistent with the file itself, which is the only
+/// "too large" this module rejects.
+fn read_named_section<'data>(
+    section: &object::Section<'data, '_, impl ReadRef<'data>>,
+    input_len: u64,
+    name: &str,
+) -> Result<Vec<u8>, Error> {
+    let range = section
+        .compressed_file_range()
+        .map_err(|_| Error::Malformed(format!("{name} has no file range")))?;
+    if range.format != object::CompressionFormat::None {
+        return Err(Error::Unsupported(format!("compressed {name} section")));
+    }
+    if range
+        .offset
+        .checked_add(range.uncompressed_size)
+        .is_none_or(|end| end > input_len)
+    {
+        return Err(Error::Malformed(format!(
+            "{name} claims {} bytes at offset {} but the input is {} bytes",
+            range.uncompressed_size, range.offset, input_len
+        )));
+    }
+    Ok(section
+        .uncompressed_data()
+        .map_err(|_| Error::Malformed(format!("short read of {name}")))?
+        .into_owned())
 }
 
 #[cfg(test)]
@@ -197,6 +255,24 @@ mod tests {
         assert!(!elf.has_symtab);
         assert_eq!(elf.table.func_count(), tab.func_count());
 
+        // The sectionless shape (distro external-linking PIE builds, e.g.
+        // Amazon Linux 2023 containerd): no section is named
+        // ".gopclntab", the table sits anonymously inside a data section
+        // and only its header identifies it. Simulated by renaming the
+        // section — the bytes stay exactly where they were — the scan
+        // fallback must find the table and agree with the named path.
+        let renamed = rename_gopclntab(&bytes);
+        let elf = ElfPclntab::from_bytes(&renamed)
+            .unwrap()
+            .expect("scan fallback missed the renamed pclntab");
+        assert!(!elf.has_symtab);
+        assert_eq!(elf.table.func_count(), tab.func_count());
+        let f = elf.table.find_func(tab.func_entry(0).unwrap()).unwrap();
+        assert_eq!(
+            f.name,
+            tab.find_func(tab.func_entry(0).unwrap()).unwrap().name
+        );
+
         // Corrupt the section header so .gopclntab claims to extend past
         // end-of-file: the only "too large" that gets rejected is metadata
         // inconsistent with the input itself.
@@ -205,6 +281,42 @@ mod tests {
             ElfPclntab::from_bytes(&corrupt),
             Err(Error::Malformed(_))
         ));
+    }
+
+    /// Overwrite the `.gopclntab` name in `.shstrtab` with an unknown
+    /// same-length name, so name-based lookups fail while the section's
+    /// bytes and headers otherwise stay intact — the closest simulation
+    /// of a link that never emitted the dedicated name. Pokes the ELF64
+    /// layout directly, like [`corrupt_gopclntab_size`].
+    fn rename_gopclntab(elf: &[u8]) -> Vec<u8> {
+        use object::read::elf::ElfFile64;
+        let parsed: ElfFile64 = ElfFile64::parse(elf).unwrap();
+        let section = parsed.section_by_name(".gopclntab").unwrap();
+        let index = section.index().0;
+
+        let e_shoff = u64::from_le_bytes(elf[0x28..0x30].try_into().unwrap()) as usize;
+        let e_shentsize = u16::from_le_bytes(elf[0x3a..0x3c].try_into().unwrap()) as usize;
+        let e_shstrndx = u16::from_le_bytes(elf[0x3e..0x40].try_into().unwrap()) as usize;
+
+        // The section's name offset within .shstrtab (sh_name, u32 at +0
+        // of its Elf64_Shdr), and .shstrtab's own file offset (sh_offset,
+        // u64 at +0x18 of its header).
+        let sh_name = u32::from_le_bytes(
+            elf[e_shoff + index * e_shentsize..][..4]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let strtab_off = u64::from_le_bytes(
+            elf[e_shoff + e_shstrndx * e_shentsize + 0x18..][..8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+
+        let mut out = elf.to_vec();
+        let name_at = strtab_off + sh_name;
+        assert_eq!(&out[name_at..name_at + 10], b".gopclntab");
+        out[name_at..name_at + 10].copy_from_slice(b".mystery00");
+        out
     }
 
     /// Flip the `sh_size` of `.gopclntab` to a value larger than the file.

--- a/crates/gopclntab/src/lib.rs
+++ b/crates/gopclntab/src/lib.rs
@@ -60,6 +60,24 @@ const GO120_MAGIC: u32 = 0xFFFF_FFF1;
 /// Header prefix: magic u32, two pad bytes, minLC u8, ptrsize u8.
 const HEADER_PREFIX_LEN: usize = 8;
 
+/// Whether `b` starts with a plausible pclntab header: a supported magic,
+/// the two mandatory zero pad bytes, an instruction-size quantum Go
+/// actually emits (1 on x86, 2 on arm, 4 on arm64/riscv), and a sane
+/// pointer size. Eight constrained bytes — cheap enough to test at every
+/// aligned offset of a scan, selective enough that full parse validation
+/// only runs on real candidates.
+fn header_signature(b: &[u8]) -> bool {
+    if b.len() < HEADER_PREFIX_LEN {
+        return false;
+    }
+    let magic = u32::from_le_bytes(b[0..4].try_into().unwrap());
+    matches!(magic, GO116_MAGIC | GO118_MAGIC | GO120_MAGIC)
+        && b[4] == 0
+        && b[5] == 0
+        && matches!(b[6], 1 | 2 | 4)
+        && matches!(b[7], 4 | 8)
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum PclnVersion {
     /// Go 1.16/1.17: functab holds ptrsize-wide absolute entry addresses.
@@ -209,6 +227,35 @@ impl GoPclntab {
             functab,
             functab_field,
         })
+    }
+
+    /// Locate and parse a pclntab embedded at an unknown offset inside a
+    /// larger byte region.
+    ///
+    /// Some links emit no dedicated `.gopclntab` section — distro
+    /// external-linking PIE builds merge the table anonymously into
+    /// `.data.rel.ro` — leaving its header as the only identification.
+    /// The scan matches the 8-byte header signature (a known magic, two
+    /// zero pad bytes, a plausible instruction quantum and pointer size)
+    /// at 8-byte alignment, then validates each candidate by fully
+    /// parsing it: the header's offset words must all land inside the
+    /// region, which rejects signature lookalikes. The first candidate
+    /// that parses wins; `None` means the region holds no parseable
+    /// table.
+    pub fn scan(region: &[u8], text_vaddr: Option<u64>) -> Option<Self> {
+        let mut off = 0;
+        while off + HEADER_PREFIX_LEN <= region.len() {
+            if header_signature(&region[off..]) {
+                match Self::parse(region[off..].to_vec(), text_vaddr) {
+                    // An empty table parses but resolves nothing; keep
+                    // scanning rather than let it shadow a real one.
+                    Ok(table) if table.func_count() > 0 => return Some(table),
+                    _ => {}
+                }
+            }
+            off += 8;
+        }
+        None
     }
 
     /// The number of functions in the table.
@@ -477,6 +524,44 @@ mod tests {
             .end(0x400)
             .parse()
             .unwrap()
+    }
+
+    #[test]
+    fn scan_finds_embedded_table() {
+        let table = TabBuilder::v118(0x40_0000)
+            .func(0x0, "runtime.main")
+            .func(0x100, "main.main")
+            .end(0x400)
+            .build();
+
+        // Embed the table at an aligned offset in a larger region, with a
+        // decoy earlier: a valid 8-byte signature whose header words are
+        // garbage. The decoy must be rejected by full parse validation and
+        // the scan must carry on to the real table.
+        let mut region = vec![0u8; 64 * 1024];
+        region[0..4].copy_from_slice(&GO120_MAGIC.to_le_bytes());
+        region[6] = 1;
+        region[7] = 8;
+        for b in &mut region[8..72] {
+            *b = 0xFF;
+        }
+        let off = 4096;
+        region[off..off + table.len()].copy_from_slice(&table);
+
+        let tab = GoPclntab::scan(&region, Some(0x40_0000)).expect("scan missed embedded table");
+        assert_eq!(tab.func_count(), 2);
+        assert_eq!(tab.find_func(0x40_0100).unwrap().name, "main.main");
+    }
+
+    #[test]
+    fn scan_rejects_empty_and_garbage() {
+        assert!(GoPclntab::scan(&[], None).is_none());
+        assert!(GoPclntab::scan(&[0u8; 4096], None).is_none());
+        // Signature at an UNALIGNED offset is not considered.
+        let mut region = vec![0u8; 4096];
+        let table = TabBuilder::v118(0).end(0).build();
+        region[100..100 + table.len()].copy_from_slice(&table);
+        assert!(GoPclntab::scan(&region, None).is_none());
     }
 
     #[test]


### PR DESCRIPTION
The gopclntab resolver located the table by `section_by_name(".gopclntab")` only. That name doesn't always exist: distro external-linking PIE builds can merge the pclntab anonymously into `.data.rel.ro`, leaving no dedicated section — the binary is correctly identified as stripped Go, the resolver reports not-a-candidate, and every frame renders as `<binary>:unknown`. In production profiling data this presents as a stripped Go binary that stays ~100% unresolved while its neighbors (e.g. an upstream-built kubelet, which keeps the named section) symbolize fully.

**The artifact evidence** (public packages, reproducible): Amazon Linux 2023's containerd RPMs, pulled from the AL2023 CDN — `containerd-1.7.27` (go1.23.8) and `containerd-1.7.11` (go1.20.12). Both are PIE, external-linked, RPM-stripped (no `.symtab`), and have **no `.gopclntab` section at all**; the GO120-magic header sits inside `.data.rel.ro` (at `+0x4f49a0` in the 1.7.27 build) with the table fully intact. The shape spans the distro's whole build history, not one toolchain version. `ElfPclntab::from_path` on these binaries returned `Ok(None)` before this change.

**The fix — three location tiers:**

1. `.gopclntab` by name (unchanged fast path, including the existing malformed-metadata errors).
2. `.data.rel.ro.gopclntab` by name (the dedicated-name variant some PIE links emit).
3. A budgeted scan of non-executable data sections (`.data.rel.ro` and `.rodata` first, then remaining data sections) for a validating table: the 8-byte header signature (known magic, mandatory zero pad, plausible instruction quantum and pointer size) is matched at 8-byte-aligned offsets, and each candidate must survive the full header parse — its offset words must all land in-bounds — which rejects signature lookalikes. Empty tables are skipped rather than allowed to shadow a real one. Total scanned bytes are capped (1 GiB) so adversarial section layouts can't make the probe super-linear; real binaries resolve within the first few dozen MiB of `.data.rel.ro`.

**Negative controls:** binaries with a `.symtab` still defer to the richer symtab+DWARF path (`has_symtab` semantics untouched) — COS-style kubelet builds are unaffected; binaries with the named section never reach the scan, so the existing fleet behavior is byte-identical for them. Scan failures are "not a candidate", never errors: a binary with no findable table degrades exactly as today.

**Verification:** the real AL2023 binaries go from not-a-candidate to **59,228** (1.7.27) and **56,283** (1.7.11) resolved functions, and the existing full-table sweep test (`GOPCLNTAB_TEST_BINARY`) passes against them — every functab entry resolves back to itself. New unit tests cover the embedded-table scan (with a signature-decoy that must be rejected), unaligned/garbage rejection, and a real-toolchain fixture whose `.gopclntab` is renamed in `.shstrtab` — the bytes stay put, the name is gone, the scan must find it (the closest simulation of the sectionless link). 16/16 crate tests, full workspace lib suite, fmt and clippy clean.

No version change per the merge-workflow convention; non-schema. The `gopclntab` crate is published separately — whether this warrants a crates.io re-publish is left to the maintainer.
