### PR TITLE
gopclntab: validate scan candidates before copying, gate on Go metadata

### DIFF
--- a/crates/gopclntab/src/elf.rs
+++ b/crates/gopclntab/src/elf.rs
@@ -93,13 +93,28 @@ impl ElfPclntab {
             return Ok(Some(Self { table, has_symtab }));
         }
 
-        // No dedicated section: scan non-executable data sections for a
-        // validating header, likeliest homes first. Failures here are
-        // "not a candidate", not errors — this path is discovery, and
-        // sections that cannot be read or hold no table are simply
-        // skipped. The budget bounds total work on adversarial inputs;
-        // real binaries put the table within the first few dozen MiB of
-        // `.data.rel.ro` or `.rodata`.
+        // No dedicated section. The scan below reads whole data sections,
+        // which every stripped ELF that reaches this point would pay —
+        // so first require evidence the binary is Go at all. Both marker
+        // sections survive external linking and stripping (they are
+        // present on the sectionless distro builds this fallback exists
+        // for), unlike `.gopclntab` itself. This also narrows foreign-
+        // table adoption: a non-Go binary embedding a complete Go ELF in
+        // its data is no longer scanned at all.
+        if elf.section_by_name(".go.buildinfo").is_none()
+            && elf.section_by_name(".note.go.buildid").is_none()
+        {
+            return Ok(None);
+        }
+
+        // Scan non-executable data sections for a validating header,
+        // likeliest homes first. Failures here are "not a candidate",
+        // not errors — this path is discovery, and sections that cannot
+        // be read or hold no table are simply skipped. The budget bounds
+        // total bytes read on adversarial inputs (candidate rejection
+        // within a region is constant-time per candidate — see
+        // [`GoPclntab::scan`]); real binaries put the table within the
+        // first few dozen MiB of `.data.rel.ro` or `.rodata`.
         const SCAN_BUDGET: u64 = 1 << 30;
         let mut budget = SCAN_BUDGET;
         let mut sections: Vec<_> = elf
@@ -261,7 +276,7 @@ mod tests {
         // and only its header identifies it. Simulated by renaming the
         // section — the bytes stay exactly where they were — the scan
         // fallback must find the table and agree with the named path.
-        let renamed = rename_gopclntab(&bytes);
+        let renamed = rename_section(&bytes, ".gopclntab", ".mystery00");
         let elf = ElfPclntab::from_bytes(&renamed)
             .unwrap()
             .expect("scan fallback missed the renamed pclntab");
@@ -271,6 +286,29 @@ mod tests {
         assert_eq!(
             f.name,
             tab.find_func(tab.func_entry(0).unwrap()).unwrap().name
+        );
+        // ...and it proves the Go-ness gate passes real Go binaries: the
+        // marker sections were still present for that scan.
+
+        // With the marker sections renamed away as well, nothing
+        // identifies the binary as Go and the scan tier is skipped —
+        // not-a-candidate, though the (renamed) table bytes are all
+        // still in the file.
+        let mut gateless = renamed.clone();
+        let mut markers = 0;
+        for (from, to) in [
+            (".note.go.buildid", ".note.no.buildid"),
+            (".go.buildinfo", ".no.buildinfo"),
+        ] {
+            if section_exists(&gateless, from) {
+                gateless = rename_section(&gateless, from, to);
+                markers += 1;
+            }
+        }
+        assert!(markers > 0, "fixture carries no Go marker sections at all");
+        assert!(
+            ElfPclntab::from_bytes(&gateless).unwrap().is_none(),
+            "gate failed: scan ran on a binary with no Go evidence"
         );
 
         // Corrupt the section header so .gopclntab claims to extend past
@@ -283,15 +321,23 @@ mod tests {
         ));
     }
 
