### PR TITLE
memory: threshold-batch rss_stat events + tp_btf attach path

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -4914,26 +4914,32 @@ int BPF_PROG(systing_rss_stat_exit_flush, struct task_struct *task)
 {
 	if (tool_config.memory_rss_threshold_bytes == 0)
 		return 0;
-	/* Delete even for untraced tasks (no map-entry leak if trace_task's
-	 * answer changed between insert and exit); emit only for traced. */
-	u32 tgid = BPF_CORE_READ(task, tgid);
+	/* Filter first: this hook fires for every task exit on the host, so
+	 * untraced exits pay only the tool check and this. Trade: an entry
+	 * inserted while its task was traced is no longer deleted if the
+	 * task's filter answer changed before exit (e.g. cgroup migration in
+	 * cgroup-targeted mode) — bounded by the map's fall-through-on-full
+	 * semantics (batching degrades to direct-submit, correctness
+	 * unaffected) and impossible in whole-system mode where the filter
+	 * answer is constant. */
+	if (!trace_task(task))
+		return 0;
 	if (BPF_CORE_READ(task, signal, live.counter) != 0)
 		return 0;
+	u32 tgid = BPF_CORE_READ(task, tgid);
 	struct rss_stat_state *st = bpf_map_lookup_elem(&rss_stat_last, &tgid);
 	if (!st)
 		return 0;
 
-	if (trace_task(task)) {
-		/* task->mm is NULL here (exit_mm() precedes this tracepoint),
-		 * so flush latest_seen[] captured on the rss_stat path rather
-		 * than re-reading mm. */
-		for (u32 m = 0; m < NR_MM_COUNTERS; m++) {
-			s64 latest = st->latest_seen[m];
-			if (latest < 0)
-				continue; /* never seen */
-			if (latest != st->last_emitted[m])
-				emit_rss_stat_event(task, m, latest);
-		}
+	/* task->mm is NULL here (exit_mm() precedes this tracepoint), so
+	 * flush latest_seen[] captured on the rss_stat path rather than
+	 * re-reading mm. */
+	for (u32 m = 0; m < NR_MM_COUNTERS; m++) {
+		s64 latest = st->latest_seen[m];
+		if (latest < 0)
+			continue; /* never seen */
+		if (latest != st->last_emitted[m])
+			emit_rss_stat_event(task, m, latest);
 	}
 	bpf_map_delete_elem(&rss_stat_last, &tgid);
 	return 0;

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -4825,12 +4825,13 @@ static __always_inline int emit_rss_stat_event(struct task_struct *task,
 	return 0;
 }
 
-/* Threshold gate shared by both attach paths. */
+/* Threshold gate shared by both attach paths. Callers have already
+ * gated with trace_task() — the filter runs before any per-event work
+ * (counter reads, size math) so untraced tasks pay as close to zero as
+ * possible on this very hot tracepoint. */
 static __always_inline int handle_rss_stat(struct task_struct *task,
 					   u32 member, s64 size_bytes)
 {
-	if (!trace_task(task))
-		return 0;
 	if (member >= NR_MM_COUNTERS)
 		return 0;
 
@@ -4876,6 +4877,8 @@ SEC("tp_btf/rss_stat")
 int BPF_PROG(systing_rss_stat_btf, struct mm_struct *mm, int member)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	if (!trace_task(task))
+		return 0;
 	s64 pages = read_mm_rss_pages(mm, (u32)member);
 	if (pages < 0)
 		pages = 0;
@@ -4886,6 +4889,8 @@ SEC("tracepoint/kmem/rss_stat")
 int systing_rss_stat(struct trace_event_raw_rss_stat *ctx)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	if (!trace_task(task))
+		return 0;
 	/* ctx->size is the kernel's exact percpu_counter_sum_positive() already
 	 * shifted to bytes; this path pays that O(nr_cpus) cost per event but
 	 * is only selected when tp_btf is unavailable. Clamp transient

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -73,6 +73,16 @@ const volatile struct {
 	u32 memory_fault_sample_rate; /* Sample 1 in N page faults (0 or 1 = all) */
 	u32 memory_alloc_sample_rate; /* Sample 1 in N malloc/free calls (0 or 1 = all) */
 	u32 page_size;         /* sysconf(_SC_PAGESIZE) for page-count -> byte conversion */
+	/* Minimum absolute byte-drift before an rss_stat event is emitted.
+	 * Computed by userspace as max(16 MiB, 64 * nr_cpus * page_size). On the
+	 * tp_btf path (>=6.2), the emitted value is an approximate percpu_counter
+	 * read whose worst-case error is percpu_counter_batch * nr_cpus pages
+	 * (batch = max(32, 2*nr_cpus), so quadratic on many-core hosts). In
+	 * typical operation only a few CPUs hold unflushed drift for a given mm
+	 * and the error is far below threshold; in the pathological case a
+	 * spurious emit is harmless (absolute value, just noisier cadence).
+	 * 0 disables the threshold (emit every event, the pre-change behavior). */
+	u64 memory_rss_threshold_bytes;
 	u32 no_sched;          /* Sched recorder off: sched_switch still runs for
 				* cpu_running_pid and sleep stacks, but task_event
 				* emission is suppressed. */
@@ -925,6 +935,30 @@ struct {
 	__type(key, u32);
 	__type(value, u64);
 } memory_fault_counter SEC(".maps");
+
+/* Per-process rss_stat emission state. Keyed by tgid (not tgidpid): the
+ * kernel's mm->rss_stat counters are per-mm, shared across all threads in a
+ * thread group, so a per-thread key would redundantly track the same value
+ * from every thread that happens to fault. last_emitted/latest_seen are
+ * absolute byte values per member (MM_FILEPAGES..MM_SHMEMPAGES); -1 marks
+ * "never seen". */
+struct rss_stat_state {
+	s64 last_emitted[NR_MM_COUNTERS];
+	s64 latest_seen[NR_MM_COUNTERS];
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	/* Bounds concurrent TRACED processes (tgids), not threads or events.
+	 * 65536 matches memory_syscall_scratch and is comfortably above the
+	 * ~20k-task ceiling observed on the busiest CI clusters; on overflow
+	 * the rss_stat progs fall through to direct-submit so no sample is
+	 * ever dropped, only the threshold-batching optimization is lost for
+	 * the overflow tgids. */
+	__uint(max_entries, 65536);
+	__type(key, u32);   // tgid
+	__type(value, struct rss_stat_state);
+} rss_stat_last SEC(".maps");
 
 /* Per-thread scratch for pairing allocator uprobe enter→uretprobe exit.
  * Separate from memory_syscall_scratch so a malloc that internally calls
@@ -4703,13 +4737,78 @@ static __always_inline void memory_capture_stack(void *ctx, struct memory_event 
 #endif
 }
 
-SEC("tracepoint/kmem/rss_stat")
-int systing_rss_stat(struct trace_event_raw_rss_stat *ctx)
-{
-	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
-	if (!trace_task(task))
-		return 0;
+/* ---- rss_stat: CO-RE read + per-tgid threshold-batched emission ----
+ *
+ * Attach path: tp_btf/rss_stat (BPF_PROG_TYPE_TRACING) is preferred. The
+ * classic tracepoint/kmem/rss_stat path routes every firing through the
+ * kernel's perf_trace_rss_stat glue, whose TP_fast_assign on >=6.2 calls
+ * percpu_counter_sum_positive() — an O(nr_cpus) cache-line walk per event.
+ * On fault-heavy nodes that glue alone has been measured at ~1% of on-CPU
+ * time during a capture window. tp_btf bypasses the glue entirely and reads
+ * the counter from mm directly. The classic prog is kept as a fallback
+ * (selected at load time; see systing_core.rs select_rss_stat_prog()) for
+ * kernels whose BTF lacks btf_trace_rss_stat.
+ *
+ * Threshold batching: the kernel fires rss_stat on every per-page counter
+ * update, so a fault storm produces one event per page. We emit only when
+ * the absolute value drifts >= tool_config.memory_rss_threshold_bytes from
+ * the last emitted value for (tgid, member), and flush any sub-threshold
+ * residual at last-thread-exit. memory_rss.size stays an absolute
+ * byte-valued counter sample; only the emission cadence changes.
+ */
 
+/* CO-RE flavor for <6.2 kernels where mm->rss_stat was still
+ * struct mm_rss_stat { atomic_long_t count[NR_MM_COUNTERS]; } rather than
+ * struct percpu_counter rss_stat[NR_MM_COUNTERS]. The ___pre62 suffix is
+ * stripped by CO-RE matching. */
+struct mm_rss_stat___pre62 {
+	atomic_long_t count[NR_MM_COUNTERS];
+};
+struct mm_struct___pre62 {
+	struct mm_rss_stat___pre62 rss_stat;
+};
+
+/* Read mm->rss_stat[member] as an absolute page count. On <6.2 (atomic
+ * array) this is exact. On >=6.2 (percpu_counter) this reads only .count,
+ * missing the per-CPU batch slots — error bounded by
+ * +-(percpu_counter_batch * nr_online_cpus) pages where the kernel sets
+ * batch = max(32, 2*nr_online_cpus) (lib/percpu_counter.c), so worst-case
+ * is quadratic in nr_cpus. In practice only the CPUs a given mm is actively
+ * faulting on carry unflushed drift, so typical error is a small multiple
+ * of batch.
+ *
+ * An exact sum would need bpf_per_cpu_ptr() over rss_stat[member].counters,
+ * but that helper requires ARG_PTR_TO_PERCPU_BTF_ID and a value read via
+ * BPF_CORE_READ arrives as SCALAR_VALUE; direct BTF-walk access preserves
+ * percpu-ness only on clang-built kernels with btf_type_tag("percpu") in
+ * vmlinux BTF — not portable across the fleet. The approximate read is the
+ * portable choice; the threshold absorbs the noise, and the classic
+ * fallback still emits exact values (from ctx->size) where tp_btf is
+ * unavailable. */
+static __always_inline s64 read_mm_rss_pages(struct mm_struct *mm, u32 member)
+{
+	struct mm_struct___pre62 *old = (void *)mm;
+	if (bpf_core_field_exists(old->rss_stat.count)) {
+		switch (member) {
+		case MM_FILEPAGES:  return BPF_CORE_READ(old, rss_stat.count[MM_FILEPAGES].counter);
+		case MM_ANONPAGES:  return BPF_CORE_READ(old, rss_stat.count[MM_ANONPAGES].counter);
+		case MM_SWAPENTS:   return BPF_CORE_READ(old, rss_stat.count[MM_SWAPENTS].counter);
+		case MM_SHMEMPAGES: return BPF_CORE_READ(old, rss_stat.count[MM_SHMEMPAGES].counter);
+		}
+		return 0;
+	}
+	switch (member) {
+	case MM_FILEPAGES:  return BPF_CORE_READ(mm, rss_stat[MM_FILEPAGES].count);
+	case MM_ANONPAGES:  return BPF_CORE_READ(mm, rss_stat[MM_ANONPAGES].count);
+	case MM_SWAPENTS:   return BPF_CORE_READ(mm, rss_stat[MM_SWAPENTS].count);
+	case MM_SHMEMPAGES: return BPF_CORE_READ(mm, rss_stat[MM_SHMEMPAGES].count);
+	}
+	return 0;
+}
+
+static __always_inline int emit_rss_stat_event(struct task_struct *task,
+					       u32 member, s64 size_bytes)
+{
 	long flags;
 	struct memory_event_header *event = reserve_memory_event_header(&flags);
 	if (!event)
@@ -4719,11 +4818,119 @@ int systing_rss_stat(struct trace_event_raw_rss_stat *ctx)
 	event->ts = bpf_ktime_get_boot_ns();
 	event->cpu = bpf_get_smp_processor_id();
 	record_task_info(&event->task, task);
-	event->member = ctx->member;
-	/* rss_stat tracepoint already shifts by PAGE_SHIFT; size is bytes. */
-	event->size = (u64)(s64)ctx->size;
+	event->member = member;
+	event->size = (u64)size_bytes;
 
 	bpf_ringbuf_submit(event, flags);
+	return 0;
+}
+
+/* Threshold gate shared by both attach paths. */
+static __always_inline int handle_rss_stat(struct task_struct *task,
+					   u32 member, s64 size_bytes)
+{
+	if (!trace_task(task))
+		return 0;
+	if (member >= NR_MM_COUNTERS)
+		return 0;
+
+	/* Threshold disabled (0): preserve pre-change behavior exactly. */
+	if (tool_config.memory_rss_threshold_bytes == 0)
+		return emit_rss_stat_event(task, member, size_bytes);
+
+	u32 tgid = BPF_CORE_READ(task, tgid);
+	struct rss_stat_state *st = bpf_map_lookup_elem(&rss_stat_last, &tgid);
+	if (!st) {
+		struct rss_stat_state init;
+		__builtin_memset(&init, 0xff, sizeof(init)); /* all members = -1 (never seen) */
+		/* Map full, or lost the insert race to another thread of this
+		 * tgid: fall through to direct-submit so no sample is dropped.
+		 * BPF_NOEXIST (not BPF_ANY) so the race-loser doesn't clobber
+		 * the winner's populated state. */
+		if (bpf_map_update_elem(&rss_stat_last, &tgid, &init, BPF_NOEXIST) != 0)
+			return emit_rss_stat_event(task, member, size_bytes);
+		st = bpf_map_lookup_elem(&rss_stat_last, &tgid);
+		if (!st)
+			return emit_rss_stat_event(task, member, size_bytes);
+	}
+
+	/* Unsynchronized per-member s64 stores — multiple threads of a tgid
+	 * may race here. Benign: worst case is a duplicate emit or one stale
+	 * last_emitted (one extra emit); never a lost sample. */
+	st->latest_seen[member] = size_bytes;
+	s64 last = st->last_emitted[member];
+	/* First sighting for this member: always emit so consumers have a
+	 * baseline (last == -1 from the 0xff memset). */
+	s64 drift = last < 0 ? (s64)tool_config.memory_rss_threshold_bytes
+			     : size_bytes - last;
+	if (drift < 0)
+		drift = -drift;
+	if ((u64)drift < tool_config.memory_rss_threshold_bytes)
+		return 0;
+
+	st->last_emitted[member] = size_bytes;
+	return emit_rss_stat_event(task, member, size_bytes);
+}
+
+SEC("tp_btf/rss_stat")
+int BPF_PROG(systing_rss_stat_btf, struct mm_struct *mm, int member)
+{
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	s64 pages = read_mm_rss_pages(mm, (u32)member);
+	if (pages < 0)
+		pages = 0;
+	return handle_rss_stat(task, (u32)member, pages * (s64)tool_config.page_size);
+}
+
+SEC("tracepoint/kmem/rss_stat")
+int systing_rss_stat(struct trace_event_raw_rss_stat *ctx)
+{
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	/* ctx->size is the kernel's exact percpu_counter_sum_positive() already
+	 * shifted to bytes; this path pays that O(nr_cpus) cost per event but
+	 * is only selected when tp_btf is unavailable. Clamp transient
+	 * negatives (possible on <6.2 SPLIT_RSS_COUNTING kernels near zero) so
+	 * the threshold gate's last<0 sentinel stays unambiguous. */
+	s64 size = (s64)ctx->size;
+	if (size < 0)
+		size = 0;
+	return handle_rss_stat(task, (u32)ctx->member, size);
+}
+
+/* Flush sub-threshold residual rss_stat state at last-thread-exit so a
+ * process that exits between thresholds still records its final counter
+ * values, then release the map entry. Separate program (not inlined into
+ * systing_sched_process_exit) so the memory_ringbufs reference stays
+ * confined to memory-recorder programs and the sched program can load when
+ * memory_ringbufs is autocreate=false. Multiple tp_btf progs on one
+ * tracepoint is fine. */
+SEC("tp_btf/sched_process_exit")
+int BPF_PROG(systing_rss_stat_exit_flush, struct task_struct *task)
+{
+	if (tool_config.memory_rss_threshold_bytes == 0)
+		return 0;
+	/* Delete even for untraced tasks (no map-entry leak if trace_task's
+	 * answer changed between insert and exit); emit only for traced. */
+	u32 tgid = BPF_CORE_READ(task, tgid);
+	if (BPF_CORE_READ(task, signal, live.counter) != 0)
+		return 0;
+	struct rss_stat_state *st = bpf_map_lookup_elem(&rss_stat_last, &tgid);
+	if (!st)
+		return 0;
+
+	if (trace_task(task)) {
+		/* task->mm is NULL here (exit_mm() precedes this tracepoint),
+		 * so flush latest_seen[] captured on the rss_stat path rather
+		 * than re-reading mm. */
+		for (u32 m = 0; m < NR_MM_COUNTERS; m++) {
+			s64 latest = st->latest_seen[m];
+			if (latest < 0)
+				continue; /* never seen */
+			if (latest != st->last_emitted[m])
+				emit_rss_stat_event(task, m, latest);
+		}
+	}
+	bpf_map_delete_elem(&rss_stat_last, &tgid);
 	return 0;
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,12 @@ struct Command {
     /// Sample 1 in N user page faults when the memory recorder is enabled (0 or 1 = record all)
     #[arg(long, default_value = "97")]
     memory_fault_sample_rate: u32,
+    /// Override the minimum byte-drift between emitted rss_stat events (default: max(16 MiB, 64*nr_cpus*page_size); 0 = emit every event)
+    #[arg(long)]
+    memory_rss_threshold_bytes: Option<u64>,
+    /// Force the classic tracepoint/kmem/rss_stat attach path even when tp_btf/rss_stat is available (testing only)
+    #[arg(long, hide = true)]
+    memory_rss_force_classic: bool,
     // Heap-allocator tracing enabled state (set by recorder management, not a CLI flag)
     #[arg(skip)]
     memory_alloc: bool,
@@ -223,6 +229,8 @@ impl From<Command> for Config {
             marker_duration_threshold: cmd.marker_duration_threshold,
             memory: cmd.memory,
             memory_fault_sample_rate: cmd.memory_fault_sample_rate,
+            memory_rss_threshold_bytes: cmd.memory_rss_threshold_bytes,
+            memory_rss_force_classic: cmd.memory_rss_force_classic,
             memory_alloc: cmd.memory_alloc,
             memory_alloc_sample_rate: cmd.memory_alloc_sample_rate,
             memory_alloc_lib: cmd.memory_alloc_lib,

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -201,7 +201,12 @@ const SYSCALL_BPF_PROGRAMS: &[&str] = &[
 ];
 
 const MEMORY_BPF_PROGRAMS: &[&str] = &[
-    "systing_rss_stat",
+    // rss_stat has two implementations (tp_btf and classic tracepoint);
+    // exactly one is selected at load time — see get_required_bpf_programs.
+    // The exit-flush prog is a separate tp_btf/sched_process_exit attach so
+    // the memory_ringbufs map reference stays out of the sched recorder's
+    // program and each recorder's ringbuf families stay independent.
+    "systing_rss_stat_exit_flush",
     "systing_mmap_enter",
     "systing_mmap_exit",
     "systing_munmap_enter",
@@ -533,6 +538,12 @@ pub fn get_required_bpf_programs(
         }
     }
 
+    // rss_stat attach-path selection: exactly one of the two progs is loaded.
+    // MEMORY_BPF_PROGRAMS deliberately lists neither.
+    if opts.memory {
+        required.insert(select_rss_stat_prog(opts.memory_rss_force_classic));
+    }
+
     required
 }
 
@@ -609,6 +620,13 @@ pub struct Config {
     pub memory: bool,
     /// Sample 1 in N user page faults (0 or 1 = record all)
     pub memory_fault_sample_rate: u32,
+    /// Minimum absolute byte-drift between emitted rss_stat events (0 = emit
+    /// every event). Default is max(16 MiB, 64 * nr_cpus * page_size); see
+    /// `memory_rss_threshold_bytes` in `tool_config` for the derivation.
+    pub memory_rss_threshold_bytes: Option<u64>,
+    /// Force the classic `tracepoint/kmem/rss_stat` attach path even when
+    /// `tp_btf/rss_stat` is available. Testing-only (exercises the fallback).
+    pub memory_rss_force_classic: bool,
     /// Enable heap allocator uprobes (malloc/free/calloc/realloc/...)
     pub memory_alloc: bool,
     /// Sample 1 in N allocator calls (0 or 1 = record all)
@@ -686,6 +704,8 @@ impl Default for Config {
             marker_duration_threshold: None,
             memory: false,
             memory_fault_sample_rate: 97,
+            memory_rss_threshold_bytes: None,
+            memory_rss_force_classic: false,
             memory_alloc: false,
             memory_alloc_sample_rate: 1,
             memory_alloc_lib: None,
@@ -1354,6 +1374,39 @@ fn sum_percpu_counter(map: &dyn libbpf_rs::MapCore) -> u64 {
         }
     }
     total
+}
+
+/// Probe whether the running kernel's vmlinux BTF exposes the
+/// `btf_trace_rss_stat` typedef that `SEC("tp_btf/rss_stat")` attaches to.
+/// When absent (or when the caller forces the classic path for testing), fall
+/// back to the classic `tracepoint/kmem/rss_stat` prog. See the block
+/// comment above `systing_rss_stat_btf` in `systing_system.bpf.c` for why
+/// tp_btf is preferred (it skips the perf_trace glue and its O(nr_cpus)
+/// percpu_counter_sum on every event).
+fn kernel_has_rss_stat_btf() -> bool {
+    match libbpf_rs::btf::Btf::from_vmlinux() {
+        Ok(btf) => btf
+            .type_by_name::<libbpf_rs::btf::types::Typedef<'_>>("btf_trace_rss_stat")
+            .is_some(),
+        Err(e) => {
+            eprintln!(
+                "Warning: failed to open vmlinux BTF ({e}); \
+                 falling back to classic rss_stat tracepoint attach"
+            );
+            false
+        }
+    }
+}
+
+/// Pick the rss_stat BPF program name to load: `systing_rss_stat_btf` when
+/// the kernel supports tp_btf attach for rss_stat and the user hasn't forced
+/// the classic fallback (for test coverage), otherwise `systing_rss_stat`.
+fn select_rss_stat_prog(force_classic: bool) -> &'static str {
+    if !force_classic && kernel_has_rss_stat_btf() {
+        "systing_rss_stat_btf"
+    } else {
+        "systing_rss_stat"
+    }
 }
 
 fn is_old_kernel() -> bool {
@@ -2077,6 +2130,10 @@ fn warn_failed_probe_attachments(skel: &SystingSystemSkel) {
             "systing_sched_process_exit" => skel.links.systing_sched_process_exit.is_none(),
             "systing_sched_process_fork" => skel.links.systing_sched_process_fork.is_none(),
             "systing_sched_process_exec" => skel.links.systing_sched_process_exec.is_none(),
+            // Memory recorder
+            "systing_rss_stat_btf" => skel.links.systing_rss_stat_btf.is_none(),
+            "systing_rss_stat" => skel.links.systing_rss_stat.is_none(),
+            "systing_rss_stat_exit_flush" => skel.links.systing_rss_stat_exit_flush.is_none(),
             // IRQ probes
             "systing_irq_handler_entry" => skel.links.systing_irq_handler_entry.is_none(),
             "systing_irq_handler_exit" => skel.links.systing_irq_handler_exit.is_none(),
@@ -2202,7 +2259,17 @@ fn configure_bpf_skeleton(
         if opts.memory {
             rodata.tool_config.collect_memory = 1;
             rodata.tool_config.memory_fault_sample_rate = opts.memory_fault_sample_rate;
-            rodata.tool_config.page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
+            let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u32;
+            rodata.tool_config.page_size = page_size;
+            // Default threshold: max(16 MiB, 64 * nr_cpus * page_size). The
+            // 64*nr_cpus term keeps the threshold above typical
+            // percpu_counter read noise on many-core hosts; see the
+            // tool_config comment in systing_system.bpf.c for the full
+            // error-bound story and why worst-case noise can still exceed
+            // this on very large hosts (harmless — spurious emits only).
+            rodata.tool_config.memory_rss_threshold_bytes = opts
+                .memory_rss_threshold_bytes
+                .unwrap_or_else(|| (16u64 << 20).max(64 * num_cpus as u64 * page_size as u64));
         }
         if opts.memory_alloc {
             rodata.tool_config.memory_alloc_sample_rate = opts.memory_alloc_sample_rate;

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -525,6 +525,16 @@ pub struct CpuInfoRecord {
 ///
 /// `member` indexes the kernel `rss_stat` counter (0=file, 1=anon, 2=swap, 3=shmem).
 /// Negative members are synthetic: -1 = hiwater_rss, -2 = total_vm (from periodic mm snapshots).
+///
+/// Emission cadence: rss_stat samples are threshold-batched in BPF (one event
+/// per ≥ `memory_rss_threshold_bytes` of drift per (tgid, member), default
+/// max(16 MiB, 64·nr_cpus·page_size)), not one per kernel tracepoint firing.
+/// On the `tp_btf/rss_stat` attach path (kernels ≥6.2 with BTF), `size` is
+/// an approximate `percpu_counter_read()` of `mm->rss_stat[member]` — it
+/// misses the per-CPU batch slots, so its worst-case error is
+/// ±(percpu_counter_batch · nr_online_cpus) pages where the kernel sets
+/// batch = max(32, 2·nr_online_cpus). On the classic `tracepoint/kmem/rss_stat`
+/// fallback the kernel's own exact sum is used.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MemoryRssRecord {
     pub ts: i64,

--- a/tests/memory_recorder.rs
+++ b/tests/memory_recorder.rs
@@ -569,3 +569,134 @@ fn test_exe_defines_malloc_negative() {
         "test binary is glibc-linked; exe_defines_malloc should return None"
     );
 }
+
+/// Threshold-batching correctness test: with a known threshold, a workload
+/// that touches N * threshold bytes of anon memory should produce on the
+/// order of N rss_stat events — not one per 4 KiB page — and the peak
+/// emitted value should match the workload's ground-truth RSS.
+///
+/// Exercised on BOTH attach paths: the default (tp_btf/rss_stat where the
+/// kernel supports it) and the forced classic tracepoint fallback.
+fn run_rss_threshold_test(force_classic: bool) {
+    const THRESHOLD: u64 = 4 << 20; // 4 MiB: small and kernel-independent
+    const STEPS: i64 = 32; // ~128 MiB total anon growth
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+
+    // Workload: grow a single bytearray in THRESHOLD-sized steps, touching
+    // every page so each step produces ~THRESHOLD of anon-RSS growth. Using
+    // one resized buffer (not many) keeps the kernel's rss_stat firings on a
+    // single monotonic ramp, which is what the threshold gate sees.
+    let py_prog = format!(
+        "import time\n\
+         buf = bytearray()\n\
+         step = {step}\n\
+         for _ in range({steps}):\n\
+         \x20 buf.extend(b'\\x00' * step)\n\
+         \x20 for i in range(len(buf)-step, len(buf), 4096):\n\
+         \x20\x20 buf[i] = 1\n\
+         \x20 time.sleep(0.01)\n\
+         time.sleep(0.2)\n",
+        step = THRESHOLD,
+        steps = STEPS,
+    );
+    let run_cmd = vec!["python3".to_string(), "-c".to_string(), py_prog];
+    let traced_child =
+        systing::traced_command::spawn_traced_child(&run_cmd).expect("Failed to spawn child");
+    let child_pid = traced_child.pid as i32;
+
+    eprintln!(
+        "Recording rss_stat threshold test (pid {}, {}x{} MiB, force_classic={})...",
+        child_pid,
+        STEPS,
+        THRESHOLD >> 20,
+        force_classic,
+    );
+
+    let config = Config {
+        memory: true,
+        memory_rss_threshold_bytes: Some(THRESHOLD),
+        memory_rss_force_classic: force_classic,
+        parquet_only: true,
+        output_dir: dir.path().to_path_buf(),
+        output: dir.path().join("trace.pb"),
+        ..Config::default()
+    };
+    let exit_code = systing(config, Some(traced_child)).expect("systing recording failed");
+    assert_eq!(exit_code, 0, "workload should exit 0");
+
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "rsstest")
+        .expect("DuckDB conversion failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+
+    let (anon_rows, max_anon): (i64, i64) = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*), COALESCE(MAX(size), 0)
+                 FROM memory_rss WHERE member = 1 AND utid IN {UTIDS_FOR_PID}"
+            ),
+            [child_pid],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("Failed to query memory_rss");
+
+    let target_bytes = STEPS * THRESHOLD as i64;
+    eprintln!(
+        "    anon rss_stat events: {} (target ~{}); max size: {} MiB (target ~{} MiB)",
+        anon_rows,
+        STEPS,
+        max_anon >> 20,
+        target_bytes >> 20,
+    );
+
+    // Event count: without thresholding, ~THRESHOLD/4096 * STEPS = ~32768
+    // events. With a THRESHOLD gate, expect on the order of STEPS emits on
+    // the ramp plus interpreter startup/teardown — bound generously, but
+    // tight enough to fail if the gate is broken (which would give >=1000).
+    assert!(
+        (STEPS / 2..STEPS * 8).contains(&anon_rows),
+        "[rss_stat threshold] anon event count {} outside [{}..{}) \
+         (force_classic={}, target ~{}) — threshold gate broken?",
+        anon_rows,
+        STEPS / 2,
+        STEPS * 8,
+        force_classic,
+        STEPS,
+    );
+
+    // Peak value: max emitted anon size should be within [target - threshold,
+    // target + python-overhead]. The lower bound checks that threshold
+    // batching didn't drop the peak; the upper is a loose sanity ceiling.
+    assert!(
+        (target_bytes - THRESHOLD as i64..target_bytes + (128 << 20)).contains(&max_anon),
+        "[rss_stat threshold] max anon {} bytes outside [{}, {}) \
+         (force_classic={}) — peak value wrong?",
+        max_anon,
+        target_bytes - THRESHOLD as i64,
+        target_bytes + (128 << 20),
+        force_classic,
+    );
+
+    // Byte semantics guard: fails if the tp_btf path emitted pages instead
+    // of bytes (off by 4096x).
+    assert!(
+        max_anon > target_bytes / 16,
+        "[rss_stat threshold] max anon {} suspiciously small vs target {} \
+         — page/byte unit bug on tp_btf path?",
+        max_anon,
+        target_bytes,
+    );
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_memory_rss_threshold_tp_btf() {
+    run_rss_threshold_test(false);
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_memory_rss_threshold_classic_fallback() {
+    run_rss_threshold_test(true);
+}


### PR DESCRIPTION
# memory: threshold-batch rss_stat events + tp_btf attach path

## Summary

Two layered fixes for the memory recorder's `rss_stat` hook overhead on
fault-heavy hosts:

**Layer 1 — attach path.** Add `SEC("tp_btf/rss_stat")` as the preferred
attach, keeping the existing `SEC("tracepoint/kmem/rss_stat")` as a
load-time fallback (selected by probing vmlinux BTF for
`btf_trace_rss_stat`; forceable via the hidden
`--memory-rss-force-classic` for test coverage). The classic path routes
every tracepoint firing through the kernel's `perf_trace_rss_stat` glue,
whose `TP_fast_assign` on ≥6.2 kernels calls
`percpu_counter_sum_positive()` — an O(nr_cpus) cache-line walk per event.
`tp_btf` bypasses the glue and reads `mm->rss_stat[member]` directly via
CO-RE (dual-layout: `percpu_counter[4]` on ≥6.2, `struct mm_rss_stat` on
<6.2). The tp_btf read is a cheap `percpu_counter_read()` approximation;
see "Accuracy" below.

**Layer 2 — threshold batching.** The kernel fires `rss_stat` on every
per-page counter update, so a fault storm produces one event per 4 KiB page.
Both attach paths now feed a shared `handle_rss_stat()` helper that emits
only when the absolute per-(tgid, member) counter drifts
≥ `memory_rss_threshold_bytes` (default max(16 MiB, 64·nr_cpus·page_size),
overridable via `--memory-rss-threshold-bytes`; `0` restores the
pre-change emit-every-event behavior). Sub-threshold residuals are flushed at
last-thread-exit by a dedicated `tp_btf/sched_process_exit` program
(`systing_rss_stat_exit_flush` — separate from the sched recorder's own
exit hook so each recorder's map references stay independent). On map-full
the gate falls through to direct-submit, so no sample is ever dropped — only
the batching optimization is lost for overflow tgids. `memory_rss.size`
stays an absolute byte-valued counter sample; only emission cadence changes,
so any downstream per-window `max(size)` aggregate is unaffected within
±threshold.

## Motivation

On fault-heavy hosts (e.g. many-core CI nodes running allocator-intensive
jobs), `perf_trace_rss_stat` has been observed at ~1% of on-CPU samples
during a memory-recorder capture window — effectively all profiler
self-observation. tp_btf skips the per-event O(nr_cpus) sum; threshold
batching cuts the remaining per-event fixed cost from once-per-page to
once-per-N-MiB.

## Accuracy

On the tp_btf path (≥6.2 kernels), `memory_rss.size` is the approximate
`percpu_counter_read()` of `mm->rss_stat[member]` — it misses per-CPU
batch slots. Worst-case error is ±(percpu_counter_batch · nr_online_cpus)
pages, where the kernel sets batch = max(32, 2·nr_online_cpus), i.e.
quadratic in core count. In practice only CPUs the mm is actively faulting
on hold drift, and typical error is a small multiple of batch. The classic
fallback still emits the kernel's own exact sum. An exact-sum tp_btf emit
via `bpf_per_cpu_ptr` over `rss_stat[].counters` is not portably
verifiable (the helper needs `ARG_PTR_TO_PERCPU_BTF_ID`, which a
`BPF_CORE_READ`-obtained pointer is not; direct BTF-walk access preserves
percpu-ness only on clang-built kernels with `btf_type_tag("percpu")` in
vmlinux BTF). Documented in `MemoryRssRecord` and the BPF comments.

## Notes

- The aggregation map is keyed by **tgid**, not tgidpid: `rss_stat`
  counters are per-mm (process-wide), so a per-thread key would redundantly
  track the same value from every thread. Concurrent per-tgid updates are
  unsynchronized by design (worst case: one duplicate emit).
- No schema change; `memory_rss.size` semantics unchanged.

