### PR TITLE
analyze: let the MCP launcher bound DuckDB's on-disk spill

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -246,6 +246,30 @@ pub struct AnalyzeDb {
 impl AnalyzeDb {
     /// Open a trace database.
     pub fn open(path: &Path, read_only: bool) -> Result<Self> {
+        Self::open_with_spill_cap(path, read_only, None)
+    }
+
+    /// Open a trace database, optionally bounding DuckDB's on-disk spill.
+    ///
+    /// DuckDB derives its default `max_temp_directory_size` from the
+    /// filesystem's free space, which quota-limited environments misreport:
+    /// a Kubernetes emptyDir `sizeLimit` is enforced by a periodic kubelet
+    /// scan, not by the filesystem, so `statvfs` reports the whole node's
+    /// free disk and a single spilling query can blow past the quota and get
+    /// the pod evicted mid-run. A caller that knows its real scratch budget
+    /// passes it here (any DuckDB size string, e.g. "8GiB") so an oversized
+    /// aggregation fails that one query instead of killing the process.
+    ///
+    /// This is a structural default, not a jail: unlike `temp_directory`,
+    /// DuckDB does not lock this setting when external access is disabled,
+    /// so in-session SQL can still raise it (covered by a test). That is the
+    /// right trade for the intended failure mode — queries that never think
+    /// about spill — and it keeps deliberate in-session tuning possible.
+    pub fn open_with_spill_cap(
+        path: &Path,
+        read_only: bool,
+        spill_cap: Option<&str>,
+    ) -> Result<Self> {
         if !path.exists() {
             bail!("Database not found: {}", path.display());
         }
@@ -273,6 +297,14 @@ impl AnalyzeDb {
             Some(spill_dir) => config.with("temp_directory", spill_dir.to_string_lossy())?,
             None => config.with("temp_directory", "")?,
         };
+        if let Some(cap) = spill_cap {
+            // Set on the Config, like temp_directory above, so the bound is
+            // in force from the first query. DuckDB validates the size string
+            // at open, so a malformed cap fails loudly here rather than being
+            // silently ignored.
+            config = config.with("max_temp_directory_size", cap)?;
+            eprintln!("duckdb: max_temp_directory_size={cap}");
+        }
         if let Some(m) = mem_limit_mib {
             config = config.max_memory(&format!("{m}MiB"))?;
             eprintln!("duckdb: memory_limit={m}MiB threads={threads}");
@@ -833,6 +865,79 @@ mod tests {
                 "unexpected error: {set_err}"
             );
         }
+    }
+
+    #[test]
+    fn test_open_with_spill_cap_applies_bound() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.duckdb");
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1);")
+                .unwrap();
+        }
+
+        let read_setting = |db: &AnalyzeDb| -> String {
+            let result = db
+                .query("SELECT current_setting('max_temp_directory_size')")
+                .unwrap();
+            result.rows[0][0].as_str().unwrap().to_string()
+        };
+
+        // Capped open reports the requested bound.
+        let capped = AnalyzeDb::open_with_spill_cap(&db_path, true, Some("100MiB")).unwrap();
+        let capped_value = read_setting(&capped);
+        assert!(
+            capped_value.starts_with("100") && capped_value.contains("MiB"),
+            "expected the 100MiB cap to be in force, got '{capped_value}'"
+        );
+
+        // Uncapped open differs — proves the assertion above is not vacuous.
+        let uncapped = AnalyzeDb::open(&db_path, true).unwrap();
+        assert_ne!(
+            read_setting(&uncapped),
+            capped_value,
+            "uncapped open unexpectedly reports the capped value"
+        );
+    }
+
+    #[test]
+    fn test_open_with_invalid_spill_cap_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.duckdb");
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE t (x INTEGER);").unwrap();
+        }
+
+        // A malformed size string must fail the open loudly, not be ignored.
+        let err = AnalyzeDb::open_with_spill_cap(&db_path, true, Some("not-a-size"));
+        assert!(err.is_err(), "malformed spill cap was silently accepted");
+    }
+
+    /// Documents the cap's trust boundary: `enable_external_access(false)`
+    /// locks `temp_directory` but NOT `max_temp_directory_size`, so SQL run
+    /// in-session can still raise the bound. The flag is a structural
+    /// default protecting against queries that never think about spill (the
+    /// real-world failure mode), not a jail against adversarial SQL — an
+    /// adversary with query access could raise it back. If DuckDB ever
+    /// starts locking this setting alongside temp_directory, this test
+    /// fails and the doc-comments should be updated to promise more.
+    #[test]
+    fn test_spill_cap_is_session_overridable() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.duckdb");
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE t (x INTEGER);").unwrap();
+        }
+        let db = AnalyzeDb::open_with_spill_cap(&db_path, true, Some("100MiB")).unwrap();
+        db.query("SET max_temp_directory_size = '999GiB'")
+            .expect("session SET is currently allowed for this setting");
+        let v = db
+            .query("SELECT current_setting('max_temp_directory_size')")
+            .unwrap();
+        assert_eq!(v.rows[0][0].as_str().unwrap(), "999.0 GiB");
     }
 
     #[test]

