### PR TITLE
exit_snapshot: only pin ELF backing files

### DIFF
--- a/src/exit_snapshot.rs
+++ b/src/exit_snapshot.rs
@@ -213,8 +213,8 @@ impl ExitSnapshots {
     }
 
     /// Ensure the backing file of a parsed mapping is pinned. Returns false
-    /// when the file cannot be opened (the segment is then not recorded and
-    /// its addresses keep the [exited] rendering).
+    /// when the file cannot be opened or is not an ELF object (the segment
+    /// is then not recorded and its addresses keep the [exited] rendering).
     fn pin_file(&mut self, tgid: i32, parsed: &ParsedMapsLine) -> bool {
         if self.files.contains_key(&parsed.file) {
             return true;
@@ -253,10 +253,16 @@ impl ExitSnapshots {
 /// path through the process's root, then the plain path — each verified
 /// against the mapping's (device, inode) so a recycled or namespace-mismatched
 /// path can never pin the wrong file.
+///
+/// Whatever path opened it, the file must pass the ELF-magic screen: a
+/// non-ELF backing file can never symbolize, so pinning it is pure cost
+/// (see [`is_elf`]). A file that fails the screen fails it on every path
+/// (they all reach the same inode), so there is no point trying the next
+/// candidate.
 fn open_mapping_file(tgid: i32, parsed: &ParsedMapsLine) -> Option<File> {
     let link = format!("/proc/{tgid}/map_files/{:x}-{:x}", parsed.start, parsed.end);
     if let Ok(file) = File::open(link) {
-        return Some(file);
+        return is_elf(&file).then_some(file);
     }
     for candidate in [
         format!("/proc/{tgid}/root{}", parsed.path),
@@ -264,11 +270,32 @@ fn open_mapping_file(tgid: i32, parsed: &ParsedMapsLine) -> Option<File> {
     ] {
         if let Ok(file) = File::open(candidate) {
             if file_key(&file) == Some(parsed.file) {
-                return Some(file);
+                return is_elf(&file).then_some(file);
             }
         }
     }
     None
+}
+
+/// Whether the file starts with the ELF magic.
+///
+/// Executable file-backed mappings are not always ELF objects: runtimes
+/// that manage code or memory through memfd — sandbox runtimes mapping
+/// guest memory arenas, JITs mapping code files — produce maps entries
+/// that look file-backed and executable but hold raw bytes symbolization
+/// can never resolve. Pinning those files costs a descriptor per unique
+/// file with zero chance of a name, and because a held descriptor keeps
+/// an unlinked file alive, it can extend a dead process's memory arena
+/// until the next reset. On hosts dense with such processes the pinned
+/// set is dominated by these files; screening at pin time keeps the
+/// descriptor footprint proportional to real binaries.
+fn is_elf(file: &File) -> bool {
+    use std::os::unix::fs::FileExt;
+    let mut magic = [0u8; 4];
+    match file.read_exact_at(&mut magic, 0) {
+        Ok(()) => magic == [0x7f, b'E', b'L', b'F'],
+        Err(_) => false,
+    }
 }
 
 /// (device, inode) of an open file, encoded like the maps-line key.
@@ -476,5 +503,65 @@ mod tests {
             .filter(|segment| snapshots.files.contains_key(&segment.file))
             .count();
         assert!(resolvable <= 1);
+    }
+
+    #[test]
+    fn is_elf_screens_magic() {
+        use std::io::Write;
+        let exe = File::open("/proc/self/exe").expect("open own exe");
+        assert!(is_elf(&exe));
+        let mut junk = tempfile::tempfile().expect("tempfile");
+        junk.write_all(b"raw bytes, not an object").expect("write");
+        assert!(!is_elf(&junk));
+        // Shorter than the magic: the read fails, the screen rejects.
+        let empty = tempfile::tempfile().expect("tempfile");
+        assert!(!is_elf(&empty));
+    }
+
+    #[test]
+    fn capture_skips_non_elf_backing_files() {
+        // An exec-mapped memfd full of raw bytes: its maps line is
+        // executable and file-backed (leading '/', nonzero inode), which is
+        // exactly how runtime-managed memory arenas present. The screen must
+        // keep it out of the pinned set while real ELF mappings still pin.
+        let page = 4096usize;
+        let fd = unsafe { libc::memfd_create(b"junk\0".as_ptr().cast(), 0) };
+        assert!(fd >= 0, "memfd_create failed");
+        let junk = vec![0xAAu8; page];
+        let written = unsafe { libc::write(fd, junk.as_ptr().cast(), page) };
+        assert_eq!(written, page as isize, "memfd write failed");
+        let mapped = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                page,
+                libc::PROT_READ | libc::PROT_EXEC,
+                libc::MAP_PRIVATE,
+                fd,
+                0,
+            )
+        };
+        assert_ne!(mapped, libc::MAP_FAILED, "mmap failed");
+
+        let mut snapshots = ExitSnapshots::new();
+        let me = std::process::id() as i32;
+        snapshots.observe_tgid(me);
+        let snapshot = snapshots.snapshots.get(&me).expect("snapshot exists");
+        let mapped_start = mapped as u64;
+        assert!(
+            !snapshot
+                .segments
+                .iter()
+                .any(|segment| segment.start == mapped_start),
+            "non-ELF memfd mapping must not be recorded"
+        );
+        assert!(
+            !snapshot.segments.is_empty(),
+            "real ELF mappings must still be recorded"
+        );
+
+        unsafe {
+            libc::munmap(mapped, page);
+            libc::close(fd);
+        }
     }
 }


### PR DESCRIPTION
## Summary

`exit_snapshot` currently pins any executable file-backed mapping's
backing file. Executable file-backed mappings are not always ELF
objects: runtimes that manage code or memory through memfd — sandbox
runtimes such as gVisor mapping guest memory arenas, JITs mapping code
files — produce maps entries that pass the executable/file-backed
screen but hold raw bytes symbolization can never resolve. This PR
screens the backing file at pin time: read four bytes, require the ELF
magic.

## Why pinning non-ELF files is worse than useless

- **It can never produce a name.** The snapshot's whole purpose is
  feeding `Source::Elf` at end-of-pass symbolization; a non-ELF file
  fails ELF parsing every time. The pin is pure cost.
- **Descriptor pressure scales with the wrong thing.** On hosts running
  ordinary workloads, executable mappings dedupe to a small set of real
  binaries (a few dozen unique files even under heavy fork/exec load).
  On hosts dense with sandboxed workloads, every sandbox's memory arena
  is a *distinct* memfd — the pinned set saturates its cap with useless
  files, and the per-pass descriptor peak (pins plus the symbolizer's
  own per-source descriptors) scales with sandbox churn. Under a
  1024-class `RLIMIT_NOFILE` that peak is reachable every pass.
- **A held descriptor extends dead processes' memory lifetimes.** The
  pins are real descriptors; holding one to an unlinked memfd keeps the
  arena's pages alive until the next reset — deferring reclaim of
  potentially large amounts of memory for files that were never
  symbolizable in the first place.

## The change

`open_mapping_file` now verifies the ELF magic on whichever path opened
the file (map_files primary or the verified fallbacks) before returning
it. A file that fails the screen fails on every path — they all reach
the same inode — so no further candidates are tried. A mapping whose
file fails the screen is simply not recorded: its addresses keep the
`[exited]` rendering, the same degradation contract as every other
capture failure. Cost: one 4-byte `pread` of an already-open descriptor
per unique file per snapshot pass.

## Validation

- New unit test `is_elf_screens_magic` (own exe passes; junk and empty
  files fail).
- New unit test `capture_skips_non_elf_backing_files` exercises the
  exact production path: an exec-mapped non-ELF memfd (which presents
  in maps as executable + file-backed, just like a runtime arena) is
  screened out of the snapshot while real ELF mappings still pin.
- Full lib suite green; clippy `-D warnings` clean.
- Full VM gate green at this exact head: 9/9 targets (run
  20260721-222030), including the gVisor/runsc recording target and the
  exited-process recovery e2e (trace-validation 33/33) — the recovery
  feature is verified unaffected for real binaries (the test binary is
  a real ELF and passes the screen).
