### PR TITLE
stack_recorder: bound symbolizer descriptors in the exited-process pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,8 +677,8 @@ dependencies = [
 
 [[package]]
 name = "blazesym"
-version = "0.2.5"
-source = "git+https://github.com/libbpf/blazesym.git?rev=862c2cf5d424307456322d2c68fe86c591baece2#862c2cf5d424307456322d2c68fe86c591baece2"
+version = "0.2.6"
+source = "git+https://github.com/libbpf/blazesym.git?rev=8705da0a8cec2bb27f897ac732e27121f9be7936#8705da0a8cec2bb27f897ac732e27121f9be7936"
 dependencies = [
  "cpp_demangle",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bitfield = "0.19.0"
 # 0.2.x releases (where Sym::code_info became Option<Box<CodeInfo>>), so
 # `cargo install` without --locked picked an incompatible version. An exact pin
 # keeps fresh resolutions reproducible.
-blazesym = { git = "https://github.com/libbpf/blazesym.git", rev = "862c2cf5d424307456322d2c68fe86c591baece2" }
+blazesym = { git = "https://github.com/libbpf/blazesym.git", rev = "8705da0a8cec2bb27f897ac732e27121f9be7936" }
 clap = { version = "4.5.20", features = ["derive"] }
 ctrlc = "3.4"
 dashmap = "6"

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -21,7 +22,7 @@ use crate::utid::{ThreadAwareRecorder, UtidGenerator};
 use blazesym::helper::{read_elf_build_id, ElfResolver};
 use blazesym::symbolize::source::{Elf, Kernel, Process, Source};
 use blazesym::symbolize::{
-    cache, Input, ProcessMemberInfo, ProcessMemberType, Resolve, Sym, Symbolizer,
+    cache, evict, Input, ProcessMemberInfo, ProcessMemberType, Resolve, Sym, Symbolizer,
 };
 use blazesym::Error as BlazeErr;
 use blazesym::Pid;
@@ -441,6 +442,30 @@ fn emit_stack_record(
     })
 }
 