--- a/src/bin/systing_analyze.rs
+++ b/src/bin/systing_analyze.rs
@@ -45,6 +45,13 @@ enum Commands {
         /// Path to DuckDB database to open on startup (optional)
         #[arg(short, long)]
         database: Option<PathBuf>,
+        /// Bound DuckDB's on-disk spill usage, e.g. "8GiB" (any DuckDB size
+        /// string). DuckDB sizes the default from the filesystem's free
+        /// space, which quota-limited scratch (e.g. a Kubernetes emptyDir
+        /// sizeLimit) misreports -- pass the real budget so an oversized
+        /// query fails instead of the process being evicted.
+        #[arg(long, value_name = "SIZE")]
+        max_temp_directory_size: Option<String>,
     },
 }
 
@@ -1049,9 +1056,15 @@ fn main() -> Result<()> {
             NetworkCommands::Interfaces(iface_args) => run_network_interfaces(iface_args),
             NetworkCommands::SocketPairs(pairs_args) => run_network_socket_pairs(pairs_args),
         },
-        Commands::Mcp { database } => {
+        Commands::Mcp {
+            database,
+            max_temp_directory_size,
+        } => {
             let rt = tokio::runtime::Runtime::new()?;
-            rt.block_on(systing::mcp::run_mcp_server(database))
+            rt.block_on(systing::mcp::run_mcp_server(
+                database,
+                max_temp_directory_size,
+            ))
         }
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -46,28 +46,35 @@ struct DbHandle {
 
 impl DbHandle {
     /// Spawn the database thread, optionally opening an initial database.
-    fn new(initial_db: Option<PathBuf>) -> Result<Self> {
+    ///
+    /// `spill_cap` bounds DuckDB's on-disk spill for every database this
+    /// server opens, initial and lazily-opened alike — see
+    /// [`AnalyzeDb::open_with_spill_cap`].
+    fn new(initial_db: Option<PathBuf>, spill_cap: Option<String>) -> Result<Self> {
         let (sender, mut receiver) = mpsc::channel::<(DbRequest, oneshot::Sender<DbResponse>)>(32);
 
         std::thread::spawn(move || {
             let mut dbs: HashMap<PathBuf, AnalyzeDb> = HashMap::new();
             let mut last_used: Option<PathBuf> = None;
+            let spill_cap = spill_cap.as_deref();
 
             if let Some(path) = initial_db {
                 match std::fs::canonicalize(&path) {
-                    Ok(canonical) => match AnalyzeDb::open(&canonical, true) {
-                        Ok(db) => {
-                            dbs.insert(canonical.clone(), db);
-                            last_used = Some(canonical);
+                    Ok(canonical) => {
+                        match AnalyzeDb::open_with_spill_cap(&canonical, true, spill_cap) {
+                            Ok(db) => {
+                                dbs.insert(canonical.clone(), db);
+                                last_used = Some(canonical);
+                            }
+                            Err(e) => eprintln!("Warning: failed to open initial database: {e}"),
                         }
-                        Err(e) => eprintln!("Warning: failed to open initial database: {e}"),
-                    },
+                    }
                     Err(e) => eprintln!("Warning: cannot resolve path '{}': {e}", path.display()),
                 }
             }
 
             while let Some((request, reply)) = receiver.blocking_recv() {
-                let result = handle_db_request(&mut dbs, &mut last_used, request);
+                let result = handle_db_request(&mut dbs, &mut last_used, spill_cap, request);
                 let _ = reply.send(result);
             }
         });
@@ -93,6 +100,7 @@ const MAX_CACHED_DBS: usize = 8;
 fn get_or_open<'a>(
     dbs: &'a mut HashMap<PathBuf, AnalyzeDb>,
     last_used: &mut Option<PathBuf>,
+    spill_cap: Option<&str>,
     path: Option<PathBuf>,
 ) -> Result<&'a AnalyzeDb, String> {
     let raw_path = match path {
@@ -119,7 +127,7 @@ fn get_or_open<'a>(
                 dbs.insert(k, db);
             }
         }
-        let db = AnalyzeDb::open(&canonical, true)
+        let db = AnalyzeDb::open_with_spill_cap(&canonical, true, spill_cap)
             .map_err(|e| format!("Failed to open database '{}': {e}", canonical.display()))?;
         dbs.insert(canonical.clone(), db);
     }
@@ -133,11 +141,12 @@ fn get_or_open<'a>(
 fn handle_db_request(
     dbs: &mut HashMap<PathBuf, AnalyzeDb>,
     last_used: &mut Option<PathBuf>,
+    spill_cap: Option<&str>,
     request: DbRequest,
 ) -> DbResponse {
     match request {
         DbRequest::Query(path, sql) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.query(&sql)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -145,7 +154,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Query error: {e}"))
         }
         DbRequest::ListTables(path) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.list_tables()
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -153,7 +162,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Error listing tables: {e}"))
         }
         DbRequest::DescribeTable(path, name) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.describe_table(&name)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -161,7 +170,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Error describing table: {e}"))
         }
         DbRequest::Flamegraph(path, params) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.flamegraph(&params)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -169,7 +178,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Flamegraph error: {e}"))
         }
         DbRequest::SchedStats(path, params) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.sched_stats(&params)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -177,7 +186,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Sched stats error: {e}"))
         }
         DbRequest::CpuStats(path, params) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.cpu_stats(&params)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -185,7 +194,7 @@ fn handle_db_request(
                 .map_err(|e| format!("CPU stats error: {e}"))
         }
         DbRequest::TraceInfo(path) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.trace_info()
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -193,7 +202,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Error getting trace info: {e}"))
         }
         DbRequest::NetworkConnections(path, params) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.network_connections(&params)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -201,7 +210,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Network connections error: {e}"))
         }
         DbRequest::NetworkInterfaces(path, params) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.network_interfaces(&params)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -209,7 +218,7 @@ fn handle_db_request(
                 .map_err(|e| format!("Network interfaces error: {e}"))
         }
         DbRequest::NetworkSocketPairs(path, params) => {
-            let db = get_or_open(dbs, last_used, path)?;
+            let db = get_or_open(dbs, last_used, spill_cap, path)?;
             db.network_socket_pairs(&params)
                 .and_then(|r| {
                     serde_json::to_value(r).map_err(|e| anyhow::anyhow!("Serialization error: {e}"))
@@ -808,8 +817,14 @@ impl ServerHandler for SystingMcpServer {
 }
 
 /// Run the MCP server over stdio transport.
-pub async fn run_mcp_server(database: Option<PathBuf>) -> Result<()> {
-    let db_handle = DbHandle::new(database)?;
+///
+/// `max_temp_directory_size` bounds DuckDB's on-disk spill for every
+/// database the server opens — see [`AnalyzeDb::open_with_spill_cap`].
+pub async fn run_mcp_server(
+    database: Option<PathBuf>,
+    max_temp_directory_size: Option<String>,
+) -> Result<()> {
+    let db_handle = DbHandle::new(database, max_temp_directory_size)?;
     let server = SystingMcpServer::new(db_handle);
 
     let service = server.serve(stdio()).await?;


### PR DESCRIPTION
## Problem

`systing-analyze mcp` opens trace databases with DuckDB's default `max_temp_directory_size`, which DuckDB derives from the filesystem's free space. On quota-limited scratch that number is a lie: a Kubernetes emptyDir `sizeLimit` is enforced by a periodic kubelet scan, not by the filesystem, so `statvfs` reports the whole node's free disk. A single spilling aggregation against a ~5M-row trace was observed writing >10 GiB into a 10 GiB scratch volume in under two minutes — the kubelet then evicts the entire pod mid-run, killing all of the run's bookkeeping, which is a strictly worse failure than the one query erroring out.

## Change

- New `--max-temp-directory-size <SIZE>` on the `mcp` subcommand (any DuckDB size string, e.g. `8GiB`), threaded through to **every** database the server opens — the initial `-d` database and lazily-opened ones alike.
- Applied on the `duckdb::Config` (like `temp_directory`), so the bound is in force from the first query and a malformed size string fails the open loudly instead of being ignored.
- `AnalyzeDb::open` is unchanged for all existing callers; it now delegates to the new `open_with_spill_cap`.

## What the cap does and does not promise

With the cap set, an oversized aggregation fails **that query** with DuckDB's temp-directory-limit error; the caller (an AI assistant driving the MCP server, in the motivating case) can rephrase or narrow it, and the process survives.

It is a structural default, not a jail: `enable_external_access(false)` locks `temp_directory` but — verified empirically, not assumed — does **not** lock `max_temp_directory_size`, so in-session SQL can still raise it deliberately. That is the right trade for the failure mode this addresses (queries that never think about spill at all), and `test_spill_cap_is_session_overridable` pins the boundary so a future DuckDB that starts locking the setting gets noticed and the docs can promise more.

## Tests

- `test_open_with_spill_cap_applies_bound` — capped open reports the bound; uncapped open differs (non-vacuous).
- `test_open_with_invalid_spill_cap_fails` — malformed size fails the open.
- `test_spill_cap_is_session_overridable` — documents the trust boundary above.

`cargo clippy --lib --bins -- -D warnings` clean; full lib suite 406/406.
