### PR TITLE
Symbolize processes that exit before end-of-trace symbolization

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -81,6 +81,10 @@ const volatile struct {
 				* gate is belt-and-braces (and lets the verifier
 				* prune the bodies if the programs ever get loaded
 				* for another reason). */
+	u32 collect_exited_recovery; /* First-sample mapping snapshots for
+				      * exited-process symbolization: gates the
+				      * snapshot-hint sidecar ringbuf and the
+				      * exec-invalidation path. */
 } tool_config = {};
 
 enum event_type {
@@ -396,12 +400,13 @@ struct memory_event {
  * Dummy instance to get skeleton to generate definition for
  * `struct task_event`
  */
-#ifdef SYSTING_PYSTACKS
 /*
- * Notify userspace that a traced process exec'd or forked so it can update
- * the pystacks discovery state. The handler in handle_exec_events() reads
- * /proc/<pid>/{exe,maps}, so this only carries the pid and a flag describing
- * what kernel event produced it (exec vs. fork) for logging/diagnostics.
+ * Notify userspace that a traced process exec'd or forked. Two consumers:
+ * pystacks discovery state updates, and exited-recovery mapping-snapshot
+ * invalidation (exec replaces the address space, so a snapshot captured
+ * for the old image must be dropped). The handler in handle_exec_events()
+ * reads /proc/<pid>/{exe,maps}, so this only carries the pid and a flag
+ * describing what kernel event produced it (exec vs. fork).
  */
 struct exec_event {
 	u32 pid;
@@ -412,7 +417,22 @@ struct exec_event {
 	 * memory to userspace. */
 	u32 is_fork;
 };
-#endif
+
+/*
+ * Sidecar notification that a stack sample with a user stack was taken for
+ * a tgid. A dedicated userspace thread drains these and captures the
+ * process's executable mappings on first sight: the main stack ringbuf can
+ * queue seconds behind under load, and a short-lived process is gone
+ * before its first sample is consumed from it — a snapshot captured then
+ * comes too late. Hints are advisory; if one is dropped the stack-event
+ * consumer makes the same observation later, just slower.
+ */
+struct snapshot_hint {
+	u32 tgid;
+	/* Explicit, zeroed padding: bpf_ringbuf_reserve() does not zero its
+	 * allocation, and implicit padding would leak kernel memory. */
+	u32 reserved;
+};
 
 struct task_event _event = {0};
 struct stack_event _stack_event = {0};
@@ -428,9 +448,8 @@ struct memory_event_header _memory_event_header = {0};
 enum memory_event_type _memory_event_type = MEMORY_RSS_STAT;
 enum memory_rss_member _memory_rss_member = MEMORY_MM_FILEPAGES;
 enum memory_alloc_op _memory_alloc_op = MEMORY_OP_MALLOC;
-#ifdef SYSTING_PYSTACKS
 struct exec_event _exec_event = {0};
-#endif
+struct snapshot_hint _snapshot_hint = {0};
 struct arg_desc _arg_desc = {0};
 enum event_type _type = SCHED_SWITCH;
 enum arg_type _arg_type = ARG_NONE;
@@ -739,7 +758,6 @@ struct memory_ringbuf_map {
 	ringbuf_memory_events_node6 SEC(".maps"),
 	ringbuf_memory_events_node7 SEC(".maps");
 
-#ifdef SYSTING_PYSTACKS
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
 	/*
@@ -752,7 +770,36 @@ struct {
 	 */
 	__uint(max_entries, 16384);
 } ringbuf_exec_events SEC(".maps");
-#endif
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	/*
+	 * 64KB of ~16-byte snapshot hints. Overflow is harmless by design:
+	 * the stack-event consumer performs the same first-sample
+	 * observation when it gets there — a dropped hint costs capture
+	 * latency, never correctness.
+	 */
+	__uint(max_entries, 65536);
+} ringbuf_snapshot_hints SEC(".maps");
+
+/*
+ * Once-per-tgid gate for snapshot hints. The consumer only acts on the
+ * first hint it sees for a tgid (one capture attempt per tgid), so
+ * emitting a hint per user-stack sample is pure waste past the first:
+ * gating emission here keeps the hint ringbuf and its consumer thread
+ * out of the per-sample picture entirely. Sized for 8192
+ * concurrently-live tgids before benign eviction: an
+ * evicted-then-resampled tgid re-hints, and the consumer's one-attempt
+ * rule absorbs the duplicate — the same advisory semantics as a
+ * dropped hint, in the other direction. Exec deletes the entry (see
+ * systing_sched_process_exec) so a replaced address space re-hints.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 8192);
+	__type(key, u32);
+	__type(value, u8);
+} recovery_hinted_tgids SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_RINGBUF);
@@ -1611,7 +1658,41 @@ static void emit_stack_event_with_ts(void *ctx, struct task_struct *task,
 		event->kernel_stack_length = len / sizeof(u64);
 	else
 		event->kernel_stack_length = 0;
+
+	u32 user_stack_length = event->user_stack_length;
 	bpf_ringbuf_submit(event, flags);
+
+	/*
+	 * Exited-recovery snapshot hint, after the main submit so the stack
+	 * event's latency is unaffected. Only samples with a user stack need
+	 * a mapping snapshot; kernel-only samples symbolize without one, and
+	 * only the FIRST hint per tgid does any work downstream — the LRU
+	 * lookup keeps the hot path to one hash probe per sample.
+	 */
+	if (tool_config.collect_exited_recovery && user_stack_length > 0) {
+		u32 tgid = task->tgid;
+
+		if (!bpf_map_lookup_elem(&recovery_hinted_tgids, &tgid)) {
+			struct snapshot_hint *hint = bpf_ringbuf_reserve(
+				&ringbuf_snapshot_hints, sizeof(*hint), 0);
+			if (hint) {
+				u8 seen = 1;
+
+				hint->tgid = tgid;
+				hint->reserved = 0;
+				bpf_ringbuf_submit(hint, 0);
+				/*
+				 * Mark only after a successful emit: a failed
+				 * reserve retries on the next sample, keeping
+				 * hints advisory. Two CPUs racing the lookup
+				 * emit a duplicate, which the consumer's
+				 * one-attempt rule absorbs.
+				 */
+				bpf_map_update_elem(&recovery_hinted_tgids,
+						    &tgid, &seen, BPF_ANY);
+			}
+		}
+	}
 }
 
 static void emit_stack_event(void *ctx, struct task_struct *task,
@@ -1927,15 +2008,28 @@ int BPF_PROG(systing_sched_process_fork, struct task_struct *parent,
 	return handle_sched_process_fork(parent, child);
 }
 
-#ifdef SYSTING_PYSTACKS
 SEC("tp_btf/sched_process_exec")
 int BPF_PROG(systing_sched_process_exec, struct task_struct *task,
 	     pid_t old_pid, struct linux_binprm *bprm)
 {
-	if (!tool_config.collect_pystacks)
+	if (!tool_config.collect_pystacks && !tool_config.collect_exited_recovery)
 		return 0;
 	if (!trace_task(task))
 		return 0;
+
+	/*
+	 * Exec replaced the address space, so the once-per-tgid hint gate
+	 * must reopen regardless of what happens to the exec event below: if
+	 * the event is dropped (ringbuf full), the stale userspace snapshot
+	 * survives until the consumer notices, but the re-hint on the next
+	 * sample gives it that chance — deleting after a failed reserve
+	 * would close both doors.
+	 */
+	if (tool_config.collect_exited_recovery) {
+		u32 exec_tgid = task->tgid;
+
+		bpf_map_delete_elem(&recovery_hinted_tgids, &exec_tgid);
+	}
 
 	/*
 	 * Reserve the ringbuf slot *before* clearing the stale pystacks config.
@@ -1950,6 +2044,7 @@ int BPF_PROG(systing_sched_process_exec, struct task_struct *task,
 	if (!event)
 		return 0;
 
+#ifdef SYSTING_PYSTACKS
 	/*
 	 * Exec replaces the address space, so any pystacks config we have for
 	 * this pid (whether registered at startup, dynamically discovered, or
@@ -1960,15 +2055,21 @@ int BPF_PROG(systing_sched_process_exec, struct task_struct *task,
 	 * This is what keeps subprocess.Popen() from a Python parent from
 	 * leaking a stale entry per call: fork propagates the parent's config
 	 * to the child, then exec into the subprocess binary clears it again.
+	 *
+	 * The same exec event separately invalidates any exited-recovery
+	 * mapping snapshot in userspace (see handle_exec_events()), which is
+	 * why this program runs — and the event is submitted — even when
+	 * pystacks is off.
 	 */
-	pystacks_clear_pid(task->tgid);
+	if (tool_config.collect_pystacks)
+		pystacks_clear_pid(task->tgid);
+#endif
 
 	event->pid = task->tgid;
 	event->is_fork = 0;
 	bpf_ringbuf_submit(event, 0);
 	return 0;
 }
-#endif
 
 SEC("tp_btf/irq_handler_entry")
 int BPF_PROG(systing_irq_handler_entry, int irq, struct irqaction *action)

--- a/src/exit_snapshot.rs
+++ b/src/exit_snapshot.rs
@@ -1,0 +1,480 @@
+//! Post-mortem symbolization support for short-lived processes.
+//!
+//! blazesym symbolizes live processes through `/proc/<pid>/maps` and
+//! `/proc/<pid>/map_files`; once a process exits both are gone and its user
+//! frames render as `unknown ([exited]) <addr>`. On fork/exec-heavy hosts
+//! (build and CI machines) that class can dominate the profile.
+//!
+//! This module closes most of it. The first time a stack sample arrives for
+//! a tgid — the process is on-CPU, so it is alive right now — its executable
+//! file-backed mappings are captured and each backing file is pinned with a
+//! read-only descriptor, deduplicated by (device, inode). At end-of-trace
+//! symbolization, a dead tgid with a snapshot resolves user addresses to
+//! (pinned file, file offset) and symbolizes through `/proc/self/fd/<n>`;
+//! addresses that miss the snapshot keep the `[exited]` rendering.
+//!
+//! Bounded on every axis: one capture attempt per tgid, a per-second capture
+//! budget for fork storms, a per-process segment cap, and a global pinned-file
+//! cap with oldest-first eviction. Every limit degrades to the existing
+//! `[exited]` rendering, never to an error.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fs::File;
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+use std::time::Instant;
+
+/// Executable mappings beyond this count are ignored; processes mapping more
+/// executable file segments than this are not the short-lived class this
+/// exists for.
+const MAX_SEGMENTS_PER_PROC: usize = 128;
+
+/// Default cap on distinct pinned files. Short-lived-process churn reuses the
+/// same binaries (shells, compilers, interpreters), so the working set is far
+/// smaller than the process count. Kept safely below common RLIMIT_NOFILE
+/// soft limits since each pin holds a descriptor until the next reset.
+const DEFAULT_MAX_FILES: usize = 512;
+
+/// Default cap on capture attempts per second. A fork storm beyond this rate
+/// degrades to the existing `[exited]` rendering for the overflow.
+const DEFAULT_CAPTURES_PER_SEC: u32 = 500;
+
+/// (device, inode) — identifies a mapped file independent of path or process.
+type FileKey = (u64, u64);
+
+struct PinnedFile {
+    file: File,
+    /// Basename of the mapping's pathname, for frame module attribution
+    /// (the `/proc/self/fd/<n>` path would otherwise leak into frames).
+    display: String,
+}
+
+struct ExecSegment {
+    start: u64,
+    end: u64,
+    file_offset: u64,
+    file: FileKey,
+}
+
+/// Executable-mapping snapshot for one process, sorted by start address.
+struct ProcSnapshot {
+    segments: Vec<ExecSegment>,
+}
+
+/// A user address resolved against a snapshot: where to symbolize from and
+/// what to call the module.
+pub struct ResolvedAddr {
+    /// `/proc/self/fd/<n>` path of the pinned backing file.
+    pub elf_path: PathBuf,
+    /// Offset of the address within that file.
+    pub file_offset: u64,
+    /// Module name for frame rendering (original binary basename).
+    pub module: String,
+}
+
+pub struct ExitSnapshots {
+    enabled: bool,
+    /// tgids already attempted (successfully or not) — one attempt each.
+    seen: HashSet<i32>,
+    snapshots: HashMap<i32, ProcSnapshot>,
+    files: HashMap<FileKey, PinnedFile>,
+    /// Pin order for oldest-first eviction.
+    file_order: VecDeque<FileKey>,
+    max_files: usize,
+    captures_per_sec: u32,
+    budget_window: Instant,
+    budget_left: u32,
+}
+
+impl Default for ExitSnapshots {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExitSnapshots {
+    pub fn new() -> Self {
+        Self {
+            enabled: true,
+            seen: HashSet::new(),
+            snapshots: HashMap::new(),
+            files: HashMap::new(),
+            file_order: VecDeque::new(),
+            max_files: DEFAULT_MAX_FILES,
+            captures_per_sec: DEFAULT_CAPTURES_PER_SEC,
+            budget_window: Instant::now(),
+            budget_left: DEFAULT_CAPTURES_PER_SEC,
+        }
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    /// Note a stack sample for `tgid`, capturing its executable mappings on
+    /// first sighting. Called from the stack-event hot path: the steady-state
+    /// cost is one HashSet lookup.
+    pub fn observe_tgid(&mut self, tgid: i32) {
+        if !self.enabled || tgid <= 0 {
+            return;
+        }
+        if !self.seen.insert(tgid) {
+            return;
+        }
+        let now = Instant::now();
+        if now.duration_since(self.budget_window).as_secs() >= 1 {
+            self.budget_window = now;
+            self.budget_left = self.captures_per_sec;
+        }
+        if self.budget_left == 0 {
+            // Over budget: the tgid stays marked seen and its frames keep the
+            // [exited] rendering if it dies — same as before this feature.
+            return;
+        }
+        self.budget_left -= 1;
+        if let Some(snapshot) = self.capture(tgid) {
+            if !snapshot.segments.is_empty() {
+                self.snapshots.insert(tgid, snapshot);
+            }
+        }
+    }
+
+    /// Resolve a user address for a (dead) process against its snapshot.
+    pub fn resolve(&self, tgid: i32, addr: u64) -> Option<ResolvedAddr> {
+        let snapshot = self.snapshots.get(&tgid)?;
+        let idx = snapshot
+            .segments
+            .partition_point(|segment| segment.end <= addr);
+        let segment = snapshot.segments.get(idx)?;
+        if addr < segment.start {
+            return None;
+        }
+        let pinned = self.files.get(&segment.file)?;
+        Some(ResolvedAddr {
+            elf_path: PathBuf::from(format!("/proc/self/fd/{}", pinned.file.as_raw_fd())),
+            file_offset: addr - segment.start + segment.file_offset,
+            module: pinned.display.clone(),
+        })
+    }
+
+    /// Whether a snapshot exists for `tgid`.
+    pub fn has_snapshot(&self, tgid: i32) -> bool {
+        self.snapshots.contains_key(&tgid)
+    }
+
+    /// Forget a tgid on exec. Exec replaced the address space, so an earlier
+    /// snapshot describes mappings that no longer exist — and worse than
+    /// being stale, it can overlap the new image's address ranges and
+    /// symbolize post-exec addresses to confidently wrong names. Because the
+    /// seen-set is one-attempt, the stale entry would also block the correct
+    /// re-capture. Dropping both lets the process's next stack sample
+    /// capture the new image; if it dies unsampled instead, its frames keep
+    /// the honest [exited] rendering. Pinned files stay until reset(): other
+    /// snapshots may share them, and the descriptor cap bounds the count.
+    pub fn forget_on_exec(&mut self, tgid: i32) {
+        self.seen.remove(&tgid);
+        self.snapshots.remove(&tgid);
+    }
+
+    /// Drop all snapshots and release every pinned descriptor. Called at the
+    /// end of each symbolization pass so continuous mode doesn't accumulate
+    /// descriptors across ticks.
+    pub fn reset(&mut self) {
+        self.seen.clear();
+        self.snapshots.clear();
+        self.files.clear();
+        self.file_order.clear();
+        self.budget_left = self.captures_per_sec;
+        self.budget_window = Instant::now();
+    }
+
+    fn capture(&mut self, tgid: i32) -> Option<ProcSnapshot> {
+        let maps = std::fs::read_to_string(format!("/proc/{tgid}/maps")).ok()?;
+        let mut segments = Vec::new();
+        for line in maps.lines() {
+            if segments.len() >= MAX_SEGMENTS_PER_PROC {
+                break;
+            }
+            let Some(parsed) = parse_exec_maps_line(line) else {
+                continue;
+            };
+            if self.pin_file(tgid, &parsed) {
+                segments.push(ExecSegment {
+                    start: parsed.start,
+                    end: parsed.end,
+                    file_offset: parsed.file_offset,
+                    file: parsed.file,
+                });
+            }
+        }
+        // /proc/<pid>/maps is sorted by address, but don't rely on it.
+        segments.sort_by_key(|segment| segment.start);
+        Some(ProcSnapshot { segments })
+    }
+
+    /// Ensure the backing file of a parsed mapping is pinned. Returns false
+    /// when the file cannot be opened (the segment is then not recorded and
+    /// its addresses keep the [exited] rendering).
+    fn pin_file(&mut self, tgid: i32, parsed: &ParsedMapsLine) -> bool {
+        if self.files.contains_key(&parsed.file) {
+            return true;
+        }
+        let Some(file) = open_mapping_file(tgid, parsed) else {
+            return false;
+        };
+        if self.files.len() >= self.max_files {
+            // A file evicted and later re-pinned leaves a stale key in the
+            // order queue; skip such entries until one actually evicts.
+            while let Some(oldest) = self.file_order.pop_front() {
+                if self.files.remove(&oldest).is_some() {
+                    break;
+                }
+            }
+        }
+        self.file_order.push_back(parsed.file);
+        self.files.insert(
+            parsed.file,
+            PinnedFile {
+                file,
+                display: parsed.display.clone(),
+            },
+        );
+        true
+    }
+}
+
+/// Open the backing file of an executable mapping.
+///
+/// The map_files link is the primary path: its entry names are unpadded hex,
+/// it re-opens the mapped file itself (namespace-independent, and it keeps
+/// working after the file is unlinked), and it is authoritative by
+/// construction so needs no verification. It requires CAP_SYS_ADMIN, so when
+/// it is unavailable (reduced-capability environments), fall back to the
+/// path through the process's root, then the plain path — each verified
+/// against the mapping's (device, inode) so a recycled or namespace-mismatched
+/// path can never pin the wrong file.
+fn open_mapping_file(tgid: i32, parsed: &ParsedMapsLine) -> Option<File> {
+    let link = format!("/proc/{tgid}/map_files/{:x}-{:x}", parsed.start, parsed.end);
+    if let Ok(file) = File::open(link) {
+        return Some(file);
+    }
+    for candidate in [
+        format!("/proc/{tgid}/root{}", parsed.path),
+        parsed.path.clone(),
+    ] {
+        if let Ok(file) = File::open(candidate) {
+            if file_key(&file) == Some(parsed.file) {
+                return Some(file);
+            }
+        }
+    }
+    None
+}
+
+/// (device, inode) of an open file, encoded like the maps-line key.
+fn file_key(file: &File) -> Option<FileKey> {
+    use std::os::unix::fs::MetadataExt;
+    let meta = file.metadata().ok()?;
+    let major = libc::major(meta.dev()) as u64;
+    let minor = libc::minor(meta.dev()) as u64;
+    Some(((major << 32) | minor, meta.ino()))
+}
+
+struct ParsedMapsLine {
+    start: u64,
+    end: u64,
+    file_offset: u64,
+    file: FileKey,
+    path: String,
+    display: String,
+}
+
+/// Parse one /proc/<pid>/maps line, returning Some only for executable,
+/// file-backed mappings: `start-end perms offset dev inode path`.
+fn parse_exec_maps_line(line: &str) -> Option<ParsedMapsLine> {
+    let mut fields = line.split_whitespace();
+    let range = fields.next()?;
+    let perms = fields.next()?;
+    let offset = fields.next()?;
+    let dev = fields.next()?;
+    let inode = fields.next()?;
+    let path = fields.next()?;
+
+    if !perms.contains('x') || !path.starts_with('/') {
+        return None;
+    }
+    let inode: u64 = inode.parse().ok()?;
+    if inode == 0 {
+        return None;
+    }
+
+    let (start, end) = range.split_once('-')?;
+    let start = u64::from_str_radix(start, 16).ok()?;
+    let end = u64::from_str_radix(end, 16).ok()?;
+    let file_offset = u64::from_str_radix(offset, 16).ok()?;
+
+    let (major, minor) = dev.split_once(':')?;
+    let major = u64::from_str_radix(major, 16).ok()?;
+    let minor = u64::from_str_radix(minor, 16).ok()?;
+
+    // Module display name: basename of the path field. When the binary has
+    // been unlinked (common for ephemeral CI files), the kernel appends a
+    // " (deleted)" marker that whitespace-splitting leaves in a trailing
+    // field we never read — and the pinned descriptor reads the unlinked
+    // file fine regardless.
+    let display = path.rsplit('/').next().unwrap_or(path).to_string();
+
+    Some(ParsedMapsLine {
+        start,
+        end,
+        file_offset,
+        file: ((major << 32) | minor, inode),
+        path: path.to_string(),
+        display,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_accepts_executable_file_mappings() {
+        let parsed = parse_exec_maps_line(
+            "7f2a1c400000-7f2a1c5b0000 r-xp 00028000 fd:01 1837462 /usr/lib/x86_64-linux-gnu/libc.so.6",
+        )
+        .expect("should parse");
+        assert_eq!(parsed.start, 0x7f2a1c400000);
+        assert_eq!(parsed.end, 0x7f2a1c5b0000);
+        assert_eq!(parsed.file_offset, 0x28000);
+        assert_eq!(parsed.file, ((0xfd << 32) | 0x01, 1837462));
+        assert_eq!(parsed.display, "libc.so.6");
+    }
+
+    #[test]
+    fn parse_rejects_non_executable_and_anonymous() {
+        // Data segment: not executable.
+        assert!(parse_exec_maps_line(
+            "7f2a1c5b0000-7f2a1c5b4000 r--p 001b0000 fd:01 1837462 /usr/lib/libc.so.6"
+        )
+        .is_none());
+        // Anonymous executable (JIT): no backing file to pin.
+        assert!(parse_exec_maps_line("7f2a1d000000-7f2a1d100000 rwxp 00000000 00:00 0").is_none());
+        // vdso: pseudo-path.
+        assert!(
+            parse_exec_maps_line("7ffe32bc0000-7ffe32bc2000 r-xp 00000000 00:00 0 [vdso]")
+                .is_none()
+        );
+        // Garbage.
+        assert!(parse_exec_maps_line("not a maps line").is_none());
+        assert!(parse_exec_maps_line("").is_none());
+    }
+
+    #[test]
+    fn parse_handles_deleted_and_plain_paths() {
+        let plain = parse_exec_maps_line(
+            "55d400000000-55d400001000 r-xp 00000000 fd:01 99 /tmp/build/prog",
+        )
+        .expect("should parse");
+        assert_eq!(plain.display, "prog");
+        // Unlinked binary: the kernel appends " (deleted)", which lands in a
+        // trailing field the parser never reads.
+        let deleted = parse_exec_maps_line(
+            "55d400000000-55d400001000 r-xp 00000000 fd:01 99 /tmp/build/prog (deleted)",
+        )
+        .expect("should parse");
+        assert_eq!(deleted.display, "prog");
+    }
+
+    #[test]
+    fn observe_respects_seen_and_budget() {
+        let mut snapshots = ExitSnapshots::new();
+        snapshots.captures_per_sec = 1;
+        snapshots.budget_left = 1;
+        // Own pid: capture succeeds against our real /proc.
+        let me = std::process::id() as i32;
+        snapshots.observe_tgid(me);
+        assert!(snapshots.has_snapshot(me), "own process should snapshot");
+        // Second observe of the same tgid is a no-op (seen).
+        snapshots.observe_tgid(me);
+        // Budget exhausted: a different tgid is skipped even if alive.
+        snapshots.budget_window = Instant::now(); // hold the window open
+        snapshots.observe_tgid(1);
+        assert!(
+            !snapshots.has_snapshot(1),
+            "over-budget tgid must be skipped"
+        );
+    }
+
+    #[test]
+    fn resolve_own_process_maps_to_file_offsets() {
+        let mut snapshots = ExitSnapshots::new();
+        let me = std::process::id() as i32;
+        snapshots.observe_tgid(me);
+        let snapshot = snapshots.snapshots.get(&me).expect("snapshot exists");
+        let segment = snapshot.segments.first().expect("has exec segments");
+        let (start, file_offset) = (segment.start, segment.file_offset);
+        let probe = start + 0x100;
+        let resolved = snapshots.resolve(me, probe).expect("resolves");
+        assert_eq!(resolved.file_offset, 0x100 + file_offset);
+        assert!(resolved.elf_path.starts_with("/proc/self/fd/"));
+        assert!(!resolved.module.is_empty());
+        // An address below every segment resolves to None.
+        assert!(snapshots.resolve(me, 0x1000).is_none());
+        // Unknown tgid resolves to None.
+        assert!(snapshots.resolve(-1, probe).is_none());
+    }
+
+    #[test]
+    fn reset_releases_everything() {
+        let mut snapshots = ExitSnapshots::new();
+        let me = std::process::id() as i32;
+        snapshots.observe_tgid(me);
+        assert!(snapshots.has_snapshot(me));
+        snapshots.reset();
+        assert!(!snapshots.has_snapshot(me));
+        assert!(snapshots.files.is_empty());
+        assert!(snapshots.seen.is_empty());
+        // Observable again after reset.
+        snapshots.observe_tgid(me);
+        assert!(snapshots.has_snapshot(me));
+    }
+
+    #[test]
+    fn forget_on_exec_drops_snapshot_and_allows_recapture() {
+        let mut snapshots = ExitSnapshots::new();
+        let me = std::process::id() as i32;
+        snapshots.observe_tgid(me);
+        assert!(snapshots.has_snapshot(me));
+        snapshots.forget_on_exec(me);
+        // Snapshot gone: post-exec addresses degrade to [exited] rather than
+        // resolving against the pre-exec image.
+        assert!(!snapshots.has_snapshot(me));
+        assert!(!snapshots.seen.contains(&me));
+        // The next sample re-captures (seen-set no longer blocks it), and a
+        // forgotten tgid's pinned files remain until reset().
+        snapshots.observe_tgid(me);
+        assert!(snapshots.has_snapshot(me));
+        // Unknown tgid is a no-op.
+        snapshots.forget_on_exec(-1);
+    }
+
+    #[test]
+    fn eviction_is_oldest_first_and_resolve_degrades() {
+        let mut snapshots = ExitSnapshots::new();
+        snapshots.max_files = 1;
+        let me = std::process::id() as i32;
+        snapshots.observe_tgid(me);
+        // With a cap of one file, only the newest pin survives; addresses in
+        // segments whose file was evicted resolve to None rather than
+        // erroring.
+        assert!(snapshots.files.len() <= 1);
+        let snapshot = snapshots.snapshots.get(&me).expect("snapshot exists");
+        let resolvable = snapshot
+            .segments
+            .iter()
+            .filter(|segment| snapshots.files.contains_key(&segment.file))
+            .count();
+        assert!(resolvable <= 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod validation;
 
 // Tracing modules (previously in binary only)
 pub mod events;
+pub mod exit_snapshot;
 pub mod gopclntab_resolver;
 pub mod gvisor_guest;
 pub mod marker_recorder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,11 @@ struct Command {
     /// to symbol-table-only resolution, which renders them as hex)
     #[arg(long)]
     no_gopclntab: bool,
+    /// Do not capture mapping snapshots at each process's first stack
+    /// sample (revert to rendering processes that exit before end-of-trace
+    /// symbolization as "[exited]")
+    #[arg(long)]
+    no_exited_recovery: bool,
     /// Resolve user-space symbols from ELF symbol tables only: skips DWARF
     /// debug info, source line info, inlined-function resolution, and
     /// debuginfod. Function names are unchanged for binaries that carry a
@@ -214,6 +219,7 @@ impl From<Command> for Config {
             no_frame_labels: cmd.no_frame_labels,
             no_gvisor_guest_maps: cmd.no_gvisor_guest_maps,
             no_gopclntab: cmd.no_gopclntab,
+            no_exited_recovery: cmd.no_exited_recovery,
             symbolize_names_only: cmd.symbolize_names_only,
             no_sched: cmd.no_sched,
             no_irq: cmd.no_irq,

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -3,10 +3,11 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
 
+use crate::exit_snapshot::ExitSnapshots;
 use crate::gvisor_guest::{GuestAddr, GuestProcess, SandboxIndex};
 use crate::pystacks::stack_walker::{PyAddr, StackWalkerRun};
 use crate::record::RecordCollector;
@@ -573,6 +574,14 @@ pub struct StackRecorder {
     /// mid-build) accumulates past any fixed budget — while the
     /// symbol-table path costs a few MiB per binary for identical names.
     names_only: bool,
+    /// Executable-mapping snapshots and pinned backing files, captured at
+    /// each process's first stack sample so processes that exit before
+    /// end-of-trace symbolization can still be symbolized. Shared: the
+    /// snapshot-hint drain thread observes (captures) and the exec-event
+    /// handler invalidates through [`StackRecorder::exit_snapshots_handle`];
+    /// this recorder observes as a fallback, resolves, and resets. See
+    /// [`crate::exit_snapshot`].
+    exit_snapshots: Arc<Mutex<ExitSnapshots>>,
 }
 
 impl ThreadAwareRecorder for StackRecorder {
@@ -603,12 +612,26 @@ impl StackRecorder {
             gvisor_guest_maps: true,
             gopclntab: true,
             names_only: false,
+            exit_snapshots: Arc::new(Mutex::new(ExitSnapshots::new())),
         }
+    }
+
+    /// Shared handle to the exited-process snapshot state, for the
+    /// snapshot-hint drain thread (timely capture) and the exec-event
+    /// handler (invalidation on exec).
+    pub fn exit_snapshots_handle(&self) -> Arc<Mutex<ExitSnapshots>> {
+        Arc::clone(&self.exit_snapshots)
     }
 
     /// Disable contextual labels on unresolvable frames (revert to bare hex).
     pub fn set_frame_labels(&mut self, enabled: bool) {
         self.frame_labels = enabled;
+    }
+
+    /// Disable first-sample mapping snapshots for post-mortem symbolization
+    /// of processes that exit before end-of-trace symbolization.
+    pub fn set_exited_recovery(&mut self, enabled: bool) {
+        self.exit_snapshots.lock().unwrap().set_enabled(enabled);
     }
 
     /// Disable `.gopclntab`-based symbolization of stripped Go binaries.
@@ -726,7 +749,12 @@ impl StackRecorder {
             .streaming_collector
             .take()
             .expect("streaming collector must be set");
-        self.finish_inner(own.as_mut())?;
+        let result = self.finish_inner(own.as_mut());
+        // Release pinned mapping descriptors whether or not symbolization
+        // succeeded: in continuous mode finish() runs every tick, and the
+        // next tick's processes get fresh snapshots.
+        self.exit_snapshots.lock().unwrap().reset();
+        result?;
         own.flush()?;
         own.finish_boxed()?;
         Ok(collector)
@@ -821,6 +849,7 @@ impl StackRecorder {
                 let frame_names = self.symbolize_stack_frames(
                     &mut symbolizer,
                     &stack,
+                    tgid,
                     None,
                     &kernel_src,
                     &mut kernel_cache,
@@ -935,6 +964,7 @@ impl StackRecorder {
                     let frame_names = self.symbolize_stack_frames(
                         &mut symbolizer,
                         &stack,
+                        tgid,
                         Some((&ctx, &mut user_cache)),
                         &kernel_src,
                         &mut kernel_cache,
@@ -1020,14 +1050,16 @@ impl StackRecorder {
     ///
     /// `user` carries the symbolization context and per-process address
     /// cache for a live process; `None` means the process has exited, in
-    /// which case user addresses cannot be symbolized (no /proc/<pid>/maps)
-    /// and are rendered as `unknown ([exited]) <addr>` (or raw hex with
-    /// labels disabled). Kernel addresses go through the shared
-    /// `kernel_cache`.
+    /// which case user addresses are resolved from the process's
+    /// first-sample mapping snapshot where one was captured (see
+    /// [`crate::exit_snapshot`]) and otherwise rendered as
+    /// `unknown ([exited]) <addr>` (or raw hex with labels disabled).
+    /// Kernel addresses go through the shared `kernel_cache`.
     fn symbolize_stack_frames(
         &self,
         symbolizer: &mut Symbolizer,
         stack: &Stack,
+        tgid: i32,
         user: Option<(&UserSymbolizeCtx<'_>, &mut HashMap<u64, String>)>,
         kernel_src: &Source<'_>,
         kernel_cache: &mut HashMap<u64, String>,
@@ -1056,7 +1088,29 @@ impl StackRecorder {
                 }
             }
             None => {
+                // One lock per dead-process stack rather than per frame; the
+                // hint drain thread only contends while this pass runs.
+                let exit_snapshots = self.exit_snapshots.lock().unwrap();
                 for &addr in &stack.user_stack {
+                    if let Some(resolved) = exit_snapshots.resolve(tgid, addr) {
+                        let mut elf = Elf::new(&resolved.elf_path);
+                        elf.debug_syms = !self.names_only;
+                        let elf_src = Source::Elf(elf);
+                        if let Some(sym) = symbolizer
+                            .symbolize_single(&elf_src, Input::FileOffset(resolved.file_offset))
+                            .ok()
+                            .and_then(|s| s.into_sym())
+                        {
+                            // sym.module would render the /proc/self/fd link;
+                            // report the binary the mapping belonged to.
+                            frame_names.push(format_symbolized_frame_forced_module(
+                                &sym,
+                                addr,
+                                &resolved.module,
+                            ));
+                            continue;
+                        }
+                    }
                     if self.frame_labels {
                         frame_names.push(format!("unknown ([exited]) <{addr:#x}>"));
                     } else {
@@ -1219,6 +1273,14 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
             let ustack_vec = Vec::from(&event.user_stack[..event.user_stack_length as usize]);
             let stack_key = (event.task.tgidpid >> 32) as i32;
             let py_stack = self.psr.get_pystack_from_event(&event);
+
+            // First sample from a process: it is on-CPU right now, so this
+            // is the earliest (and often only) chance to capture its
+            // mappings before it exits. Steady-state cost is one hash
+            // lookup per event.
+            if event.user_stack_length > 0 {
+                self.exit_snapshots.lock().unwrap().observe_tgid(stack_key);
+            }
 
             let stack = Stack::new(&kstack_vec, &ustack_vec, &py_stack);
             let tid = event.task.tgidpid as i32;

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -521,8 +521,10 @@ pub fn get_required_bpf_programs(
         required.insert("systing_sched_process_fork");
     }
 
-    // Pystacks with PID filtering needs exec tracking to discover new Python processes
-    if collect_pystacks && !opts.pid.is_empty() {
+    // Pystacks with PID filtering needs exec tracking to discover new Python
+    // processes; exited recovery needs it unconditionally, to invalidate
+    // mapping snapshots when exec replaces a process's address space.
+    if (collect_pystacks && !opts.pid.is_empty()) || exited_recovery_enabled(opts) {
         required.insert("systing_sched_process_exec");
     }
 
@@ -590,6 +592,10 @@ pub struct Config {
     pub no_gvisor_guest_maps: bool,
     /// Do not symbolize stripped Go binaries from their `.gopclntab`
     pub no_gopclntab: bool,
+    /// Do not capture first-sample mapping snapshots for post-mortem
+    /// symbolization of processes that exit before end-of-trace
+    /// symbolization
+    pub no_exited_recovery: bool,
     /// Resolve user-space symbols from ELF symbol tables only (no DWARF
     /// debug info, line info, inlined functions, or debuginfod)
     pub symbolize_names_only: bool,
@@ -677,6 +683,7 @@ impl Default for Config {
             no_frame_labels: false,
             no_gvisor_guest_maps: false,
             no_gopclntab: false,
+            no_exited_recovery: false,
             symbolize_names_only: false,
             no_sched: false,
             no_irq: false,
@@ -813,7 +820,9 @@ unsafe impl Plain for memory_event_header {}
 
 /// BPF exec/fork event - delivered via the `ringbuf_exec_events` ringbuf when
 /// a traced process execs (any traced task) or forks (Python parents only).
-/// Used to dynamically keep pystacks discovery in sync with the process tree.
+/// Two consumers in handle_exec_events(): pystacks discovery updates, and
+/// exited-recovery mapping-snapshot invalidation (exec replaces the address
+/// space, so a snapshot of the old image must be dropped).
 /// Layout must match `struct exec_event` in `systing_system.bpf.c`.
 #[repr(C)]
 #[derive(Default, Clone, Copy)]
@@ -828,6 +837,19 @@ struct exec_event {
     is_fork: u32,
 }
 unsafe impl Plain for exec_event {}
+
+/// Snapshot hint - delivered via the `ringbuf_snapshot_hints` ringbuf for
+/// every stack sample with a user stack (rodata-gated on exited recovery).
+/// Layout must match `struct snapshot_hint` in `systing_system.bpf.c`.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+#[allow(non_camel_case_types)]
+struct snapshot_hint {
+    tgid: u32,
+    /// Explicit padding, zeroed by the BPF side.
+    reserved: u32,
+}
+unsafe impl Plain for snapshot_hint {}
 
 /// Trait for events that can be recorded in a ring buffer.
 pub trait SystingRecordEvent<T>: crate::utid::ThreadAwareRecorder {
@@ -1116,6 +1138,13 @@ struct RecorderChannels {
     memory_rx: Receiver<memory_event>,
     marker_rx: Receiver<marker_event>,
     exec_event_rx: Option<Receiver<exec_event>>,
+    /// Snapshot hints: one tiny event per stack sample with a user stack,
+    /// drained by a dedicated thread that captures exited-recovery mapping
+    /// snapshots on first sight of a tgid. Dedicated because the stack_rx
+    /// consumer can run seconds behind under load, and a short-lived process
+    /// is gone before its first sample is consumed from there. Present only
+    /// when exited recovery is enabled.
+    snapshot_hint_rx: Option<Receiver<snapshot_hint>>,
     /// Python symbol records emitted by BPF on first sight of a symbol;
     /// consumed by the pystack_symbol_loader thread, which interns them and
     /// updates the BPF gate map. Present only when pystacks is enabled.
@@ -1507,6 +1536,13 @@ fn configure_recorder(opts: &Config, recorder: &Arc<SessionRecorder>) {
     if opts.no_gopclntab {
         recorder.stack_recorder.lock().unwrap().set_gopclntab(false);
     }
+    if opts.no_exited_recovery {
+        recorder
+            .stack_recorder
+            .lock()
+            .unwrap()
+            .set_exited_recovery(false);
+    }
     if opts.symbolize_names_only {
         recorder.stack_recorder.lock().unwrap().set_names_only(true);
         if opts.enable_debuginfod {
@@ -1712,6 +1748,7 @@ fn handle_exec_events(
     psr: Arc<crate::pystacks::stack_walker::StackWalkerRun>,
     pids_map: libbpf_rs::MapHandle,
     pystacks_debug: bool,
+    exit_snapshots: Arc<Mutex<crate::exit_snapshot::ExitSnapshots>>,
 ) {
     // Pids we've successfully registered with pystacks. Used only to keep the
     // logging quiet on repeat events; it does NOT short-circuit re-discovery,
@@ -1725,6 +1762,14 @@ fn handle_exec_events(
     while let Ok(event) = exec_rx.recv() {
         let pid = event.pid;
         let is_fork = event.is_fork != 0;
+        // Exec replaced the address space: drop any first-sample mapping
+        // snapshot BEFORE anything that can bail on this event — the process
+        // may already be gone (readlink below fails), but its stale snapshot
+        // must still die, or dead post-exec addresses resolve against the
+        // wrong image. Forks are new tgids with no snapshot to drop.
+        if !is_fork {
+            exit_snapshots.lock().unwrap().forget_on_exec(pid as i32);
+        }
         let kind = if is_fork { "Fork" } else { "Exec" };
         let Ok(exe) = std::fs::read_link(format!("/proc/{pid}/exe")) else {
             if pystacks_debug {
@@ -1983,6 +2028,8 @@ fn setup_ringbuffers<'a>(
     let (marker_tx, marker_rx) = sync_channel(CHANNEL_CAPACITY);
     let (exec_tx, exec_rx) = sync_channel(CHANNEL_CAPACITY);
     let mut has_exec_ringbuf = false;
+    let (snapshot_hint_tx, snapshot_hint_rx) = sync_channel(CHANNEL_CAPACITY);
+    let mut has_snapshot_hint_ringbuf = false;
 
     let object = skel.object();
 
@@ -2023,8 +2070,10 @@ fn setup_ringbuffers<'a>(
         }
     }
 
-    let mut pysym_rx = None;
-    if collect_pystacks {
+    // The exec ringbuf feeds two consumers via one handler: pystacks
+    // re-discovery and exited-recovery snapshot invalidation. Drain it when
+    // either is on.
+    if collect_pystacks || exited_recovery_enabled(opts) {
         for map in object.maps() {
             if map.name().to_str().unwrap() == "ringbuf_exec_events" {
                 let ring = create_ring::<exec_event>(&map, exec_tx.clone())?;
@@ -2033,7 +2082,21 @@ fn setup_ringbuffers<'a>(
                 break;
             }
         }
+    }
 
+    if exited_recovery_enabled(opts) {
+        for map in object.maps() {
+            if map.name().to_str().unwrap() == "ringbuf_snapshot_hints" {
+                let ring = create_ring::<snapshot_hint>(&map, snapshot_hint_tx.clone())?;
+                rings.push(("ringbuf_snapshot_hints".to_string(), ring));
+                has_snapshot_hint_ringbuf = true;
+                break;
+            }
+        }
+    }
+
+    let mut pysym_rx = None;
+    if collect_pystacks {
         for map in object.maps() {
             if map.name().to_str().unwrap() == "ringbuf_pysym_events" {
                 let (pysym_tx, rx) = sync_channel(CHANNEL_CAPACITY);
@@ -2066,6 +2129,11 @@ fn setup_ringbuffers<'a>(
     } else {
         None
     };
+    let snapshot_hint_rx = if has_snapshot_hint_ringbuf {
+        Some(snapshot_hint_rx)
+    } else {
+        None
+    };
 
     let channels = RecorderChannels {
         event_rxs,
@@ -2078,6 +2146,7 @@ fn setup_ringbuffers<'a>(
         epoll_rx,
         marker_rx,
         exec_event_rx,
+        snapshot_hint_rx,
         pysym_rx,
     };
 
@@ -2169,6 +2238,14 @@ fn warn_failed_probe_attachments(skel: &SystingSystemSkel) {
     }
 }
 
+/// Whether exited-process recovery is active: first-sample mapping snapshots
+/// are captured (snapshot-hint lane plus the stack consumer as fallback) and
+/// invalidated on exec. Off when stack traces are off entirely — with no
+/// user stacks recorded there is nothing to symbolize post-mortem.
+fn exited_recovery_enabled(opts: &Config) -> bool {
+    !opts.no_exited_recovery && !opts.no_stack_traces
+}
+
 fn configure_bpf_skeleton(
     open_skel: &mut OpenSystingSystemSkel,
     opts: &Config,
@@ -2225,6 +2302,9 @@ fn configure_bpf_skeleton(
         }
         if collect_pystacks {
             rodata.tool_config.collect_pystacks = 1;
+        }
+        if exited_recovery_enabled(opts) {
+            rodata.tool_config.collect_exited_recovery = 1;
         }
         if opts.syscalls {
             rodata.tool_config.collect_syscalls = 1;
@@ -2325,6 +2405,23 @@ fn configure_bpf_skeleton(
                 map.set_max_entries(1)
                     .with_context(|| format!("Failed to shrink '{name}'"))?;
             }
+        }
+        // Same constraint family: the snapshot-hint ringbuf is referenced by
+        // the always-loaded stack programs (rodata-gated via
+        // tool_config.collect_exited_recovery) and the exec ringbuf by the
+        // pid-filter-loaded fork program, so neither can be autocreate=false;
+        // shrink them when their consumers are off.
+        if !exited_recovery_enabled(opts) && name == "ringbuf_snapshot_hints" {
+            map.set_max_entries(page_size)
+                .with_context(|| format!("Failed to shrink '{name}'"))?;
+        }
+        if !exited_recovery_enabled(opts) && name == "recovery_hinted_tgids" {
+            map.set_max_entries(1)
+                .with_context(|| format!("Failed to shrink '{name}'"))?;
+        }
+        if !collect_pystacks && !exited_recovery_enabled(opts) && name == "ringbuf_exec_events" {
+            map.set_max_entries(page_size)
+                .with_context(|| format!("Failed to shrink '{name}'"))?;
         }
     }
 
@@ -3087,6 +3184,7 @@ struct ThreadHandles {
     discovery_thread: thread::JoinHandle<i32>,
     symbol_loader_thread: thread::JoinHandle<i32>,
     exec_handler_thread: Option<thread::JoinHandle<()>>,
+    snapshot_hint_thread: Option<thread::JoinHandle<()>>,
     tpu_metrics_thread: Option<thread::JoinHandle<i32>>,
     task_info_tx: Sender<task_info>,
 }
@@ -3188,10 +3286,14 @@ fn run_tracing_loop(
     for thread in handles.ringbuf_threads {
         thread.join().expect("Failed to join thread");
     }
-    // The exec handler thread reads from a channel fed by ringbuf callbacks,
-    // so it terminates after ringbuf threads exit and senders are dropped.
+    // The exec handler and snapshot-hint threads read from channels fed by
+    // ringbuf callbacks, so they terminate after ringbuf threads exit and
+    // senders are dropped.
     if let Some(thread) = handles.exec_handler_thread {
         thread.join().expect("Failed to join exec handler thread");
+    }
+    if let Some(thread) = handles.snapshot_hint_thread {
+        thread.join().expect("Failed to join snapshot hint thread");
     }
     shutdown_signal.store(true, Ordering::Relaxed);
     if let Some(thread) = handles.sysinfo_thread {
@@ -3515,6 +3617,7 @@ pub fn systing(
         // Take exec_event_rx/pysym_rx out before channels is moved into
         // spawn_recorder_threads
         let exec_event_rx = channels.exec_event_rx.take();
+        let snapshot_hint_rx = channels.snapshot_hint_rx.take();
         let pysym_rx = channels.pysym_rx.take();
 
         // Create shutdown signal for receiver threads
@@ -3631,11 +3734,50 @@ pub fn systing(
             let pystacks_debug = opts.pystacks_debug;
             let pids_map = libbpf_rs::MapHandle::try_from(&skel.maps.pids)
                 .context("Failed to get handle to BPF pids map")?;
+            let exec_exit_snapshots = recorder
+                .stack_recorder
+                .lock()
+                .unwrap()
+                .exit_snapshots_handle();
             exec_handler_thread = Some(
                 thread::Builder::new()
                     .name("pystacks_exec_handler".to_string())
                     .spawn(move || {
-                        handle_exec_events(exec_rx, exec_psr, pids_map, pystacks_debug);
+                        handle_exec_events(
+                            exec_rx,
+                            exec_psr,
+                            pids_map,
+                            pystacks_debug,
+                            exec_exit_snapshots,
+                        );
+                    })?,
+            );
+        }
+
+        // Drain snapshot hints on a dedicated thread: capture latency must
+        // not depend on the stack consumer's queue depth — under load that
+        // queue runs seconds behind, and a short-lived process is gone
+        // before its first sample is consumed from it. This thread does one
+        // hash lookup per hint (and one /proc read per NEW tgid), so it
+        // stays caught up. Like the exec handler, it exits when the ringbuf
+        // threads are joined and the channel senders drop.
+        let mut snapshot_hint_thread: Option<thread::JoinHandle<()>> = None;
+        if let Some(hint_rx) = snapshot_hint_rx {
+            let hint_exit_snapshots = recorder
+                .stack_recorder
+                .lock()
+                .unwrap()
+                .exit_snapshots_handle();
+            snapshot_hint_thread = Some(
+                thread::Builder::new()
+                    .name("exit_snapshot_hint".to_string())
+                    .spawn(move || {
+                        while let Ok(hint) = hint_rx.recv() {
+                            hint_exit_snapshots
+                                .lock()
+                                .unwrap()
+                                .observe_tgid(hint.tgid as i32);
+                        }
                     })?,
             );
         }
@@ -3904,6 +4046,7 @@ pub fn systing(
             discovery_thread,
             symbol_loader_thread: symbol_thread,
             exec_handler_thread,
+            snapshot_hint_thread,
             task_info_tx,
             tpu_metrics_thread,
         };

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -4273,3 +4273,160 @@ fn test_e2e_only_cpu_stacks_emits_samples() {
         );
     }
 }
+
+/// Not a real test: a busy-loop child process for
+/// test_exited_process_recovery, run as systing's traced command via
+/// `<test-binary> --exact burner_helper_busy_loop`. Deliberately NOT
+/// `#[ignore]`: the VM integration runner selects ignored tests
+/// (`--ignored`), and this helper must be excluded there while staying
+/// spawnable by exact name. The loop is wall-clock bound (not iteration
+/// bound) so TCG slowdown cannot shrink its lifetime, and two seconds is
+/// enough on-CPU time for the sampler and the first-sample snapshot even
+/// when the consumer side lags. The test binary carries a full symbol
+/// table, so samples landing here are name-resolvable if (and only if)
+/// symbolization has something to resolve against.
+#[test]
+fn burner_helper_busy_loop() {
+    use std::time::{Duration, Instant};
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut counter: u64 = 0;
+    while Instant::now() < deadline {
+        counter = std::hint::black_box(counter.wrapping_add(1));
+    }
+    assert!(counter > 0);
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_exited_process_recovery() {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
+    use std::time::Instant;
+    use systing::traced_command::spawn_traced_child;
+
+    // Record one trace of a single short-lived burner child and count how
+    // its frames rendered. Returns (burner_named_frames, exited_frames).
+    //
+    // The burner runs as systing's traced command, which pins the whole
+    // lifecycle to events instead of machine-speed guesses (QEMU TCG
+    // stretches BPF setup to tens of seconds): the forked child blocks
+    // until tracing is attached before it execs, so the burner cannot burn
+    // out before the window opens, and the recording stops because the
+    // child exited and was reaped (waitpid plus a drain delay), so the
+    // burner is gone from /proc before end-of-trace symbolization runs.
+    // Any name-resolved burner frame can therefore only come from the
+    // first-sample mapping snapshot, on any machine speed. This is also
+    // the population the feature exists for:
+    // `systing record -- short_lived_command`.
+    fn record_and_count(no_exited_recovery: bool) -> (usize, usize) {
+        let dir = TempDir::new().expect("Failed to create temp dir");
+        let trace_path = dir.path().join("trace.pb");
+        let own_binary = std::env::current_exe().expect("current_exe");
+
+        let child = spawn_traced_child(&[
+            own_binary
+                .to_str()
+                .expect("test binary path not utf-8")
+                .to_string(),
+            "--exact".to_string(),
+            "burner_helper_busy_loop".to_string(),
+        ])
+        .expect("failed to fork burner child");
+
+        let start = Instant::now();
+        let config = Config {
+            duration: 300, // backstop only: the child's exit stops the trace
+            no_exited_recovery,
+            output_dir: dir.path().to_path_buf(),
+            output: trace_path,
+            ..Config::default()
+        };
+        systing(config, Some(child)).expect("systing recording failed");
+        let elapsed = start.elapsed();
+        eprintln!("  recording stopped after {:.1}s", elapsed.as_secs_f64());
+        assert!(
+            elapsed < SLOW_MACHINE_BUDGET,
+            "recording should stop when the burner exits; took {:.1}s \
+             (duration backstop reached - child-exit stop broken?)",
+            elapsed.as_secs_f64()
+        );
+
+        let stack_parquet = dir.path().join("stack.parquet");
+        assert!(
+            stack_parquet.exists(),
+            "[exited recovery] stack.parquet not found"
+        );
+        let file = File::open(&stack_parquet).expect("Failed to open stack.parquet");
+        let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .expect("Failed to create reader")
+            .build()
+            .expect("Failed to build reader");
+
+        let mut burner_named = 0usize;
+        let mut exited = 0usize;
+        for batch_result in reader {
+            let batch = batch_result.expect("Failed to read batch");
+            let Some(frame_names_col) = batch.column_by_name("frame_names") else {
+                continue;
+            };
+            use arrow::array::{ListArray, StringArray};
+            let list_array = frame_names_col
+                .as_any()
+                .downcast_ref::<ListArray>()
+                .expect("frame_names should be a ListArray");
+            for i in 0..list_array.len() {
+                if list_array.is_null(i) {
+                    continue;
+                }
+                let inner = list_array.value(i);
+                let string_array = inner
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("frame_names inner should be StringArray");
+                for j in 0..string_array.len() {
+                    if string_array.is_null(j) {
+                        continue;
+                    }
+                    let frame = string_array.value(j);
+                    if frame.contains("burner_helper_busy_loop") {
+                        burner_named += 1;
+                    }
+                    if frame.contains("[exited]") {
+                        exited += 1;
+                    }
+                }
+            }
+        }
+        (burner_named, exited)
+    }
+
+    // Negative control first: with recovery disabled, the burner must have
+    // been sampled (its pid renders [exited] frames) and none of its frames
+    // may carry a resolved name - this proves both that the traced child
+    // gets sampled and that it is reliably gone by symbolization time,
+    // which run 2 inherits.
+    eprintln!("Recording with --no-exited-recovery (negative control)...");
+    let (named_off, exited_off) = record_and_count(true);
+    eprintln!("  control: burner_named={named_off} exited_frames={exited_off}");
+    assert!(
+        exited_off > 0,
+        "[exited recovery control] expected [exited] frames from the dead burner, got none \
+         (burner not sampled? sampling misconfigured?)"
+    );
+    assert_eq!(
+        named_off, 0,
+        "[exited recovery control] burner frames resolved with recovery disabled - \
+         the burner survived to the live pass, control is invalid"
+    );
+
+    // With recovery enabled (default), the same dead burner resolves by name
+    // from its first-sample mapping snapshot.
+    eprintln!("Recording with exited recovery enabled...");
+    let (named_on, exited_on) = record_and_count(false);
+    eprintln!("  recovery: burner_named={named_on} exited_frames={exited_on}");
+    assert!(
+        named_on > 0,
+        "[exited recovery] no burner frames resolved by name; first-sample \
+         snapshot recovery is not working ({exited_on} [exited] frames present)"
+    );
+}


### PR DESCRIPTION
Stacks are symbolized at end of trace, and processes that die before
then render every user frame as `unknown ([exited])`: blazesym needs
`/proc/<pid>/maps`, which is gone by then. On fork/exec-heavy hosts
(build and CI machines) the `[exited]` class can be the single largest
leaf in the profile — short-lived compilers, shells, and test children
dominate exactly the workloads being profiled.

## Fix: snapshot at first sample, on a dedicated fast lane

The first stack sample for a tgid proves the process is on-CPU and
alive — that is the earliest (and often only) chance to capture its
mappings. The new `exit_snapshot` module captures the process's
executable file-backed mappings and pins each backing file with a
read-only descriptor, deduplicated by (device, inode). At end-of-trace
symbolization, a dead tgid with a snapshot resolves user addresses to
(pinned file, file offset) and symbolizes through `/proc/self/fd/<n>`
— the same `Source::Elf` + `Input::FileOffset` path the sandbox island
bridging uses — with the frame's module reported as the original
binary basename. Addresses that miss the snapshot keep the `[exited]`
rendering.

The capture cannot ride the stack-event consumer: that queue runs
seconds behind under load, and a short-lived process is gone before
its first sample is consumed from it — the busier the host, the deeper
the queue, and the motivating workloads are the busy ones. BPF
therefore emits a tiny sidecar hint (the tgid) per user-stack sample
into its own ringbuf, drained by a dedicated thread that does nothing
but observe tgids and capture on first sight, so capture latency is
independent of the main queue's depth. Hints are advisory: a dropped
hint costs capture latency (the stack consumer makes the same
observation when it gets there), never correctness.

### Exec invalidates snapshots

A process sampled before exec and again after it would otherwise
resolve post-exec addresses against the pre-exec image — confidently
wrong names, worse than an honest `[exited]` — and the
one-attempt-per-tgid rule would block the correct re-capture. The
existing `sched_process_exec` program already notifies userspace for
pystacks re-discovery; it now runs (and its ringbuf is drained)
whenever either pystacks or exited recovery is enabled — the pystacks
config clearing stays pystacks-gated — and the handler drops the
tgid's snapshot before anything that can bail on the event, so even an
exec-then-exit leaves no stale snapshot behind. Either interleaving of
hint and exec event degrades safely: at worst the process re-captures
on its next sample, or its frames keep the `[exited]` rendering.

### Pinning

`/proc/<pid>/map_files/<range>` is the primary path: namespace-
independent, unlink-proof (ephemeral CI binaries are often deleted
before symbolization), and authoritative by construction. Where it is
unavailable (reduced-capability environments), pinning falls back to
the path through `/proc/<pid>/root`, then the plain path — each
verified against the mapping's (device, inode), so a recycled or
namespace-mismatched path can never pin the wrong file.

### Bounded on every axis

Every limit degrades to the existing `[exited]` rendering, never to an
error: one capture attempt per tgid; a per-second capture budget (fork
storms beyond it keep today's behavior for the overflow); a per-process
segment cap; a global pinned-descriptor cap (512, below common
RLIMIT_NOFILE soft limits) with oldest-first eviction; a 64KB hint
ringbuf whose overflow only defers capture to the stack consumer; an
8192-entry seen-tgid LRU whose eviction of a live tgid merely re-hints
once (the consumer's one-attempt rule absorbs the duplicate). All
snapshots and descriptors are released at the end of each
symbolization pass, so continuous mode starts every tick fresh and
never accumulates descriptors across ticks.

### Hot-path cost, measured

Enabling recovery costs where the feature delivers — at end-of-trace
symbolization — not on the hot path. Instrumented runs on an
allocation-heavy integration test (per-program `bpf_stats`
run_time/run_cnt, per-thread CPU, and `/proc/stat` phase timelines
sampled inside the test VM; receipts in the results comment) show:

- The recording phase and total BPF program time are at parity with
  recovery disabled. Four hot-path gating variants (per-sample
  emission, LRU-gated, LRU + per-cpu cache, plain-hash gate) landed in
  one scattered wall-clock band with no ordering by mechanism — the
  per-sample hot path is not a measurable term on this rig.
- The entire enable-delta sits in the post-recording, single-threaded
  end-of-trace phase: resolving the dead process's stacks through its
  snapshot does the ELF parsing and symbol lookup that the `[exited]`
  rendering never paid. The run-to-run scatter tracks how much each
  run's captures actually resolve.

That makes the cost a trade, not a tax: the delta scales with the
number of processes actually recovered — it is the price of the names
delivered, paid only where the profile would otherwise read
`[exited]` — and it is bounded by the existing caps (one attempt per
tgid, the per-second capture budget, the segment cap, the
512-descriptor cap). In continuous mode it rides the per-tick
symbolization pass that already exists and releases everything at
tick end. The emulated rig amplifies constants 10-20x — the
transferable result is the phase attribution, not the absolute
seconds.

The hint lane itself stays out of the per-sample picture by design:
emission is LRU-gated to once per tgid lifetime (wasted ringbuf
traffic and consumer wakeups are never generated), the mark is
written only after a successful submit so a failed reserve retries on
the next sample, racing duplicates are absorbed by the consumer's
one-attempt rule, and exec deletes the entry so a replaced address
space re-hints even if its exec event was dropped. Capture is one
maps read plus a handful of opens, once per new process,
budget-capped. When disabled, the hint ringbuf and the LRU shrink to
minimum size and the BPF hint path is compiled out by the rodata
gate.

`--no-exited-recovery` reverts to the previous behavior.

### Known limitation: tgid recycling

Snapshots are keyed by tgid. A tgid recycled within one trace (or one
continuous-mode tick) after its original owner died — and whose new
owner also dies before symbolization — can resolve against the old
owner's snapshot; under ASLR that yields wrong names rather than an
honest `[exited]`. The window needs pid-space wrap-around while a
trace is open, which is realistic only on fork-storm hosts with the
default `pid_max` of 32768 (~30s at 1000 forks/s). A follow-up can
close it by keying snapshots by (tgid, start_time) and sealing on the
exit event that userspace already receives; kept out of this PR to
hold the review surface down.

## Validation

- New integration test with its negative control run first: the burner
  (the test binary re-invoking itself, full symbol table) runs as
  systing's traced command, so it execs only after tracing is attached
  and the recording stops because the burner exited and was reaped —
  sampled-while-alive and gone-by-symbolization hold by construction at
  any machine speed, not by timing margins. With recovery disabled the
  dead burner must produce `[exited]` frames and zero named frames;
  with recovery enabled the same burner must resolve by name. The test
  fails against the consumer-side capture alone and passes with the
  hint lane, so it guards the latency property, not just the happy
  path.
- 8 unit tests on the snapshot module: maps-line parsing (executable
  file-backed only, deleted-marker handling), budget and seen-tgid
  behavior, resolution arithmetic against the test's own live process,
  reset semantics, eviction degradation, exec invalidation and
  re-capture.
- 428/428 lib tests; `clippy -D warnings` and `fmt` clean.
- Full vng integration gate green on this branch (per-target results in
  the comment below).

## Expected effect

On a busy CI host we measured the `[exited]` leaf as the single largest
attribution class; after this change it should shrink to the residue of
processes whose entire life fits inside the hint drain's wakeup latency
plus over-budget fork-storm overflow. The before/after is directly
observable in any profile view of a fork/exec-heavy host.