-    /// Overwrite the `.gopclntab` name in `.shstrtab` with an unknown
-    /// same-length name, so name-based lookups fail while the section's
-    /// bytes and headers otherwise stay intact — the closest simulation
-    /// of a link that never emitted the dedicated name. Pokes the ELF64
-    /// layout directly, like [`corrupt_gopclntab_size`].
-    fn rename_gopclntab(elf: &[u8]) -> Vec<u8> {
+    /// Whether the ELF has a section with this exact name.
+    fn section_exists(elf: &[u8], name: &str) -> bool {
         use object::read::elf::ElfFile64;
         let parsed: ElfFile64 = ElfFile64::parse(elf).unwrap();
-        let section = parsed.section_by_name(".gopclntab").unwrap();
+        parsed.section_by_name(name).is_some()
+    }
+
+    /// Overwrite a section's name in `.shstrtab` with an unknown
+    /// same-length name, so name-based lookups fail while the section's
+    /// bytes and headers otherwise stay intact — the closest simulation
+    /// of a link that never emitted that name. Pokes the ELF64 layout
+    /// directly, like [`corrupt_gopclntab_size`].
+    fn rename_section(elf: &[u8], from: &str, to: &str) -> Vec<u8> {
+        use object::read::elf::ElfFile64;
+        assert_eq!(from.len(), to.len(), "rename must preserve name length");
+        let parsed: ElfFile64 = ElfFile64::parse(elf).unwrap();
+        let section = parsed.section_by_name(from).unwrap();
         let index = section.index().0;
 
         let e_shoff = u64::from_le_bytes(elf[0x28..0x30].try_into().unwrap()) as usize;
@@ -314,8 +360,8 @@ mod tests {
 
         let mut out = elf.to_vec();
         let name_at = strtab_off + sh_name;
-        assert_eq!(&out[name_at..name_at + 10], b".gopclntab");
-        out[name_at..name_at + 10].copy_from_slice(b".mystery00");
+        assert_eq!(&out[name_at..name_at + from.len()], from.as_bytes());
+        out[name_at..name_at + to.len()].copy_from_slice(to.as_bytes());
         out
     }
 

--- a/crates/gopclntab/src/lib.rs
+++ b/crates/gopclntab/src/lib.rs
@@ -134,6 +134,20 @@ pub struct GoFunc<'tab> {
     pub size: u64,
 }
 
+/// Header fields validated by a borrowed parse: every offset has been
+/// bounds-checked against the input it was parsed from, including the
+/// full functab extent.
+struct Header {
+    version: PclnVersion,
+    ptrsize: usize,
+    nfunctab: usize,
+    text_start: u64,
+    funcnametab: usize,
+    funcdata: usize,
+    functab: usize,
+    functab_field: usize,
+}
+
 impl GoPclntab {
     /// Parse a pclntab from its raw bytes (e.g. the contents of the
     /// `.gopclntab` ELF section).
@@ -143,6 +157,24 @@ impl GoPclntab {
     /// value (which may be unrelocated in edge cases) and so does this
     /// crate. [`ElfPclntab`] supplies it automatically.
     pub fn parse(data: Vec<u8>, text_vaddr: Option<u64>) -> Result<Self, Error> {
+        let h = Self::parse_header(&data, text_vaddr)?;
+        Ok(Self {
+            data,
+            version: h.version,
+            ptrsize: h.ptrsize,
+            nfunctab: h.nfunctab,
+            text_start: h.text_start,
+            funcnametab: h.funcnametab,
+            funcdata: h.funcdata,
+            functab: h.functab,
+            functab_field: h.functab_field,
+        })
+    }
+
+    /// All of [`GoPclntab::parse`]'s validation on a borrowed slice,
+    /// without taking ownership of the bytes — the scan path uses this to
+    /// vet candidates before paying for a copy.
+    fn parse_header(data: &[u8], text_vaddr: Option<u64>) -> Result<Header, Error> {
         if data.len() < HEADER_PREFIX_LEN {
             return Err(Error::Malformed(format!(
                 "too short for header: {} bytes",
@@ -166,7 +198,7 @@ impl GoPclntab {
 
         let word = |idx: usize| -> Result<u64, Error> {
             let off = HEADER_PREFIX_LEN + idx * ptrsize;
-            read_uint(&data, off, ptrsize)
+            read_uint(data, off, ptrsize)
                 .ok_or_else(|| Error::Malformed(format!("header word {idx} out of bounds")))
         };
         let tab_offset = |idx: usize, what: &str| -> Result<usize, Error> {
@@ -216,8 +248,7 @@ impl GoPclntab {
             )));
         }
 
-        Ok(Self {
-            data,
+        Ok(Header {
             version,
             ptrsize,
             nfunctab,
@@ -237,19 +268,26 @@ impl GoPclntab {
     /// `.data.rel.ro` — leaving its header as the only identification.
     /// The scan matches the 8-byte header signature (a known magic, two
     /// zero pad bytes, a plausible instruction quantum and pointer size)
-    /// at 8-byte alignment, then validates each candidate by fully
-    /// parsing it: the header's offset words must all land inside the
-    /// region, which rejects signature lookalikes. The first candidate
-    /// that parses wins; `None` means the region holds no parseable
-    /// table.
+    /// at 8-byte alignment, then validates each candidate on the borrowed
+    /// slice: the header's offset words and the full functab extent must
+    /// all land inside the region, which rejects signature lookalikes.
+    /// Bytes are copied exactly once, for the adopted table — candidate
+    /// validation allocates nothing, so a region tiled with fake
+    /// signatures costs a constant-time rejection each, not a copy each.
+    /// The first non-empty candidate that validates wins; `None` means
+    /// the region holds no parseable table.
     pub fn scan(region: &[u8], text_vaddr: Option<u64>) -> Option<Self> {
         let mut off = 0;
         while off + HEADER_PREFIX_LEN <= region.len() {
             if header_signature(&region[off..]) {
-                match Self::parse(region[off..].to_vec(), text_vaddr) {
+                match Self::parse_header(&region[off..], text_vaddr) {
                     // An empty table parses but resolves nothing; keep
                     // scanning rather than let it shadow a real one.
-                    Ok(table) if table.func_count() > 0 => return Some(table),
+                    Ok(h) if h.nfunctab > 0 => {
+                        // The borrowed validation just passed over these
+                        // exact bytes, so this parse cannot fail.
+                        return Self::parse(region[off..].to_vec(), text_vaddr).ok();
+                    }
                     _ => {}
                 }
             }
@@ -551,6 +589,32 @@ mod tests {
         let tab = GoPclntab::scan(&region, Some(0x40_0000)).expect("scan missed embedded table");
         assert_eq!(tab.func_count(), 2);
         assert_eq!(tab.find_func(0x40_0100).unwrap().name, "main.main");
+    }
+
+    #[test]
+    fn scan_rejects_tiled_signatures_in_linear_time() {
+        // A region tiled with valid 8-byte signatures at every aligned
+        // offset: each candidate's "header words" are the following
+        // tiles' bytes, which read as out-of-bounds offsets, so all of
+        // them must be rejected — on the borrowed slice, without copying
+        // the tail. (The pre-fix behavior copied per candidate and went
+        // quadratic: ~1.6 s per MiB, ×4 per doubling; the borrowed
+        // validation does the whole region in milliseconds.)
+        let mut region = vec![0u8; 2 << 20];
+        let mut off = 0;
+        while off + HEADER_PREFIX_LEN <= region.len() {
+            region[off..off + 4].copy_from_slice(&GO120_MAGIC.to_le_bytes());
+            region[off + 6] = 1;
+            region[off + 7] = 8;
+            off += 8;
+        }
+        let start = std::time::Instant::now();
+        assert!(GoPclntab::scan(&region, None).is_none());
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(3),
+            "tiled-signature scan took {:?} — per-candidate cost regressed",
+            start.elapsed()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up hardening for the sectionless-pclntab scan from #158, from a post-merge review of the scan tier's adversarial bounds. Two fixes:

**1. Candidate validation no longer allocates — kills a quadratic on adversarial content.** The scan copied `region[off..]` into a `Vec` for every signature-matching candidate *before* validating it. A region tiled with fake 8-byte signatures therefore cost a full tail copy per candidate: measured ~1.6 s per MiB and ×4 per size doubling on the merged code — extrapolating to days at the 1 GiB budget. That contradicts #158's claim that the budget prevents super-linear behavior: the budget caps bytes *read*, not per-candidate copy cost — that sentence in #158's description was wrong, and this PR is the correction. Reachable as an availability problem: the probe runs on every ELF member of every profiled process, so one crafted stripped binary in a workload could wedge a symbolization pass. The fix splits the owned parse into a borrowed header validation (`parse_header`, all the same checks including the functab-extent bound) plus construction; candidates are rejected in constant time on the slice, and bytes are copied exactly once — for the adopted table. Benign binaries see identical behavior (they have at most one candidate).

**2. The scan tier now requires Go build metadata.** Previously every stripped ELF with no named table paid a full read of its data sections (transient RSS up to section sizes, plus a ~0.23 s/GiB sweep) where a name-miss used to be near-free — a real cost on memory-sensitive deployments, charged mostly to non-Go binaries that could never benefit. The scan now runs only when `.go.buildinfo` or `.note.go.buildid` is present; both survive external linking and stripping, and both are present on the sectionless distro builds the scan exists for (verified on the AL2023 containerd artifacts from #158). This also structurally narrows the foreign-table case noted in review — a non-Go binary embedding a complete Go ELF in its data is no longer scanned at all; for a Go binary embedding another Go ELF the first validating table still wins, which the module doc now says explicitly.

One review note accepted as-is: an adopted table retains bytes from its start to the end of its host section rather than its exact extent (the true end isn't cheaply derivable from the header). Bounded by section size, one allocation, benign shapes are small — documented rather than engineered around.

**Verification:** new `scan_rejects_tiled_signatures_in_linear_time` test (a 2 MiB fully-tiled region must complete in milliseconds — it would take seconds-to-minutes with the pre-fix per-candidate copy) and a gate test (real-toolchain fixture with `.gopclntab` *and* all Go marker sections renamed away in `.shstrtab` must report not-a-candidate, while the marker-intact rename fixture from #158 continues to prove the scan path works). The real AL2023 containerd binaries (1.7.27/go1.23.8, 1.7.11/go1.20.12) still resolve their full tables through the gate — full-table sweep green against both. 17/17 crate tests, full workspace suite, fmt and clippy clean.

No version change per the merge-workflow convention; non-schema.
