### PR TITLE
Add --symbolize-elide-generics to bound pathological symbol names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod sched;
 pub mod session_recorder;
 pub mod stack_recorder;
 pub mod stream;
+pub mod symbol_shorten;
 pub mod systing_core;
 pub mod tpu;
 pub mod trace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,15 @@ struct Command {
     /// GiBs.
     #[arg(long)]
     symbolize_names_only: bool,
+    /// Collapse generic/template argument groups in over-long symbol names:
+    /// names longer than 256 bytes render as `path::func<...>` instead of
+    /// carrying the full monomorphized argument list, keeping their path
+    /// head and function segment. Deeply generic Rust and C++ names
+    /// legitimately demangle to multi-kilobyte strings; one hot name
+    /// repeated across millions of recorded frames dominates recorder
+    /// memory and trace size. Names of 256 bytes or less are unchanged.
+    #[arg(long)]
+    symbolize_elide_generics: bool,
     /// Disable scheduler event tracing (sched_* tracepoints and scheduler event recorder)
     #[arg(long)]
     no_sched: bool,
@@ -227,6 +236,7 @@ impl From<Command> for Config {
             no_gopclntab: cmd.no_gopclntab,
             no_exited_recovery: cmd.no_exited_recovery,
             symbolize_names_only: cmd.symbolize_names_only,
+            symbolize_elide_generics: cmd.symbolize_elide_generics,
             no_sched: cmd.no_sched,
             no_irq: cmd.no_irq,
             syscalls: cmd.syscalls,

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -574,6 +574,16 @@ pub struct StackRecorder {
     /// mid-build) accumulates past any fixed budget — while the
     /// symbol-table path costs a few MiB per binary for identical names.
     names_only: bool,
+    /// When set, symbol names longer than
+    /// [`crate::symbol_shorten::ELIDE_GATE`] bytes have their generic /
+    /// template argument groups collapsed (`a::b<X<Y>, Z>::c(P)` renders
+    /// as `a::b<...>::c(...)`). Deeply monomorphized Rust and C++ names
+    /// legitimately demangle to multi-KiB strings; with stacks
+    /// materialized as per-frame strings, one hot kilobyte-scale name
+    /// repeated across millions of frames dominates recorder memory and
+    /// trace size. Shorter names are unchanged; longer names keep their
+    /// path head and function segment. See [`crate::symbol_shorten`].
+    elide_generics: bool,
     /// Executable-mapping snapshots and pinned backing files, captured at
     /// each process's first stack sample so processes that exit before
     /// end-of-trace symbolization can still be symbolized. Shared: the
@@ -612,6 +622,7 @@ impl StackRecorder {
             gvisor_guest_maps: true,
             gopclntab: true,
             names_only: false,
+            elide_generics: false,
             exit_snapshots: Arc::new(Mutex::new(ExitSnapshots::new())),
         }
     }
@@ -643,6 +654,12 @@ impl StackRecorder {
     /// `names_only` field docs for what is kept and what is lost).
     pub fn set_names_only(&mut self, enabled: bool) {
         self.names_only = enabled;
+    }
+
+    /// Collapse generic/template argument groups in over-long symbol
+    /// names (see the `elide_generics` field docs).
+    pub fn set_elide_generics(&mut self, enabled: bool) {
+        self.elide_generics = enabled;
     }
 
     /// Disable querying gVisor control sockets for guest maps.
@@ -1000,7 +1017,7 @@ impl StackRecorder {
             .ok()
             .and_then(|s| s.into_sym())
         {
-            return format_symbolized_frame(&sym, addr, "unknown");
+            return format_symbolized_frame(&sym, addr, "unknown", self.elide_generics);
         }
 
         if let Some(bridge) = ctx.maps.and_then(|m| m.bridge_for(addr)) {
@@ -1014,7 +1031,12 @@ impl StackRecorder {
             {
                 // sym.module would render the map_files link; report the
                 // original binary the island belongs to instead.
-                return format_symbolized_frame_forced_module(&sym, addr, &bridge.module_name);
+                return format_symbolized_frame_forced_module(
+                    &sym,
+                    addr,
+                    &bridge.module_name,
+                    self.elide_generics,
+                );
             }
         }
 
@@ -1107,6 +1129,7 @@ impl StackRecorder {
                                 &sym,
                                 addr,
                                 &resolved.module,
+                                self.elide_generics,
                             ));
                             continue;
                         }
@@ -1129,7 +1152,7 @@ impl StackRecorder {
                         .symbolize_single(kernel_src, Input::AbsAddr(addr))
                         .ok()
                         .and_then(|s| s.into_sym())
-                        .map(|s| format_symbolized_frame(&s, addr, "[kernel]"))
+                        .map(|s| format_symbolized_frame(&s, addr, "[kernel]", self.elide_generics))
                         .unwrap_or_else(|| format!("unknown ([kernel]) <{addr:#x}>"))
                 })
                 .clone();
@@ -1162,7 +1185,16 @@ fn format_location_info(code_info: Option<&blazesym::symbolize::CodeInfo>) -> St
 
 /// Formats a symbolized frame as a string with module and location info.
 /// Format: "function_name (module_name [file:line]) <0xaddr>"
-fn format_symbolized_frame(sym: &Sym, addr: u64, default_module: &str) -> String {
+///
+/// With `elide_generics` set, over-long function names have their
+/// generic/template argument groups collapsed first (see
+/// [`crate::symbol_shorten`]).
+fn format_symbolized_frame(
+    sym: &Sym,
+    addr: u64,
+    default_module: &str,
+    elide_generics: bool,
+) -> String {
     let module_name = sym
         .module
         .as_ref()
@@ -1170,19 +1202,27 @@ fn format_symbolized_frame(sym: &Sym, addr: u64, default_module: &str) -> String
         .and_then(|m| std::path::Path::new(m).file_name())
         .and_then(|f| f.to_str())
         .unwrap_or(default_module);
-    format_symbolized_frame_forced_module(sym, addr, module_name)
+    format_symbolized_frame_forced_module(sym, addr, module_name, elide_generics)
 }
 
 /// Same as [`format_symbolized_frame`] but with a caller-supplied module
 /// name. Used when symbolization went through an indirect source (e.g. a
 /// `map_files` link for a bridged island) whose path would be meaningless to
 /// report.
-fn format_symbolized_frame_forced_module(sym: &Sym, addr: u64, module_name: &str) -> String {
+fn format_symbolized_frame_forced_module(
+    sym: &Sym,
+    addr: u64,
+    module_name: &str,
+    elide_generics: bool,
+) -> String {
     let location_info = format_location_info(sym.code_info.as_deref());
-    format!(
-        "{} ({}{}) <{:#x}>",
-        sym.name, module_name, location_info, addr
-    )
+    let name: &str = &sym.name;
+    let name = if elide_generics {
+        crate::symbol_shorten::shorten_name(name)
+    } else {
+        std::borrow::Cow::Borrowed(name)
+    };
+    format!("{name} ({module_name}{location_info}) <{addr:#x}>")
 }
 
 /// Create a debuginfod dispatcher if debuginfod is available in the environment

--- a/src/symbol_shorten.rs
+++ b/src/symbol_shorten.rs
@@ -1,0 +1,409 @@
+//! Bounded rendering of pathological symbol names.
+//!
+//! Demangled Rust and C++ names embed the full monomorphized argument
+//! list: deeply nested iterator adapters and expression templates
+//! legitimately demangle to multi-kilobyte strings (observed up to ~28 KiB
+//! for a single instantiation). Stacks are materialized as arrays of frame
+//! strings, so one hot kilobyte-scale name repeated across millions of
+//! recorded frames comes to dominate recorder memory and the size of
+//! everything downstream — while carrying no more grouping identity than
+//! its own first and last path segments.
+//!
+//! [`shorten_name`] bounds that cost while keeping the parts a reader or a
+//! grouping query actually uses. Names at most [`ELIDE_GATE`] bytes pass
+//! through byte-verbatim. Longer names have their balanced `<…>` and `(…)`
+//! argument groups collapsed — `a::b<X<Y>, Z>::c(P)` becomes
+//! `a::b<...>::c(...)` — preserving both the path head and the trailing
+//! function segment. A name whose leading character opens a `<` group is
+//! Rust's qualified-self syntax (`<Type as Trait>::method`); that group is
+//! the identity being named, so it stays open and its child groups
+//! collapse instead. Only if a name still exceeds `SHORTENED_MAX` after
+//! elision — or its brackets do not balance — does it fall back to a
+//! middle cut that keeps the head and tail with an 8-hex hash of the full
+//! original name spliced in for grouping identity.
+//!
+//! Properties relied on downstream:
+//! - deterministic and process-independent: the same full name always
+//!   shortens to the same string (the fallback hash is FNV-1a, not a
+//!   seeded hasher);
+//! - prefix-preserving: bytes before the first collapsed group are
+//!   verbatim, so prefix matches against untransformed heads keep working;
+//! - instantiation-merging: monomorphizations of one source function
+//!   (same path and function segment, different arguments) shorten to the
+//!   same string, aggregating the family under its source function.
+
+use std::borrow::Cow;
+
+/// Names at most this many bytes are always rendered byte-verbatim.
+pub const ELIDE_GATE: usize = 256;
+
+/// Bound on the elided form. Elision keeps everything outside argument
+/// groups, so a result exceeding this (kilobytes of path segments, or a
+/// name whose brackets never balanced) falls back to [`middle_cut`].
+const SHORTENED_MAX: usize = 1024;
+
+/// Middle-cut geometry: bytes of head and tail kept around the hash.
+const CUT_HEAD: usize = 192;
+const CUT_TAIL: usize = 64;
+
+/// Render `name` within a bounded size, preserving its head and function
+/// segment. See the module docs for the exact scheme.
+pub fn shorten_name(name: &str) -> Cow<'_, str> {
+    if name.len() <= ELIDE_GATE {
+        return Cow::Borrowed(name);
+    }
+    match elide_arg_groups(name) {
+        Some(elided) if elided.len() <= SHORTENED_MAX => Cow::Owned(elided),
+        Some(elided) => Cow::Owned(middle_cut(&elided, name)),
+        None => Cow::Owned(middle_cut(name, name)),
+    }
+}
+
+/// True if the byte before position `i` allows `<` to open a generic /
+/// template argument group: an identifier character or `:` (turbofish).
+/// Anything else — space, `<` (the second char of `operator<<`), an
+/// operator symbol — leaves the `<` literal.
+fn ident_or_colon_before(bytes: &[u8], i: usize) -> bool {
+    i > 0 && matches!(bytes[i - 1], b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_' | b':')
+}
+
+/// True if the bytes immediately before position `i` spell the standalone
+/// keyword `operator`: C++ `operator<`, `operator<<`, `operator<=>` and
+/// `operator()` must not be taken as group openers.
+fn preceded_by_operator(bytes: &[u8], i: usize) -> bool {
+    const TOKEN: &[u8] = b"operator";
+    let Some(start) = i.checked_sub(TOKEN.len()) else {
+        return false;
+    };
+    if &bytes[start..i] != TOKEN {
+        return false;
+    }
+    // A standalone keyword, not the tail of an identifier like `my_operator`.
+    start == 0
+        || !matches!(
+            bytes[start - 1],
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'_'
+        )
+}
+
+/// Collapse balanced `<…>` and `(…)` groups to `<...>` / `(...)`.
+///
+/// Returns `None` when the brackets do not balance (truncated or exotic
+/// symtab strings) — the caller falls back to [`middle_cut`], so a scan
+/// failure can never produce an unbounded or non-deterministic result.
+fn elide_arg_groups(name: &str) -> Option<String> {
+    let bytes = name.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(name.len().min(SHORTENED_MAX));
+    // Expected closers for currently-open groups, innermost last.
+    let mut open: Vec<u8> = Vec::new();
+    // While `Some(d)`, bytes are dropped until `open` shrinks back to
+    // length `d` (the collapsed group and everything nested in it).
+    let mut suppress_at: Option<usize> = None;
+
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match c {
+            b'<' | b'(' => {
+                let opens = if c == b'<' {
+                    (i == 0 || ident_or_colon_before(bytes, i)) && !preceded_by_operator(bytes, i)
+                } else {
+                    !preceded_by_operator(bytes, i)
+                };
+                if !opens {
+                    if suppress_at.is_none() {
+                        out.push(c);
+                    }
+                    i += 1;
+                    continue;
+                }
+                let closer = if c == b'<' { b'>' } else { b')' };
+                if suppress_at.is_none() {
+                    if c == b'<' && i == 0 {
+                        // Rust qualified-self (`<Type as Trait>::method`):
+                        // the group IS the identity being named — keep it
+                        // open; groups nested directly inside it collapse.
+                        out.push(c);
+                    } else {
+                        // Top-level group (or first level inside the
+                        // qualified-self group): collapse it.
+                        suppress_at = Some(open.len());
+                        out.push(c);
+                        out.extend_from_slice(b"...");
+                    }
+                }
+                open.push(closer);
+            }
+            b'>' | b')' => {
+                // `->` inside function-pointer types must not close `<`.
+                if c == b'>' && i > 0 && bytes[i - 1] == b'-' {
+                    if suppress_at.is_none() {
+                        out.push(c);
+                    }
+                    i += 1;
+                    continue;
+                }
+                match open.last() {
+                    Some(&expected) if expected == c => {
+                        open.pop();
+                        if suppress_at == Some(open.len()) {
+                            suppress_at = None;
+                            out.push(c);
+                        } else if suppress_at.is_none() {
+                            // Closing the qualified-self group itself.
+                            out.push(c);
+                        }
+                    }
+                    Some(_) => return None, // mismatched pair
+                    None => {
+                        // Stray closer at depth 0 (`operator>`, spaceship
+                        // remnants): literal.
+                        out.push(c);
+                    }
+                }
+            }
+            _ => {
+                if suppress_at.is_none() {
+                    out.push(c);
+                }
+            }
+        }
+        i += 1;
+    }
+    if !open.is_empty() {
+        return None;
+    }
+    Some(String::from_utf8(out).expect("elided output is rebuilt from valid UTF-8 slices"))
+}
+
+/// Deterministic fallback for names elision cannot bound: keep the head
+/// and tail, splice in an 8-hex FNV-1a hash of the FULL original name so
+/// distinct originals stay distinct.
+fn middle_cut(s: &str, full_original: &str) -> String {
+    let marker = format!("...#{:08x}...", stable_hash32(full_original));
+    if s.len() <= CUT_HEAD + CUT_TAIL + marker.len() {
+        return s.to_string();
+    }
+    let mut head_end = CUT_HEAD;
+    while !s.is_char_boundary(head_end) {
+        head_end -= 1;
+    }
+    let mut tail_start = s.len() - CUT_TAIL;
+    while !s.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    format!("{}{}{}", &s[..head_end], marker, &s[tail_start..])
+}
+
+/// FNV-1a, folded to 32 bits. Chosen over `DefaultHasher` because the
+/// result must be identical across processes and hosts: the shortened
+/// spelling is a grouping key downstream.
+fn stable_hash32(s: &str) -> u32 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in s.as_bytes() {
+        h ^= u64::from(b);
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    (h ^ (h >> 32)) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A generic argument blob big enough to push any name past the gate.
+    fn big_args() -> String {
+        let mut s = String::from("alloc::vec::Vec<u64>");
+        while s.len() < 400 {
+            s = format!("core::iter::adapters::map::Map<{s}, alloc::string::String>");
+        }
+        s
+    }
+
+    #[test]
+    fn short_names_pass_verbatim() {
+        for name in [
+            "memcpy",
+            "alloc::vec::Vec<u64>::push",
+            "<core::option::Option<u32> as core::fmt::Debug>::fmt",
+            "Eigen::TensorEvaluator<int>::evalProduct(long)",
+            "unknown ([gvisor:runtime]) <0x7f00>",
+        ] {
+            assert!(name.len() <= ELIDE_GATE);
+            let out = shorten_name(name);
+            assert!(matches!(out, Cow::Borrowed(_)), "{name} was not borrowed");
+            assert_eq!(out, name);
+        }
+    }
+
+    #[test]
+    fn gate_is_inclusive() {
+        let at_gate = format!("f<{}>", "a".repeat(ELIDE_GATE - 3));
+        assert_eq!(at_gate.len(), ELIDE_GATE);
+        assert_eq!(shorten_name(&at_gate), at_gate);
+
+        let over_gate = format!("f<{}>", "a".repeat(ELIDE_GATE - 2));
+        assert_eq!(over_gate.len(), ELIDE_GATE + 1);
+        assert_eq!(shorten_name(&over_gate), "f<...>");
+    }
+
+    #[test]
+    fn turbofish_function_generics_collapse() {
+        let name = format!("rayon_core::registry::in_worker::<{}>", big_args());
+        assert_eq!(
+            shorten_name(&name),
+            "rayon_core::registry::in_worker::<...>"
+        );
+    }
+
+    #[test]
+    fn trailing_closure_segment_is_preserved() {
+        let name = format!(
+            "rayon_core::join::join_context::<{}>::{{closure#0}}",
+            big_args()
+        );
+        assert_eq!(
+            shorten_name(&name),
+            "rayon_core::join::join_context::<...>::{closure#0}"
+        );
+    }
+
+    #[test]
+    fn qualified_self_keeps_type_and_trait_heads() {
+        let name = format!(
+            "<core::iter::adapters::map::Map<{}> as core::iter::traits::iterator::Iterator>::next",
+            big_args()
+        );
+        assert_eq!(
+            shorten_name(&name),
+            "<core::iter::adapters::map::Map<...> as core::iter::traits::iterator::Iterator>::next"
+        );
+    }
+
+    #[test]
+    fn cpp_templates_and_params_collapse() {
+        let name = format!(
+            "void Eigen::TensorEvaluator<{}>::evalProductSequential({})",
+            big_args(),
+            big_args()
+        );
+        assert_eq!(
+            shorten_name(&name),
+            "void Eigen::TensorEvaluator<...>::evalProductSequential(...)"
+        );
+    }
+
+    #[test]
+    fn cpp_operators_stay_literal() {
+        let name = format!("ns::Matrix<{}>::operator<<(std::ostream&, int)", big_args());
+        assert_eq!(shorten_name(&name), "ns::Matrix<...>::operator<<(...)");
+
+        let call = format!("ns::Functor<{}>::operator()(int, long)", big_args());
+        assert_eq!(shorten_name(&call), "ns::Functor<...>::operator()(...)");
+    }
+
+    #[test]
+    fn identifiers_ending_in_operator_still_open_groups() {
+        let name = format!("ns::my_operator<{}>::run", big_args());
+        assert_eq!(shorten_name(&name), "ns::my_operator<...>::run");
+    }
+
+    #[test]
+    fn arrows_inside_generics_do_not_unbalance() {
+        let name = format!(
+            "ns::apply::<fn(alloc::vec::Vec<{}>) -> core::option::Option<u64>>::call",
+            big_args()
+        );
+        assert_eq!(shorten_name(&name), "ns::apply::<...>::call");
+    }
+
+    #[test]
+    fn comparison_lt_stays_literal() {
+        // A `<` after a space (const-expression remnant) is not an opener;
+        // brackets still balance around it.
+        let name = format!("ns::check<{}>::assert_lt::{{shim: a < b}}", big_args());
+        assert_eq!(
+            shorten_name(&name),
+            "ns::check<...>::assert_lt::{shim: a < b}"
+        );
+    }
+
+    #[test]
+    fn unbalanced_names_fall_back_to_middle_cut() {
+        let name = format!("broken<{}", "x".repeat(600));
+        let out = shorten_name(&name);
+        assert!(out.len() < name.len());
+        assert!(out.starts_with("broken<xxxx"), "head preserved: {out}");
+        assert!(out.ends_with(&"x".repeat(CUT_TAIL)), "tail preserved");
+        assert!(out.contains("...#"), "hash marker present: {out}");
+        // Deterministic, and distinct originals stay distinct.
+        assert_eq!(shorten_name(&name), out);
+        let other = format!("broken<{}", "y".repeat(600));
+        assert_ne!(shorten_name(&other), out);
+    }
+
+    #[test]
+    fn bracket_free_monsters_fall_back_to_middle_cut() {
+        let name = "very::long::path::".repeat(80);
+        assert!(name.len() > SHORTENED_MAX);
+        let out = shorten_name(&name);
+        assert!(out.len() <= CUT_HEAD + CUT_TAIL + 16);
+        assert!(out.starts_with("very::long::path::"));
+        assert!(out.contains("...#"));
+    }
+
+    #[test]
+    fn elided_but_still_long_names_fall_back_bounded() {
+        // Groups collapse but kilobytes of bare path remain.
+        let name = format!("{}<{}>::run", "seg::".repeat(300), big_args());
+        let out = shorten_name(&name);
+        assert!(
+            out.len() <= CUT_HEAD + CUT_TAIL + 16,
+            "bounded: {}",
+            out.len()
+        );
+        assert!(out.starts_with("seg::seg::"));
+        assert!(
+            out.ends_with("::run"),
+            "function tail survives the cut: {out}"
+        );
+    }
+
+    #[test]
+    fn monomorphizations_of_one_function_merge() {
+        let a = format!("pool::execute::<{}>", big_args());
+        let b = format!("pool::execute::<fn({}) -> u8>", big_args());
+        assert_eq!(shorten_name(&a), shorten_name(&b));
+        assert_eq!(shorten_name(&a), "pool::execute::<...>");
+    }
+
+    #[test]
+    fn different_functions_never_merge() {
+        let a = format!("pool::execute::<{}>", big_args());
+        let b = format!("pool::execute_now::<{}>", big_args());
+        assert_ne!(shorten_name(&a), shorten_name(&b));
+    }
+
+    #[test]
+    fn mismatched_pairs_fall_back() {
+        let name = format!("odd<{})::end", "q".repeat(500));
+        let out = shorten_name(&name);
+        assert!(out.contains("...#"), "mismatch routed to middle cut: {out}");
+    }
+
+    #[test]
+    fn multibyte_input_cuts_on_char_boundaries() {
+        // Unbalanced so the middle cut runs over multibyte content.
+        let name = format!("bad<{}", "α".repeat(400));
+        let out = shorten_name(&name);
+        assert!(out.contains("...#"));
+        // Would panic on a non-boundary slice; also must stay valid UTF-8.
+        assert!(out.chars().count() > 0);
+    }
+
+    #[test]
+    fn anonymous_namespace_prefix_collapses_but_stays_balanced() {
+        let name = format!("(anonymous namespace)::detail::run<{}>", big_args());
+        assert_eq!(shorten_name(&name), "(...)::detail::run<...>");
+    }
+}

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -610,6 +610,10 @@ pub struct Config {
     /// Resolve user-space symbols from ELF symbol tables only (no DWARF
     /// debug info, line info, inlined functions, or debuginfod)
     pub symbolize_names_only: bool,
+    /// Collapse generic/template argument groups in symbol names longer
+    /// than 256 bytes (`path::func<...>`), bounding the cost of deeply
+    /// monomorphized Rust/C++ names; shorter names are unchanged
+    pub symbolize_elide_generics: bool,
     /// Disable scheduler tracing
     pub no_sched: bool,
     /// Disable IRQ/softirq tracing
@@ -703,6 +707,7 @@ impl Default for Config {
             no_gopclntab: false,
             no_exited_recovery: false,
             symbolize_names_only: false,
+            symbolize_elide_generics: false,
             no_sched: false,
             no_irq: false,
             syscalls: false,
@@ -1604,6 +1609,13 @@ fn configure_recorder(opts: &Config, recorder: &Arc<SessionRecorder>) {
                  to fetch the debug info names-only symbolization skips)"
             );
         }
+    }
+    if opts.symbolize_elide_generics {
+        recorder
+            .stack_recorder
+            .lock()
+            .unwrap()
+            .set_elide_generics(true);
     }
 }
 


### PR DESCRIPTION
## Problem

Demangled Rust and C++ names carry the full monomorphized argument list. Deeply nested iterator/combinator stacks and expression templates legitimately demangle to multi-kilobyte strings — observed single instantiations up to ~28 KiB (Eigen contraction kernels) and hot 1-2 KiB Rust iterator-adapter names. Stacks are materialized as arrays of frame strings, so a handful of hot kilobyte-scale names repeated across millions of recorded frames comes to dominate recorder memory and the size of the resulting trace, while carrying no more grouping identity than their first and last path segments.

## Change

New opt-in `--symbolize-elide-generics` flag, default **off** — unflagged runs keep full symbolization, byte-identical output.

When set, names longer than 256 bytes (`ELIDE_GATE`) have their balanced `<...>` and `(...)` argument groups collapsed, preserving the path head and the function segment:

| input shape | rendered |
|---|---|
| `rayon_core::registry::in_worker::<deeply nested adapter types>` | `rayon_core::registry::in_worker::<...>` |
| `rayon_core::join::join_context::<...>::{closure#0}` | closure tail preserved |
| `<core::iter::adapters::map::Map<...> as core::iter::traits::iterator::Iterator>::next` | qualified-self type + trait heads preserved |
| `void Eigen::TensorEvaluator<...>::evalProductSequential(...)` | C++ templates and parameter lists |

Details:

- Names of 256 bytes or less pass through byte-verbatim (`Cow::Borrowed`, zero allocation) — kernel symbols and ordinary frames are untouched.
- `operator<`, `operator<<`, `operator<=>` and `operator()` never open a group; `->` inside function-pointer types never closes one; `{closure#N}` spellings are preserved.
- Rust qualified-self (`<Type as Trait>::method`) keeps the type and trait heads and collapses one level deeper.
- Names whose brackets do not balance, or that remain over-long after elision, fall back to a bounded middle cut with an 8-hex FNV-1a hash of the full original name spliced in, so distinct originals stay distinct and no input produces an unbounded result. FNV rather than `DefaultHasher` keeps the result identical across processes and hosts — the shortened spelling is a grouping key downstream.

Grouping properties (documented on the module): deterministic (same full name always shortens to the same string), prefix-preserving up to the first collapsed group, and instantiation-merging — monomorphizations of one source function aggregate under that function; two different source functions can never merge.

Composes independently with `--symbolize-names-only`; the plumbing is the same shape.

## Testing

- `cargo test --workspace --no-default-features`: all suites pass; 18 new unit tests in `symbol_shorten` cover the gate boundary, turbofish generics, closure tails, qualified-self, C++ operators, arrow returns, unbalanced/mismatched fallbacks, multibyte middle cuts, and the merge/no-merge grouping invariants.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --no-default-features -- -D warnings` both clean.