+/// Maximum number of distinct exit-snapshot ELF paths the symbolizer may
+/// hold cached before the exited-process pass evicts them. blazesym keeps
+/// one open descriptor per distinct binary it touches and never drops it on
+/// its own, so without eviction the pass would duplicate up to the snapshot
+/// layer's whole pinned-file cap on top of the pins themselves. A small
+/// batch keeps the duplicate descriptors well below that cap while still
+/// amortizing re-parses across many stacks.
+const EXITED_ELF_EVICT_BATCH: usize = 64;
+
+/// Evict the symbolizer's cached state for each touched exit-snapshot ELF
+/// path, closing the descriptor blazesym holds for it. A failed eviction
+/// only means that descriptor lives until the symbolizer is dropped, so it
+/// is not worth failing symbolization over.
+fn evict_exited_elf_paths(symbolizer: &mut Symbolizer, paths: &mut HashSet<PathBuf>) {
+    for path in paths.drain() {
+        if let Err(e) = symbolizer.evict(&evict::Evict::from(evict::Elf::new(path.clone()))) {
+            eprintln!(
+                "Warning: failed to evict symbolizer cache entry for {}: {e}",
+                path.display()
+            );
+        }
+    }
+}
+
 /// Read one spill record. Returns `Ok(None)` on clean EOF, `Err` on a torn
 /// record (which terminates reading; the writer warned when it happened).
 fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32, i64)>> {
@@ -829,9 +854,10 @@ impl StackRecorder {
 
         // Pass 1: stream spilled stacks back from disk one record at a time
         // (then any kept in memory). Stacks of exited processes are emitted
-        // immediately: their user addresses cannot be symbolized at all
-        // (blazesym needs /proc/<pid>/maps), so they only need the kernel cache
-        // and a hex rendering, and their address vectors are freed right away.
+        // immediately: their user addresses resolve through the first-sample
+        // mapping snapshots where one was captured (see
+        // [`crate::exit_snapshot`]) and render as unknown otherwise, so
+        // their address vectors are freed right away.
         // Stacks of live processes are re-spilled into RESPILL_BUCKETS
         // tgid-hashed second-tier files for pass 2, so they stay on disk
         // instead of accumulating in memory.
@@ -852,10 +878,24 @@ impl StackRecorder {
             .collect();
         let mut tgid_alive: HashMap<i32, bool> = HashMap::new();
 
+        // Exit-snapshot ELF paths the symbolizer has touched and not yet
+        // evicted. The exited pass symbolizes through /proc/self/fd/<n>
+        // paths of files the snapshot layer holds open; blazesym opens its
+        // own duplicate descriptor per distinct binary and never drops it,
+        // so the pass evicts them in bounded batches (and once more when
+        // the pass ends).
+        let mut touched_exit_elf_paths: HashSet<PathBuf> = HashSet::new();
+
         // Each interner is dropped at the end of its loop iteration, releasing
         // its dedup table before the (memory-hungry) live-process pass below.
+        //
+        // A drain failure is captured rather than propagated on the spot so
+        // the eviction sweep below also covers the bail-out path (a
+        // propagated error would drop the symbolizer anyway; sweeping first
+        // keeps the pass's descriptor accounting uniform on every exit).
+        let mut exited_pass_result: Result<()> = Ok(());
         for mut interner in interners {
-            interner.spill.drain(|stack, tgid, stack_id| {
+            let result = interner.spill.drain(|stack, tgid, stack_id| {
                 let alive = *tgid_alive
                     .entry(tgid)
                     .or_insert_with(|| Path::new("/proc").join(tgid.to_string()).exists());
@@ -868,14 +908,21 @@ impl StackRecorder {
                     &stack,
                     tgid,
                     None,
+                    Some(&mut touched_exit_elf_paths),
                     &kernel_src,
                     &mut kernel_cache,
                 );
                 pb.inc(1);
                 emit_stack_record(collector, stack_id, frame_names)
-            })?;
+            });
+            if let Err(e) = result {
+                exited_pass_result = Err(e);
+                break;
+            }
         }
         drop(tgid_alive);
+        evict_exited_elf_paths(&mut symbolizer, &mut touched_exit_elf_paths);
+        exited_pass_result?;
         phase_rss("exited-process pass done");
 
         // Pass 2: symbolize live processes one re-spill bucket at a time, and
@@ -983,6 +1030,7 @@ impl StackRecorder {
                         &stack,
                         tgid,
                         Some((&ctx, &mut user_cache)),
+                        None,
                         &kernel_src,
                         &mut kernel_cache,
                     );
@@ -1077,12 +1125,19 @@ impl StackRecorder {
     /// [`crate::exit_snapshot`]) and otherwise rendered as
     /// `unknown ([exited]) <addr>` (or raw hex with labels disabled).
     /// Kernel addresses go through the shared `kernel_cache`.
+    ///
+    /// `touched_exit_elf_paths`, when provided by the exited pass, collects
+    /// the snapshot ELF paths this stack symbolized through; once enough
+    /// distinct paths accumulate they are evicted from the symbolizer so
+    /// its open descriptors cannot pile up across the pass.
+    #[allow(clippy::too_many_arguments)]
     fn symbolize_stack_frames(
         &self,
         symbolizer: &mut Symbolizer,
         stack: &Stack,
         tgid: i32,
         user: Option<(&UserSymbolizeCtx<'_>, &mut HashMap<u64, String>)>,
+        mut touched_exit_elf_paths: Option<&mut HashSet<PathBuf>>,
         kernel_src: &Source<'_>,
         kernel_cache: &mut HashMap<u64, String>,
     ) -> Vec<String> {
@@ -1110,34 +1165,59 @@ impl StackRecorder {
                 }
             }
             None => {
-                // One lock per dead-process stack rather than per frame; the
-                // hint drain thread only contends while this pass runs.
-                let exit_snapshots = self.exit_snapshots.lock().unwrap();
+                // One lock per dead-process stack rather than per frame
+                // (re-acquired if a batch eviction fires mid-stack, so the
+                // hint drain thread is never blocked behind eviction work);
+                // the drain thread only contends while this pass runs.
+                let mut exit_snapshots = self.exit_snapshots.lock().unwrap();
                 for &addr in &stack.user_stack {
-                    if let Some(resolved) = exit_snapshots.resolve(tgid, addr) {
+                    let resolved_frame = if let Some(resolved) = exit_snapshots.resolve(tgid, addr)
+                    {
                         let mut elf = Elf::new(&resolved.elf_path);
                         elf.debug_syms = !self.names_only;
                         let elf_src = Source::Elf(elf);
-                        if let Some(sym) = symbolizer
+                        let frame = symbolizer
                             .symbolize_single(&elf_src, Input::FileOffset(resolved.file_offset))
                             .ok()
                             .and_then(|s| s.into_sym())
-                        {
-                            // sym.module would render the /proc/self/fd link;
-                            // report the binary the mapping belonged to.
-                            frame_names.push(format_symbolized_frame_forced_module(
-                                &sym,
-                                addr,
-                                &resolved.module,
-                                self.elide_generics,
-                            ));
-                            continue;
+                            .map(|sym| {
+                                // sym.module would render the /proc/self/fd
+                                // link; report the binary the mapping
+                                // belonged to.
+                                format_symbolized_frame_forced_module(
+                                    &sym,
+                                    addr,
+                                    &resolved.module,
+                                    self.elide_generics,
+                                )
+                            });
+                        // Even a failed attempt leaves a descriptor-holding
+                        // cache entry behind, so the path is recorded — and
+                        // the batch bound enforced — per attempt: one deep
+                        // stack crossing many binaries must not exceed the
+                        // cap either.
+                        if let Some(touched) = touched_exit_elf_paths.as_deref_mut() {
+                            touched.insert(resolved.elf_path);
+                            if touched.len() >= EXITED_ELF_EVICT_BATCH {
+                                // If the drain thread re-pins a descriptor
+                                // number to a new file while the lock is
+                                // dropped, evicting the old path only drops
+                                // the new file's entry: a harmless re-parse.
+                                drop(exit_snapshots);
+                                evict_exited_elf_paths(symbolizer, touched);
+                                exit_snapshots = self.exit_snapshots.lock().unwrap();
+                            }
                         }
-                    }
-                    if self.frame_labels {
-                        frame_names.push(format!("unknown ([exited]) <{addr:#x}>"));
+                        frame
                     } else {
-                        frame_names.push(format!("0x{addr:x}"));
+                        None
+                    };
+                    match resolved_frame {
+                        Some(frame) => frame_names.push(frame),
+                        None if self.frame_labels => {
+                            frame_names.push(format!("unknown ([exited]) <{addr:#x}>"))
+                        }
+                        None => frame_names.push(format!("0x{addr:x}")),
                     }
                 }
             }
@@ -1842,6 +1922,122 @@ mod tests {
         assert_eq!(
             dead.frame_names[0],
             format!("unknown ([exited]) <{dead_addr:#x}>")
+        );
+    }
+
+    /// Number of open descriptors in this process that resolve to `path`.
+    fn fd_count_for(path: &Path) -> usize {
+        std::fs::read_dir("/proc/self/fd")
+            .unwrap()
+            .filter_map(|entry| std::fs::read_link(entry.unwrap().path()).ok())
+            .filter(|target| target == path)
+            .count()
+    }
+
+    /// Evicting an exit-snapshot ELF path must close the descriptor the
+    /// symbolizer's cache holds for it; bounding descriptors in the exited
+    /// pass rests on exactly this property.
+    #[test]
+    fn test_evict_exited_elf_paths_closes_descriptors() {
+        use std::os::fd::AsRawFd as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        // A uniquely named copy of this test binary: descriptor counts for
+        // its path cannot be perturbed by concurrently running tests.
+        let elf_path = dir.path().join("evict-fd-target");
+        std::fs::copy(std::env::current_exe().unwrap(), &elf_path).unwrap();
+        let canonical = elf_path.canonicalize().unwrap();
+
+        // Stands in for an exit-snapshot pin: the descriptor whose
+        // /proc/self/fd path the exited pass symbolizes through.
+        let pin = File::open(&elf_path).unwrap();
+        let fd_path = PathBuf::from(format!("/proc/self/fd/{}", pin.as_raw_fd()));
+
+        let rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        let mut symbolizer = rec.create_symbolizer();
+        let mut elf = Elf::new(&fd_path);
+        elf.debug_syms = false;
+        let elf_src = Source::Elf(elf);
+        // The offset need not resolve to a symbol: the attempt alone
+        // creates the descriptor-holding cache entry.
+        let _ = symbolizer.symbolize_single(&elf_src, Input::FileOffset(0x1000));
+        assert!(
+            fd_count_for(&canonical) >= 2,
+            "the symbolizer should hold its own descriptor besides the pin"
+        );
+
+        let mut touched: HashSet<PathBuf> = HashSet::from([fd_path]);
+        evict_exited_elf_paths(&mut symbolizer, &mut touched);
+        assert!(touched.is_empty(), "eviction should drain the touched set");
+        assert_eq!(
+            fd_count_for(&canonical),
+            1,
+            "only the pinned descriptor should survive eviction"
+        );
+    }
+
+    /// Pins that eviction leaves nothing behind for a recycled
+    /// /proc/self/fd/<n> path: after the descriptor number is re-pointed at
+    /// a different file, symbolization must read the new file and no
+    /// descriptor for the old one may survive.
+    ///
+    /// This cannot be hit in production today: each tick symbolizes with a
+    /// fresh symbolizer, and the snapshot layer's pins normally live for
+    /// the whole pass (cap eviction aside), so a descriptor number does not
+    /// change identity within a symbolizer's lifetime — and blazesym
+    /// re-stats unpinned paths, which self-heals plain reuse. The test pins
+    /// the behavior for a future longer-lived symbolizer, where a stale
+    /// entry could serve the wrong binary after a file-metadata collision.
+    #[test]
+    fn test_evict_exited_elf_paths_guards_fd_path_reuse() {
+        use std::os::fd::AsRawFd as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let not_elf = dir.path().join("reuse-not-elf");
+        std::fs::write(&not_elf, b"not an ELF at all").unwrap();
+        let not_elf_canonical = not_elf.canonicalize().unwrap();
+        let elf_path = dir.path().join("reuse-elf");
+        std::fs::copy(std::env::current_exe().unwrap(), &elf_path).unwrap();
+        let elf_canonical = elf_path.canonicalize().unwrap();
+
+        let pin = File::open(&not_elf).unwrap();
+        let fd = pin.as_raw_fd();
+        let fd_path = PathBuf::from(format!("/proc/self/fd/{fd}"));
+
+        let rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        let mut symbolizer = rec.create_symbolizer();
+        let mut elf = Elf::new(&fd_path);
+        elf.debug_syms = false;
+        let elf_src = Source::Elf(elf);
+        // Parsing fails, but the cache entry (and its descriptor) exists.
+        let _ = symbolizer.symbolize_single(&elf_src, Input::FileOffset(0x1000));
+        assert_eq!(fd_count_for(&not_elf_canonical), 2);
+
+        let mut touched: HashSet<PathBuf> = HashSet::from([fd_path]);
+        evict_exited_elf_paths(&mut symbolizer, &mut touched);
+        assert_eq!(
+            fd_count_for(&not_elf_canonical),
+            1,
+            "eviction must also drop entries whose parse failed"
+        );
+
+        // Re-point the same descriptor number at the ELF, as descriptor
+        // recycling between snapshot generations would.
+        let replacement = File::open(&elf_path).unwrap();
+        // SAFETY: dup2 on descriptors this test owns; it atomically closes
+        // the old descriptor and reuses its number.
+        let rc = unsafe { libc::dup2(replacement.as_raw_fd(), fd) };
+        assert_eq!(rc, fd);
+
+        let _ = symbolizer.symbolize_single(&elf_src, Input::FileOffset(0x1000));
+        assert_eq!(
+            fd_count_for(&not_elf_canonical),
+            0,
+            "no descriptor for the replaced file may survive"
+        );
+        assert!(
+            fd_count_for(&elf_canonical) >= 3,
+            "the recycled path must be re-read from the new file"
         );
     }
 }

--- a/tests/exited_fd_bound.rs
+++ b/tests/exited_fd_bound.rs
@@ -1,0 +1,251 @@
+//! Integration test pinning bounded symbolizer descriptor usage in the
+//! exited-process symbolization pass.
+//!
+//! The exited pass symbolizes each dead process's user addresses through
+//! `/proc/self/fd` paths of backing files pinned by the first-sample
+//! snapshot layer (see `exit_snapshot`). The symbolizer opens its own
+//! descriptor per distinct binary it touches, so without per-pass eviction
+//! the pass holds the snapshot pins AND a duplicate of each — under a
+//! lowered `RLIMIT_NOFILE` the duplicates exhaust the table and exited
+//! frames silently degrade to `unknown ([exited])` (failed opens are
+//! swallowed by design). This test runs many short-lived children, each
+//! backed by its own copy of a symbol-bearing binary, under a descriptor
+//! limit that only a bounded-eviction pass fits into, and requires their
+//! frames to actually symbolize.
+//!
+//! Requires root/BPF privileges; run via:
+//! ```
+//! ./scripts/run-integration-tests.sh exited_fd_bound
+//! ```
+
+use std::collections::HashSet;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use systing::{systing, Config};
+use tempfile::TempDir;
+
+/// Number of short-lived child processes, each its own binary copy —
+/// hence its own snapshot pin and its own symbolizer cache entry. Kept
+/// well under the snapshot layer's pinned-file cap (with room for the
+/// driver's shared objects), so the snapshot layer's own oldest-first pin
+/// eviction never competes with the property under test. All children
+/// are alive at once at the lifetime below, so the concurrent pin count
+/// is the whole child count plus shared objects — under the cap by
+/// arithmetic, not by scheduling.
+const CHILD_COUNT: usize = 450;
+
+/// Soft `RLIMIT_NOFILE` imposed on the tracing process: comfortably above
+/// the patched peak (the snapshot pins + the eviction batch bound + the
+/// runtime baseline asserted below) and well below the unpatched demand
+/// (pins plus one duplicate per child binary, several hundred more).
+const NOFILE_SOFT_LIMIT: libc::rlim_t = 700;
+
+/// Seconds each child stays alive before exiting — long enough that the
+/// sampler catches every child AND the first-sample snapshot layer
+/// captures its mappings while it is still live, even on slow or
+/// emulated machines. Short lifetimes lose that snapshot race, which
+/// both starves resolution and deflates the very descriptor demand the
+/// limit above is calibrated against.
+const CHILD_BURN_SECS: f64 = 10.0;
+
+/// Fraction of children whose frames must symbolize into their own binary.
+/// The margin absorbs children that exit unsampled, not symbolization
+/// failures: a descriptor-exhausted pass degrades far below this.
+const RESOLVED_CHILD_FRACTION: f64 = 0.8;
+
+/// CPU-burner for the children. Compiled locally so its symbol table is
+/// present and the hot function's name is unmistakable in frame names.
+const SPIN_C: &str = r#"
+unsigned long long exited_fd_bound_spin(void) {
+    volatile unsigned long long acc = 0;
+    unsigned long long i;
+    for (i = 0; i < 50000000ULL; i++) {
+        acc += i;
+    }
+    return acc;
+}
+
+int main(void) {
+    for (;;) {
+        exited_fd_bound_spin();
+    }
+    return 0;
+}
+"#;
+
+/// Lower the soft `RLIMIT_NOFILE`, returning the previous limits.
+fn lower_nofile_soft_limit(limit: libc::rlim_t) -> libc::rlimit {
+    let mut old = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit/setrlimit on this process with valid pointers.
+    unsafe {
+        assert_eq!(libc::getrlimit(libc::RLIMIT_NOFILE, &mut old), 0);
+        let new = libc::rlimit {
+            rlim_cur: limit,
+            rlim_max: old.rlim_max,
+        };
+        assert_eq!(libc::setrlimit(libc::RLIMIT_NOFILE, &new), 0);
+    }
+    old
+}
+
+fn restore_nofile_soft_limit(old: libc::rlimit) {
+    // SAFETY: restoring limits observed by lower_nofile_soft_limit.
+    unsafe {
+        assert_eq!(libc::setrlimit(libc::RLIMIT_NOFILE, &old), 0);
+    }
+}
+
+/// Distinct child binaries appearing in a fully symbolized frame. A child
+/// counts only when a frame names the spin function AND attributes it to
+/// that child's binary copy — exactly what the snapshot path produces.
+fn resolved_child_modules(parquet_path: &Path) -> HashSet<String> {
+    use arrow::array::Array as _;
+    use arrow::array::ListArray;
+    use arrow::array::StringArray;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+
+    let file = std::fs::File::open(parquet_path).expect("Failed to open stack.parquet");
+    let builder = ParquetRecordBatchReaderBuilder::try_new(file).expect("Failed to create reader");
+    let reader = builder.build().expect("Failed to build reader");
+
+    let mut resolved = HashSet::new();
+    for batch_result in reader {
+        let batch = batch_result.expect("Failed to read batch");
+        let Some(frame_names_col) = batch.column_by_name("frame_names") else {
+            continue;
+        };
+        let list_array = frame_names_col
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("frame_names should be a ListArray");
+        for i in 0..list_array.len() {
+            if list_array.is_null(i) {
+                continue;
+            }
+            let inner = list_array.value(i);
+            let string_array = inner
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("frame_names inner should be StringArray");
+            for j in 0..string_array.len() {
+                if string_array.is_null(j) {
+                    continue;
+                }
+                let frame = string_array.value(j);
+                // Frames render as "name (module ...) <addr>"; capture the
+                // module token of spin frames.
+                let Some(rest) = frame.strip_prefix("exited_fd_bound_spin (") else {
+                    continue;
+                };
+                if let Some(module) = rest.split([' ', ')']).next() {
+                    if module.starts_with("exch-") {
+                        resolved.insert(module.to_string());
+                    }
+                }
+            }
+        }
+    }
+    resolved
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_exited_pass_fd_bound() {
+    let dir = TempDir::new().expect("Failed to create temp dir");
+
+    // One compiled burner, copied CHILD_COUNT times: distinct inodes make
+    // each child a distinct pinned file and a distinct symbolizer entry.
+    let spin_src = dir.path().join("spin.c");
+    std::fs::write(&spin_src, SPIN_C).expect("Failed to write spin.c");
+    let spin_bin = dir.path().join("spin");
+    let cc_status = Command::new("cc")
+        .arg("-O0")
+        .arg("-o")
+        .arg(&spin_bin)
+        .arg(&spin_src)
+        .status()
+        .expect("cc is required to build the child workload");
+    assert!(cc_status.success(), "Failed to compile the child workload");
+    for i in 0..CHILD_COUNT {
+        std::fs::copy(&spin_bin, dir.path().join(format!("exch-{i}")))
+            .expect("Failed to copy child binary");
+    }
+
+    // Driver script: staggered children, each burning CPU briefly and
+    // exiting; all are dead when the driver (the traced child) exits, so
+    // every child goes through the exited pass.
+    let script_path = dir.path().join("driver.sh");
+    let script = format!(
+        "#!/bin/bash\n\
+         for i in $(seq 0 {last}); do\n\
+         \x20 timeout {burn} \"{dir}/exch-$i\" >/dev/null 2>&1 &\n\
+         \x20 sleep 0.02\n\
+         done\n\
+         wait\n\
+         exit 0\n",
+        last = CHILD_COUNT - 1,
+        burn = CHILD_BURN_SECS,
+        dir = dir.path().display(),
+    );
+    std::fs::write(&script_path, script).expect("Failed to write driver script");
+    let mut perms = std::fs::metadata(&script_path)
+        .expect("Failed to stat driver script")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).expect("Failed to chmod driver script");
+
+    let traced_child = systing::traced_command::spawn_traced_child(&[
+        "bash".to_string(),
+        script_path.to_str().unwrap().to_string(),
+    ])
+    .expect("Failed to spawn driver");
+
+    eprintln!(
+        "Recording {CHILD_COUNT} short-lived children under a soft descriptor limit of {NOFILE_SOFT_LIMIT}..."
+    );
+    // Calibration canary: the margin between the patched descriptor peak
+    // and NOFILE_SOFT_LIMIT assumes a bounded pre-recording baseline. If
+    // the harness or runtime grows past this budget, fail loud here
+    // instead of silently eroding the discrimination margin.
+    let baseline_fds = std::fs::read_dir("/proc/self/fd").unwrap().count();
+    assert!(
+        baseline_fds <= 200,
+        "pre-recording descriptor baseline {baseline_fds} exceeds the \
+         calibration budget (200): recalibrate NOFILE_SOFT_LIMIT"
+    );
+    let old_limit = lower_nofile_soft_limit(NOFILE_SOFT_LIMIT);
+    let config = Config {
+        parquet_only: true,
+        output_dir: dir.path().to_path_buf(),
+        output: dir.path().join("trace.pb"),
+        ..Config::default()
+    };
+    let result = systing(config, Some(traced_child));
+    restore_nofile_soft_limit(old_limit);
+    let exit_code = result.expect("systing recording failed");
+    assert_eq!(exit_code, 0, "driver workload should exit with code 0");
+
+    let stack_parquet = dir.path().join("stack.parquet");
+    assert!(
+        stack_parquet.exists(),
+        "stack.parquet not found — descriptor exhaustion at the parquet open?"
+    );
+
+    let resolved = resolved_child_modules(&stack_parquet);
+    let required = (CHILD_COUNT as f64 * RESOLVED_CHILD_FRACTION) as usize;
+    assert!(
+        resolved.len() >= required,
+        "only {}/{CHILD_COUNT} children symbolized into their binary (required {required}): \
+         exited-pass symbolization degraded, consistent with descriptor exhaustion",
+        resolved.len(),
+    );
+    eprintln!(
+        "    {}/{CHILD_COUNT} children symbolized into their own binary",
+        resolved.len()
+    );
+}


### PR DESCRIPTION
## Problem

In continuous mode, ticks on fork/exec-heavy hosts can fail with `Too many open files (os error 24)` opening `stack.parquet`, right after the "exited-process pass done" phase marker.

Since #165, the exited-process pass symbolizes dead processes' user addresses through `/proc/self/fd/<n>` paths of backing files pinned by the first-sample snapshot layer (`exit_snapshot.rs`). Those pins are bounded (512 files, oldest-first eviction) and released at the end of each tick. But blazesym's file caches open *their own* descriptor for every distinct binary symbolized and never evict (`FileCache`'s docs: "stale/old entries are never evicted"), so a single tick holds:

- up to 512 snapshot pins (by design, released after the pass), plus
- one *duplicate* descriptor per distinct binary the symbolizer touched — unbounded, held until the symbolizer drops at the end of the tick.

On hosts with heavy short-lived-process churn — in particular sandboxed (gVisor) workloads, where memfd/stub-region backings give each process a distinct binary set — the duplicates approach the pin cap, the descriptor table fills, and the first `stack.parquet` open after the exited pass fails with EMFILE. The symbolizer's own failed opens are swallowed by design, so symbolization degrades silently (`unknown ([exited])` frames) before the hard failure surfaces.

The existing RSS-budget rebuild valve (`maybe_rebuild`) does not help: it is gated on anon RSS, and this failure mode shows up at tens of MiB of anon RSS, far under any budget.

## Fix

Bump blazesym to v0.2.6, which provides `Symbolizer::evict()` (libbpf/blazesym#1613), and evict what the exited pass touches:

- `finish_inner` tracks the distinct exit-snapshot ELF paths the symbolizer actually symbolizes through;
- the batch bound is enforced after **every** symbolization attempt (even a failed attempt leaves a descriptor-holding cache entry): once `EXITED_ELF_EVICT_BATCH` (64) distinct paths accumulate they are evicted via `Evict::Elf`, closing blazesym's descriptors — one deep stack crossing many binaries cannot exceed the cap;
- a final sweep runs when the pass ends, including when it bails out early on a drain error;
- an eviction failure warns and continues: a leaked descriptor is strictly better than a failed tick.

Net effect: the symbolizer's exit-snapshot descriptors are bounded at 64 at any instant, so a tick's peak is the pins (<= 512) plus 64 plus runtime descriptors — comfortably under a 1024 soft limit. (When debug info is enabled, blazesym may additionally cache separate on-disk debug-info files under their own paths; those are deduplicated across binaries and absent entirely in the memfd-backed sandboxed-workload scenario that motivated this fix.)

The RSS rebuild valve is untouched (it guards an orthogonal resource). Evicting by path also removes the cache entry itself, so under eviction a stale entry cannot outlive a descriptor number's reuse; today each tick symbolizes with a fresh symbolizer, so staleness cannot cross ticks, but this matters for a future longer-lived symbolizer.

## Considered and deferred

- **Evicting the live pass's gVisor bridge (`/proc/<pid>/map_files/...`) Elf entries.** The live pass ran under the descriptor limit long before #165, so it is not the leak; its entries are bounded by the live-process count, and per-group eviction would thrash re-parses of ELFs shared across processes. If measurement after this fix ever shows pressure there, the right shape is screening at bridge-open (rejecting memfd arenas before a cache entry forms), not live-pass eviction.
- **Fallback without a dependency bump:** a descriptor-count trigger on `maybe_rebuild` — count `/proc/self/fd` entries against `getrlimit(RLIMIT_NOFILE)`'s soft limit and rebuild the symbolizer at about 0.8x of it. Coarser (a trip costs a full re-parse of everything cached) and it papers over the unbounded growth rather than removing it; recorded here in case the dependency bump ever needs reverting.

## Tests

- `test_evict_exited_elf_paths_closes_descriptors` (unit): symbolizing through a `/proc/self/fd` path holds a duplicate descriptor; evicting the path closes it, leaving only the pin. Descriptors are counted by readlink match against a uniquely named binary copy, so concurrent tests cannot perturb the count.
- `test_evict_exited_elf_paths_guards_fd_path_reuse` (unit): after eviction, re-pointing the same descriptor number at a different file (`dup2`) leaves no descriptor for the old file, and the path is re-read fresh. This pins safe behavior for a future longer-lived symbolizer; the test's doc comment explains why it cannot be hit today.
- `test_exited_pass_fd_bound` (integration, `#[ignore]`, needs root/BPF): 450 short-lived children, each running its own copy of a symbol-bearing binary, traced under a soft `RLIMIT_NOFILE` of 700; at least 80% of the children's exited frames must symbolize into their own binary. Without eviction the pass exceeds the limit and frames silently degrade, failing the assertion. (The child count deliberately stays under the snapshot layer's 512 pinned-file cap so its own oldest-first pin eviction never competes with the property under test.)