### PR TITLE
stack_recorder: build-id user stacks for exited-process symbolization

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ This will display all available recorders and their default states:
 
 Python stack symbolization is not a recorder; enable it with `--collect-pystacks`, which resolves Python frames in whichever stacks the active recorders collect.
 
+`--collect-build-id` captures user stacks as (build-id, file offset) pairs
+instead of raw addresses, so frames of processes that exit before end-of-trace
+symbolization still resolve — through a build-id-keyed store filled from
+`/usr/lib/debug/.build-id`, debuginfod (with `--enable-debuginfod`), and the
+binaries of still-running processes. Frames whose build-id no source knows
+render as `unknown ([buildid:<hex>]) <0x<offset>>`, a stable identity that can
+be resolved offline later. Costs ~40% larger stack-ring reservations while
+enabled; off by default and free when off.
+
 Note: `sleep-stacks` acts as a master switch for all sleep stack collection. When enabled,
 both uninterruptible (D state) and interruptible (S state) sleep stacks are collected by
 default. Use `--no-interruptible-stack-traces` or disable the `interruptible-stacks`

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -49,6 +49,22 @@
 #define SKIP_STACK_DEPTH 3
 #define NR_RINGBUFS 8
 
+/* Mirror of the kernel's struct bpf_stack_build_id (filled by bpf_get_stack
+ * under BPF_F_USER_BUILD_ID), with the offset/ip union flattened to one u64
+ * so the generated Rust type has no union member. status says which meaning
+ * the u64 carries: BPF_STACK_BUILD_ID_VALID = file offset (build_id is set),
+ * BPF_STACK_BUILD_ID_IP = raw instruction pointer (the kernel could not
+ * resolve the frame's VMA to a file with a build-id note, or could not walk
+ * safely in this context). */
+struct systing_stack_build_id {
+	s32 status;
+	u8 build_id[20];
+	u64 offset_or_ip;
+};
+_Static_assert(sizeof(struct systing_stack_build_id) ==
+		       sizeof(struct bpf_stack_build_id),
+	       "layout must match the kernel struct bpf_get_stack fills");
+
 #define SYS_ENTER_COOKIE 0xFFFFFFFFFFFFFFFEULL
 #define SYS_EXIT_COOKIE 0xFFFFFFFFFFFFFFFFULL
 
@@ -86,6 +102,14 @@ const volatile struct {
 	u32 no_sched;          /* Sched recorder off: sched_switch still runs for
 				* cpu_running_pid and sleep stacks, but task_event
 				* emission is suppressed. */
+	u32 collect_build_id;  /* User stacks carry (build_id, file offset) pairs
+				* instead of raw IPs (BPF_F_USER_BUILD_ID), and
+				* stack_event reservations include the
+				* user_stack_bid tail. rodata: with the knob off
+				* the verifier prunes the build-id arms entirely,
+				* so the off configuration is instruction- and
+				* reservation-identical to before the knob
+				* existed. */
 	u32 no_irq;            /* IRQ recorder off: the irq/softirq programs are
 				* not loaded at all in that case, so this rodata
 				* gate is belt-and-braces (and lets the verifier
@@ -196,18 +220,34 @@ struct marker_event {
 	u64 info;          // from args[3] (flags param of faccessat2)
 };
 
+/* user_stack_format values: which entry format the user_stack region
+ * carries. The capture mode is fixed for a whole run (rodata), so the
+ * per-event flag is belt-and-braces — it makes every record
+ * self-describing for downstream readers. */
+#define USER_STACK_FORMAT_IP 0
+#define USER_STACK_FORMAT_BUILD_ID 1
+
 struct stack_event {
 	enum stack_event_type stack_event_type;
 	u64 ts;
 	u32 cpu;
+	u32 user_stack_format;
 	struct task_info task;
 	u64 kernel_stack_length;
 	u64 user_stack_length;
 	u64 kernel_stack[MAX_STACK_DEPTH];
-	u64 user_stack[MAX_STACK_DEPTH];
 #ifdef SYSTING_PYSTACKS
 	struct pystacks_message py_msg_buffer;
 #endif
+	/* One region, tail by contract, sized for the larger (build-id) entry
+	 * format. Raw-IP mode packs u64 addresses from the region start and
+	 * uses less of it: reservations stop at
+	 * offsetof(user_stack) + MAX_STACK_DEPTH * sizeof(u64) — byte-for-byte
+	 * what the pre-build-id layout reserved — and userspace zero-extends
+	 * short records (the memory ring's variable-length pattern).
+	 * user_stack_format says how to parse; user_stack_length counts
+	 * entries of that format. */
+	struct systing_stack_build_id user_stack[MAX_STACK_DEPTH];
 };
 
 struct perf_counter_event {
@@ -1216,19 +1256,37 @@ static struct stack_event *reserve_stack_event(long *flags)
 	if (!rb)
 		return NULL;
 	*flags = get_ringbuf_flags(rb);
-	struct stack_event *event = bpf_ringbuf_reserve(rb, sizeof(struct stack_event), 0);
+	/*
+	 * Two reservation sizes over ONE user_stack region: raw-IP mode packs
+	 * u64s and reserves only the bytes it uses — byte-for-byte what the
+	 * pre-build-id layout reserved — while build-id mode reserves the full
+	 * region for the 32-byte entries. collect_build_id is rodata, so the
+	 * verifier prunes the dead branch at load time. Userspace zero-extends
+	 * short records (see create_ring_zero_extend), the same contract as
+	 * the memory ring.
+	 */
+	struct stack_event *event;
+	if (tool_config.collect_build_id)
+		event = bpf_ringbuf_reserve(rb, sizeof(struct stack_event), 0);
+	else
+		event = bpf_ringbuf_reserve(
+			rb,
+			offsetof(struct stack_event, user_stack) +
+				MAX_STACK_DEPTH * sizeof(u64),
+			0);
 	if (event) {
 		/*
 		 * When SYSTING_PYSTACKS is enabled, stack_event includes a large
 		 * pystacks_message buffer (~1KB). Zero only the base fields to avoid
 		 * emitting a memset call that BPF doesn't support for large sizes.
 		 * The py_msg_buffer is populated by pystacks_read_stacks() and doesn't
-		 * need pre-zeroing.
+		 * need pre-zeroing. The user_stack region is bounded by
+		 * user_stack_length, so it needs no pre-zeroing either.
 		 */
 #ifdef SYSTING_PYSTACKS
 		__builtin_memset(event, 0, offsetof(struct stack_event, py_msg_buffer));
 #else
-		__builtin_memset(event, 0, sizeof(*event));
+		__builtin_memset(event, 0, offsetof(struct stack_event, user_stack));
 #endif
 	}
 	return event;
@@ -1628,13 +1686,39 @@ static void emit_stack_event_with_ts(void *ctx, struct task_struct *task,
 	event->stack_event_type = type;
 
 	if (!(task->flags & PF_KTHREAD)) {
-		len = bpf_get_stack(ctx, &event->user_stack,
-				    sizeof(event->user_stack),
-				    BPF_F_USER_STACK);
-		if (len > 0)
-			event->user_stack_length = len / sizeof(u64);
-		else
-			event->user_stack_length = 0;
+		/*
+		 * Both modes walk into the same user_stack region; the entry
+		 * format (and how much of the region was reserved) differs.
+		 * Build-id mode: the kernel emits (build_id, file offset) per
+		 * frame where it can resolve the VMA's file (falling back to
+		 * the raw IP with status BPF_STACK_BUILD_ID_IP where it
+		 * cannot), so frames stay symbolizable after the process
+		 * exits. The extraction is the kernel's own bounded,
+		 * trylock-guarded walk (perf's build-id mechanism) — no code
+		 * of ours runs per frame, and with the rodata knob off this
+		 * arm is pruned at load time.
+		 */
+		if (tool_config.collect_build_id) {
+			event->user_stack_format = USER_STACK_FORMAT_BUILD_ID;
+			len = bpf_get_stack(ctx, &event->user_stack,
+					    sizeof(event->user_stack),
+					    BPF_F_USER_STACK |
+						    BPF_F_USER_BUILD_ID);
+			if (len > 0)
+				event->user_stack_length =
+					len / sizeof(struct systing_stack_build_id);
+			else
+				event->user_stack_length = 0;
+		} else {
+			event->user_stack_format = USER_STACK_FORMAT_IP;
+			len = bpf_get_stack(ctx, &event->user_stack,
+					    MAX_STACK_DEPTH * sizeof(u64),
+					    BPF_F_USER_STACK);
+			if (len > 0)
+				event->user_stack_length = len / sizeof(u64);
+			else
+				event->user_stack_length = 0;
+		}
 	} else {
 		event->user_stack_length = 0;
 	}

--- a/src/build_id_store.rs
+++ b/src/build_id_store.rs
@@ -1,0 +1,277 @@
+//! Build-id-keyed symbol store for `--collect-build-id` mode.
+//!
+//! In build-id mode the kernel stack walker emits `(build_id, file offset)`
+//! pairs instead of raw IPs for user frames (`BPF_F_USER_BUILD_ID`), so a
+//! frame's identity survives the process that produced it. Symbolization
+//! becomes a pure lookup: build-id -> binary (or debug info) -> name. This
+//! module is that lookup.
+//!
+//! Fill sources, in trust order:
+//!
+//! 1. **`.build-id` debug directories** (`/usr/lib/debug/.build-id/xx/rest`)
+//!    — trusted: the path is *derived from the id*, so a traced process
+//!    cannot influence which file answers for an id it doesn't own.
+//! 2. **debuginfod** (when `--enable-debuginfod` is set) — trusted for the
+//!    same reason: the server is queried *by id*.
+//! 3. **Live binaries** — opportunistic: while a sampled process is still
+//!    alive at symbolization time, its executable mappings are read (via
+//!    namespace-immune `/proc/<pid>/map_files` links) and indexed by their
+//!    build-id note. Untrusted in the limit: a binary can carry a copied
+//!    build-id note. Therefore live fills **never override** a trusted
+//!    entry and never overwrite anything already stored — a forged note can
+//!    only affect the rendering of ids that no trusted source knows, which
+//!    is the same capability class as forging sample content outright.
+//!
+//! Misses are not failures: the caller renders the frame with its full
+//! build-id and offset, which a later pass (or downstream tooling) can
+//! resolve whenever a store learns the id.
+//!
+//! Growth is bounded from day one: the store caps its entry count and
+//! evicts the least-recently-used slot past the cap.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use debuginfod::{BuildId, CachingClient};
+
+/// Render a build-id as lowercase hex (the form `file(1)`, `readelf` and
+/// debuginfod all use).
+pub fn build_id_hex(id: &[u8]) -> String {
+    let mut s = String::with_capacity(id.len() * 2);
+    for b in id {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Where symbols for one build-id come from.
+#[derive(Debug, Clone)]
+pub struct ResolvedBinary {
+    /// ELF (or separate debug file) to symbolize file offsets against.
+    pub path: PathBuf,
+    /// Module name to render in frames. For live-binary fills this is the
+    /// mapped file's basename; for `.build-id`/debuginfod hits (where the
+    /// on-disk name is just the hex id) it is `[buildid:<hex8>]`.
+    pub display_module: String,
+}
+
+#[derive(Debug, Default)]
+struct StoreSlot {
+    /// Entry from a trusted source (`.build-id` dir or debuginfod).
+    trusted: Option<ResolvedBinary>,
+    /// Trusted sources already probed for this id (probe once, remember
+    /// misses — debuginfod fetches are not free).
+    trusted_probed: bool,
+    /// Opportunistic live-binary entry. Consulted only when no trusted
+    /// source knows the id; never overwritten once set.
+    live: Option<ResolvedBinary>,
+    /// LRU stamp for cap eviction.
+    last_used: u64,
+}
+
+/// Default entry cap. A trace window sees one entry per unique binary
+/// sampled — hundreds on busy hosts — so this is generous while still
+/// bounding a pathological (or adversarial) unique-build-id storm.
+const DEFAULT_CAP: usize = 16384;
+
+/// Debug directories probed for `.build-id/xx/<rest>.debug` (and the bare
+/// `<rest>` variant some distros install).
+const BUILD_ID_DIRS: &[&str] = &["/usr/lib/debug/.build-id"];
+
+pub struct BuildIdStore {
+    entries: HashMap<[u8; 20], StoreSlot>,
+    debuginfod: Option<Arc<CachingClient>>,
+    tick: u64,
+    cap: usize,
+}
+
+impl BuildIdStore {
+    pub fn new(debuginfod: Option<Arc<CachingClient>>) -> Self {
+        Self {
+            entries: HashMap::new(),
+            debuginfod,
+            tick: 0,
+            cap: DEFAULT_CAP,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_cap(mut self, cap: usize) -> Self {
+        self.cap = cap;
+        self
+    }
+
+    /// Resolve a build-id to the binary to symbolize against, probing
+    /// trusted sources on first sight. Returns `None` when no source knows
+    /// the id (the caller renders the deferred `[buildid:...]` form).
+    pub fn lookup(&mut self, id: &[u8; 20]) -> Option<ResolvedBinary> {
+        self.tick += 1;
+        let tick = self.tick;
+        self.evict_past_cap(id);
+        let debuginfod = self.debuginfod.clone();
+        let slot = self.entries.entry(*id).or_default();
+        slot.last_used = tick;
+        if !slot.trusted_probed {
+            slot.trusted_probed = true;
+            slot.trusted =
+                probe_build_id_dirs(id).or_else(|| fetch_debuginfod(debuginfod.as_deref(), id));
+        }
+        slot.trusted.clone().or_else(|| slot.live.clone())
+    }
+
+    /// Opportunistic fill from a live process's mapping. Never overrides a
+    /// trusted entry (lookup prefers trusted regardless) and never
+    /// overwrites an existing live entry.
+    pub fn fill_live(&mut self, id: [u8; 20], path: PathBuf, display_module: String) {
+        self.tick += 1;
+        let tick = self.tick;
+        self.evict_past_cap(&id);
+        let slot = self.entries.entry(id).or_default();
+        slot.last_used = tick;
+        if slot.live.is_none() {
+            slot.live = Some(ResolvedBinary {
+                path,
+                display_module,
+            });
+        }
+    }
+
+    /// Evict the least-recently-used slot while at the cap, unless `keep`
+    /// is already present (its slot is about to be reused, not grown).
+    fn evict_past_cap(&mut self, keep: &[u8; 20]) {
+        while self.entries.len() >= self.cap && !self.entries.contains_key(keep) {
+            let Some(oldest) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, s)| s.last_used)
+                .map(|(k, _)| *k)
+            else {
+                return;
+            };
+            self.entries.remove(&oldest);
+        }
+    }
+}
+
+/// Probe the distro `.build-id` debug directories: `<dir>/xx/<rest>.debug`
+/// (the debug-info file) and `<dir>/xx/<rest>` (a full-binary variant some
+/// layouts install). The path is derived from the id, which is what makes
+/// this source trusted.
+fn probe_build_id_dirs(id: &[u8; 20]) -> Option<ResolvedBinary> {
+    let head = format!("{:02x}", id[0]);
+    let rest = build_id_hex(&id[1..]);
+    for dir in BUILD_ID_DIRS {
+        for name in [format!("{rest}.debug"), rest.clone()] {
+            let path = Path::new(dir).join(&head).join(&name);
+            if path.is_file() {
+                return Some(ResolvedBinary {
+                    path,
+                    display_module: format!("[buildid:{}]", &build_id_hex(id)[..8]),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Fetch debug info by build-id from debuginfod (only when the client was
+/// enabled). Queried by id, so equally trusted as the `.build-id` dirs.
+///
+/// Ids shorter than 20 bytes (rare non-sha1 notes) were zero-padded by the
+/// kernel's fixed-size field, and the padding is indistinguishable from
+/// trailing zero bytes of a real sha1 — so the query uses the padded form
+/// and such ids simply miss here (deferred rendering covers them).
+fn fetch_debuginfod(client: Option<&CachingClient>, id: &[u8; 20]) -> Option<ResolvedBinary> {
+    let client = client?;
+    let build_id = BuildId::raw(id.to_vec());
+    match client.fetch_debug_info(&build_id) {
+        Ok(Some(path)) => Some(ResolvedBinary {
+            path,
+            display_module: format!("[buildid:{}]", &build_id_hex(id)[..8]),
+        }),
+        Ok(None) => None,
+        Err(e) => {
+            // One line per failing id (memoized by trusted_probed), then the
+            // frame falls back to the deferred rendering.
+            eprintln!(
+                "Warning: debuginfod fetch for build-id {} failed: {e}",
+                build_id_hex(id)
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bid(seed: u8) -> [u8; 20] {
+        [seed; 20]
+    }
+
+    fn resolved(p: &str) -> (PathBuf, String) {
+        (PathBuf::from(p), p.to_string())
+    }
+
+    #[test]
+    fn test_live_fill_never_overwrites() {
+        let mut store = BuildIdStore::new(None);
+        let (p1, d1) = resolved("/proc/1/map_files/a-b");
+        let (p2, _) = resolved("/proc/2/map_files/c-d");
+        store.fill_live(bid(1), p1.clone(), d1.clone());
+        store.fill_live(bid(1), p2, "other".into());
+        let hit = store.lookup(&bid(1)).expect("live entry");
+        assert_eq!(hit.path, p1, "second live fill must not overwrite first");
+    }
+
+    #[test]
+    fn test_trusted_preferred_over_live() {
+        // No trusted source exists in the test environment, so simulate one
+        // by injecting the slot directly: the lookup preference (trusted
+        // first) is what's under test, not the probe.
+        let mut store = BuildIdStore::new(None);
+        let (lp, ld) = resolved("/live/binary");
+        store.fill_live(bid(2), lp, ld);
+        let slot = store.entries.get_mut(&bid(2)).unwrap();
+        slot.trusted = Some(ResolvedBinary {
+            path: PathBuf::from("/usr/lib/debug/.build-id/aa/bb.debug"),
+            display_module: "[buildid:trusted]".into(),
+        });
+        slot.trusted_probed = true;
+        let hit = store.lookup(&bid(2)).expect("entry");
+        assert_eq!(
+            hit.display_module, "[buildid:trusted]",
+            "trusted entry must win over a live fill"
+        );
+    }
+
+    #[test]
+    fn test_miss_is_memoized_and_returns_none() {
+        let mut store = BuildIdStore::new(None);
+        assert!(store.lookup(&bid(3)).is_none());
+        // Second lookup takes the memoized-miss path (trusted_probed set).
+        assert!(store.lookup(&bid(3)).is_none());
+        assert!(store.entries.get(&bid(3)).unwrap().trusted_probed);
+    }
+
+    #[test]
+    fn test_cap_evicts_least_recently_used() {
+        let mut store = BuildIdStore::new(None).with_cap(2);
+        let (p, d) = resolved("/x");
+        store.fill_live(bid(1), p.clone(), d.clone());
+        store.fill_live(bid(2), p.clone(), d.clone());
+        // Touch 1 so 2 is the LRU.
+        store.lookup(&bid(1));
+        store.fill_live(bid(3), p, d);
+        assert!(store.entries.contains_key(&bid(1)));
+        assert!(!store.entries.contains_key(&bid(2)), "LRU slot evicted");
+        assert!(store.entries.contains_key(&bid(3)));
+    }
+
+    #[test]
+    fn test_build_id_hex() {
+        assert_eq!(build_id_hex(&[0xab, 0x01, 0xff]), "ab01ff");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod analyze;
 pub mod mcp;
 
 // Core library modules
+pub mod build_id_store;
 pub mod cgroup;
 pub mod duckdb;
 pub mod parquet_paths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,12 @@ struct Command {
     continuous: u64,
     #[arg(long)]
     collect_pystacks: bool,
+    /// Capture user stacks as (build-id, file offset) pairs instead of raw
+    /// IPs, so frames of exited processes remain symbolizable from a
+    /// build-id-keyed store; unresolved frames render as
+    /// "unknown ([buildid:<hex>]) <0x<offset>>" and stay resolvable offline
+    #[arg(long)]
+    collect_build_id: bool,
     /// Enable debug output for pystacks (Python stack tracing)
     #[arg(long)]
     pystacks_debug: bool,
@@ -223,6 +229,7 @@ impl From<Command> for Config {
             trace_event_config: cmd.trace_event_config,
             continuous: cmd.continuous,
             collect_pystacks: cmd.collect_pystacks,
+            collect_build_id: cmd.collect_build_id,
             pystacks_pids: Vec::new(), // CLI doesn't expose this yet, uses discovery
             pystacks_debug: cmd.pystacks_debug,
             enable_debuginfod: cmd.enable_debuginfod,

--- a/src/sandbox_maps.rs
+++ b/src/sandbox_maps.rs
@@ -208,6 +208,29 @@ impl ProcessMaps {
             .collect()
     }
 
+    /// Executable file-backed mappings as (namespace-immune `map_files`
+    /// link, display path) pairs, one per distinct file path. The link
+    /// opens the exact mapped file regardless of mount namespace (the maps
+    /// path may not resolve from the host); the display path names the
+    /// binary for humans. Feed for the build-id store's live-binary fills.
+    pub fn exec_file_links(&self) -> Vec<(PathBuf, PathBuf)> {
+        let mut seen = std::collections::HashSet::new();
+        self.entries
+            .iter()
+            .filter(|e| e.exec)
+            .filter_map(|e| match &e.backing {
+                Backing::File(p) if seen.insert(p.clone()) => Some((
+                    PathBuf::from(format!(
+                        "/proc/{}/map_files/{:x}-{:x}",
+                        self.tgid, e.start, e.end
+                    )),
+                    p.clone(),
+                )),
+                _ => None,
+            })
+            .collect()
+    }
+
     fn entry_for(&self, addr: u64) -> Option<&MapEntry> {
         // Entries are in address order as read from /proc.
         self.entries

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
+use crate::build_id_store::{build_id_hex, BuildIdStore};
 use crate::gvisor_guest::{GuestAddr, GuestProcess, SandboxIndex};
 use crate::pystacks::stack_walker::{PyAddr, StackWalkerRun};
 use crate::record::RecordCollector;
@@ -34,17 +35,35 @@ type ProcessDispatcher = Box<
 >;
 use debuginfod::{BuildId, CachingClient, Client};
 
+/// One user-space frame as delivered by the BPF walker.
+///
+/// Classic capture yields raw virtual addresses. Build-id capture
+/// (`--collect-build-id`) yields `(build_id, file offset)` pairs for frames
+/// the kernel could resolve to a mapped file carrying an ELF build-id note —
+/// a process-independent identity that stays symbolizable after the process
+/// exits — and falls back to the raw IP (`BPF_STACK_BUILD_ID_IP`) where it
+/// could not.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum UserFrame {
+    /// Raw virtual address; symbolized through the live process (or labeled
+    /// `[exited]`/`[gvisor:*]`/... when that is impossible).
+    Ip(u64),
+    /// ELF build-id plus file offset; symbolized through the build-id store
+    /// regardless of whether the process still exists.
+    BuildId { id: [u8; 20], offset: u64 },
+}
+
 // Stack structure representing kernel, user, and Python stacks.
 //
 // Direction invariant: every segment is stored ROOT-TO-LEAF (outermost
 // caller first, innermost/executing frame last). The BPF unwinder and
-// pystacks both deliver frames leaf-first; `Stack::new` reverses each
+// pystacks both deliver frames leaf-first; the constructors reverse each
 // segment so `frame_ids`, folded output, and exports all read one
 // coherent direction.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Stack {
     pub(crate) kernel_stack: Vec<u64>,
-    pub(crate) user_stack: Vec<u64>,
+    pub(crate) user_stack: Vec<UserFrame>,
     pub(crate) py_stack: Vec<PyAddr>,
 }
 
@@ -55,11 +74,26 @@ pub struct Stack {
 const MAX_USER_ADDR: u64 = 0x0000_FFFF_FFFF_FFFF;
 
 /// Filters out zero and garbage addresses from user stack and reverses to get root-to-leaf order.
-fn filter_and_reverse_user_stack(addrs: &[u64]) -> Vec<u64> {
+fn filter_and_reverse_user_stack(addrs: &[u64]) -> Vec<UserFrame> {
     addrs
         .iter()
         .copied()
         .filter(|&addr| addr != 0 && addr <= MAX_USER_ADDR)
+        .map(UserFrame::Ip)
+        .rev()
+        .collect()
+}
+
+/// Same for pre-parsed frames (build-id mode): the garbage-address filter
+/// applies to raw-IP fallback frames only — build-id frames carry a file
+/// offset, for which the virtual-address bound is meaningless.
+fn filter_and_reverse_user_frames(frames: Vec<UserFrame>) -> Vec<UserFrame> {
+    frames
+        .into_iter()
+        .filter(|f| match f {
+            UserFrame::Ip(addr) => *addr != 0 && *addr <= MAX_USER_ADDR,
+            UserFrame::BuildId { .. } => true,
+        })
         .rev()
         .collect()
 }
@@ -86,6 +120,19 @@ impl Stack {
         Self {
             kernel_stack: filter_and_reverse_kernel_stack(kernel_stack),
             user_stack: filter_and_reverse_user_stack(user_stack),
+            py_stack: reverse_py_stack(py_stack),
+        }
+    }
+
+    /// Like [`Stack::new`] but with pre-parsed user frames (build-id mode).
+    pub fn from_frames(
+        kernel_stack: &[u64],
+        user_frames: Vec<UserFrame>,
+        py_stack: &[PyAddr],
+    ) -> Self {
+        Self {
+            kernel_stack: filter_and_reverse_kernel_stack(kernel_stack),
+            user_stack: filter_and_reverse_user_frames(user_frames),
             py_stack: reverse_py_stack(py_stack),
         }
     }
@@ -172,7 +219,11 @@ impl StackSpill {
 
     /// Record format (little-endian):
     /// id: i64, tgid: i32, klen: u16, ulen: u16, pylen: u16,
-    /// then klen+ulen u64 addresses and pylen (u64 symbol_id, i32 inst_idx).
+    /// then klen u64 kernel addresses, ulen self-describing user frames
+    /// (tag u8: 0 = raw IP, u64 follows; 1 = build-id, 20 id bytes + u64
+    /// offset follow), and pylen (u64 symbol_id, i32 inst_idx) entries.
+    /// The file never outlives the run, so there is no cross-version
+    /// compatibility to keep.
     ///
     /// Called from the ringbuf consumer path, but only once per *unique* stack
     /// and buffered through page cache, so it does not normally block event
@@ -202,8 +253,18 @@ impl StackSpill {
         for addr in &stack.kernel_stack {
             self.buf.extend_from_slice(&addr.to_le_bytes());
         }
-        for addr in &stack.user_stack {
-            self.buf.extend_from_slice(&addr.to_le_bytes());
+        for frame in &stack.user_stack {
+            match frame {
+                UserFrame::Ip(addr) => {
+                    self.buf.push(0);
+                    self.buf.extend_from_slice(&addr.to_le_bytes());
+                }
+                UserFrame::BuildId { id, offset } => {
+                    self.buf.push(1);
+                    self.buf.extend_from_slice(id);
+                    self.buf.extend_from_slice(&offset.to_le_bytes());
+                }
+            }
         }
         for py in &stack.py_stack {
             self.buf.extend_from_slice(&py.addr.symbol_id.to_le_bytes());
@@ -459,25 +520,54 @@ fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32,
     let ulen = u16::from_le_bytes(hdr[14..16].try_into().unwrap()) as usize;
     let pylen = u16::from_le_bytes(hdr[16..18].try_into().unwrap()) as usize;
 
+    let mut kernel_stack = Vec::with_capacity(klen);
+    let mut buf8 = [0u8; 8];
+    for _ in 0..klen {
+        reader
+            .read_exact(&mut buf8)
+            .context("reading stack spill kernel frame")?;
+        kernel_stack.push(u64::from_le_bytes(buf8));
+    }
+
+    // User frames are self-describing (see `push`): tag 0 = raw IP (u64),
+    // tag 1 = build-id (20 id bytes + u64 file offset).
+    let mut user_stack = Vec::with_capacity(ulen);
+    for _ in 0..ulen {
+        let mut tag = [0u8; 1];
+        reader
+            .read_exact(&mut tag)
+            .context("reading stack spill user frame tag")?;
+        match tag[0] {
+            0 => {
+                reader
+                    .read_exact(&mut buf8)
+                    .context("reading stack spill user frame")?;
+                user_stack.push(UserFrame::Ip(u64::from_le_bytes(buf8)));
+            }
+            1 => {
+                let mut bid = [0u8; 20];
+                reader
+                    .read_exact(&mut bid)
+                    .context("reading stack spill build-id")?;
+                reader
+                    .read_exact(&mut buf8)
+                    .context("reading stack spill build-id offset")?;
+                user_stack.push(UserFrame::BuildId {
+                    id: bid,
+                    offset: u64::from_le_bytes(buf8),
+                });
+            }
+            t => anyhow::bail!("corrupt stack spill record: unknown user frame tag {t}"),
+        }
+    }
+
     // Python frames serialize as 12 bytes: u64 symbol_id + i32 inst_idx.
     const PY_FRAME_BYTES: usize = 12;
-    let mut addrs = vec![0u8; (klen + ulen) * 8 + pylen * PY_FRAME_BYTES];
+    let mut py_bytes = vec![0u8; pylen * PY_FRAME_BYTES];
     reader
-        .read_exact(&mut addrs)
+        .read_exact(&mut py_bytes)
         .context("reading stack spill record body")?;
-
-    let mut off = 0;
-    let read_u64s = |n: usize, off: &mut usize| -> Vec<u64> {
-        let v = addrs[*off..*off + n * 8]
-            .chunks_exact(8)
-            .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
-            .collect();
-        *off += n * 8;
-        v
-    };
-    let kernel_stack = read_u64s(klen, &mut off);
-    let user_stack = read_u64s(ulen, &mut off);
-    let py_stack = addrs[off..off + pylen * PY_FRAME_BYTES]
+    let py_stack = py_bytes
         .chunks_exact(PY_FRAME_BYTES)
         .map(|c| PyAddr {
             addr: crate::pystacks::types::StackWalkerFrame {
@@ -508,6 +598,51 @@ struct UserSymbolizeCtx<'a> {
     guest: Option<&'a GuestProcess>,
 }
 
+/// Kernel `enum bpf_stack_build_id_status` values, as delivered in
+/// `systing_stack_build_id.status` (EMPTY = 0 produces no frame at all).
+const BUILD_ID_STATUS_VALID: i32 = 1;
+const BUILD_ID_STATUS_IP: i32 = 2;
+
+/// `stack_event.user_stack_format` values (mirrors the BPF-side
+/// USER_STACK_FORMAT_* defines): which entry format the event's user_stack
+/// region carries.
+const USER_STACK_FORMAT_BUILD_ID: u32 = 1;
+
+/// Index one live process's executable mappings into the build-id store
+/// (the opportunistic fill source). Returns how many mappings were read.
+///
+/// Each mapping is read through its `map_files` link first — namespace-
+/// immune, so containerized processes' binaries index correctly under the
+/// privileges systing runs with in production — falling back to the maps
+/// path, which works unprivileged for same-namespace processes. A process
+/// racing to exit mid-read is just a miss.
+fn fill_store_from_maps(store: &mut BuildIdStore, maps: &ProcessMaps) -> usize {
+    let mut mappings = 0usize;
+    for (link, display) in maps.exec_file_links() {
+        let (bid, resolve_path) = match read_elf_build_id(&link) {
+            Ok(Some(b)) => (b, link),
+            _ => match read_elf_build_id(&display) {
+                Ok(Some(b)) => (b, display.clone()),
+                _ => continue,
+            },
+        };
+        let mut id = [0u8; 20];
+        let bytes: &[u8] = &bid;
+        let n = bytes.len().min(20);
+        // Shorter note payloads zero-extend, matching the kernel's fixed
+        // 20-byte field.
+        id[..n].copy_from_slice(&bytes[..n]);
+        let module = display
+            .file_name()
+            .and_then(|f| f.to_str())
+            .unwrap_or("[buildid]")
+            .to_string();
+        store.fill_live(id, resolve_path, module);
+        mappings += 1;
+    }
+    mappings
+}
+
 /// Convert BPF stack_event_type (u32) to i8, clamping to valid range.
 /// Valid values are 0 (STACK_SLEEP_UNINTERRUPTIBLE), 1 (STACK_RUNNING), 2 (STACK_SLEEP_INTERRUPTIBLE).
 /// Unknown values are preserved but clamped to i8::MAX to avoid truncation issues.
@@ -525,6 +660,14 @@ pub struct StackRecorder {
     pub(crate) ringbuf: RingBuffer<stack_event>,
     pub(crate) psr: Arc<StackWalkerRun>,
     process_dispatcher: Option<Arc<ProcessDispatcher>>,
+    /// Shared debuginfod client (when enabled): backs both the process
+    /// dispatcher above and the build-id store's by-id fetches.
+    debuginfod_client: Option<Arc<CachingClient>>,
+    /// When set, BPF delivered user frames as (build-id, file offset) pairs
+    /// (`--collect-build-id`): handle_event parses the `user_stack_bid`
+    /// tail, and symbolization resolves those frames through the
+    /// build-id store instead of the process.
+    build_id_mode: bool,
     // Streaming support
     /// Collector for emitting StackSampleRecords as they arrive. When set, samples
     /// are written immediately in handle_event() and stacks are deduplicated during
@@ -593,16 +736,19 @@ impl ThreadAwareRecorder for StackRecorder {
 
 impl StackRecorder {
     pub fn new(enable_debuginfod: bool, utid_generator: Arc<UtidGenerator>) -> Self {
-        let process_dispatcher = if enable_debuginfod {
-            create_debuginfod_dispatcher()
+        let debuginfod_client = if enable_debuginfod {
+            create_debuginfod_client()
         } else {
             None
         };
+        let process_dispatcher = debuginfod_client.clone().map(create_debuginfod_dispatcher);
 
         Self {
             ringbuf: RingBuffer::default(),
             psr: Arc::new(StackWalkerRun::default()),
             process_dispatcher,
+            debuginfod_client,
+            build_id_mode: false,
             streaming_collector: None,
             interner: StackInterner::new(1)
                 .with_id_limit(crate::memory_recorder::MEMORY_STACK_ID_OFFSET),
@@ -615,6 +761,14 @@ impl StackRecorder {
             names_only: false,
             elide_generics: false,
         }
+    }
+
+    /// Enable build-id mode: user frames arrive as (build-id, file offset)
+    /// pairs in the event's `user_stack_bid` tail and symbolize through the
+    /// build-id store. Must match the BPF-side `collect_build_id` rodata
+    /// setting.
+    pub fn set_build_id_mode(&mut self, enabled: bool) {
+        self.build_id_mode = enabled;
     }
 
     /// Disable contextual labels on unresolvable frames (revert to bare hex).
@@ -799,6 +953,46 @@ impl StackRecorder {
         // for all processes.
         let mut kernel_cache: HashMap<u64, String> = HashMap::new();
 
+        // Build-id store and result cache (build-id mode; both stay empty
+        // otherwise). Unlike the per-process user caches below, these are
+        // global: (build-id, offset) identifies a frame independently of
+        // any process, so one resolution serves every process — dead or
+        // alive — that ever mapped that binary.
+        let mut bid_store = BuildIdStore::new(self.debuginfod_client.clone());
+        let mut bid_cache: HashMap<([u8; 20], u64), String> = HashMap::new();
+
+        // Index every live process's executable mappings by build-id note —
+        // the store's opportunistic source. Host-wide rather than
+        // sampled-tgids-only because the binaries a dead process mapped are
+        // often held open by processes that were never sampled (the
+        // `systing record -- short_cmd` shape: the traced command dies, its
+        // binary lives on in unsampled processes). One bounded pass at
+        // symbolization time; nothing here runs during capture.
+        if self.build_id_mode {
+            let t0 = std::time::Instant::now();
+            let mut mappings = 0usize;
+            if let Ok(entries) = std::fs::read_dir("/proc") {
+                for entry in entries.flatten() {
+                    let Some(tgid) = entry
+                        .file_name()
+                        .to_str()
+                        .and_then(|s| s.parse::<i32>().ok())
+                    else {
+                        continue;
+                    };
+                    let Some(maps) = ProcessMaps::load(tgid) else {
+                        continue;
+                    };
+                    mappings += fill_store_from_maps(&mut bid_store, &maps);
+                }
+            }
+            eprintln!(
+                "Note: build-id store: indexed {mappings} executable mappings \
+                 from live processes in {:.0?}",
+                t0.elapsed()
+            );
+        }
+
         // Pass 1: stream spilled stacks back from disk one record at a time
         // (then any kept in memory). Stacks of exited processes are emitted
         // immediately: their user addresses cannot be symbolized at all
@@ -826,6 +1020,8 @@ impl StackRecorder {
 
         // Each interner is dropped at the end of its loop iteration, releasing
         // its dedup table before the (memory-hungry) live-process pass below.
+        // Build-id frames of exited processes resolve right here: the store
+        // was populated from all live processes above, before any pass ran.
         for mut interner in interners {
             interner.spill.drain(|stack, tgid, stack_id| {
                 let alive = *tgid_alive
@@ -841,6 +1037,8 @@ impl StackRecorder {
                     None,
                     &kernel_src,
                     &mut kernel_cache,
+                    &mut bid_store,
+                    &mut bid_cache,
                 );
                 pb.inc(1);
                 emit_stack_record(collector, stack_id, frame_names)
@@ -955,6 +1153,8 @@ impl StackRecorder {
                         Some((&ctx, &mut user_cache)),
                         &kernel_src,
                         &mut kernel_cache,
+                        &mut bid_store,
+                        &mut bid_cache,
                     );
                     pb.inc(1);
                     emit_stack_record(collector, stack_id, frame_names)?;
@@ -1038,14 +1238,74 @@ impl StackRecorder {
         crate::sandbox_maps::format_unresolved(addr, ctx.maps)
     }
 
+    /// Symbolize one (build-id, file offset) frame through the build-id
+    /// store, with the global result cache in front. Process-independent:
+    /// works identically whether the producing process is alive or gone.
+    /// Store misses render the deferred form — the full build-id and offset
+    /// travel in the frame string, so anything downstream can resolve it
+    /// once some store learns the id.
+    fn symbolize_build_id_frame(
+        &self,
+        symbolizer: &mut Symbolizer,
+        store: &mut BuildIdStore,
+        cache: &mut HashMap<([u8; 20], u64), String>,
+        id: [u8; 20],
+        offset: u64,
+    ) -> String {
+        if let Some(name) = cache.get(&(id, offset)) {
+            return name.clone();
+        }
+        let name = self.resolve_build_id_frame(symbolizer, store, id, offset);
+        cache.insert((id, offset), name.clone());
+        name
+    }
+
+    fn resolve_build_id_frame(
+        &self,
+        symbolizer: &mut Symbolizer,
+        store: &mut BuildIdStore,
+        id: [u8; 20],
+        offset: u64,
+    ) -> String {
+        if let Some(bin) = store.lookup(&id) {
+            let mut elf = Elf::new(&bin.path);
+            elf.debug_syms = !self.names_only;
+            let elf_src = Source::Elf(elf);
+            if let Some(sym) = symbolizer
+                .symbolize_single(&elf_src, Input::FileOffset(offset))
+                .ok()
+                .and_then(|s| s.into_sym())
+            {
+                // The trailing <...> slot carries the file offset (the
+                // frame's identity within the module), not a virtual
+                // address — build-id frames don't have one.
+                return format_symbolized_frame_forced_module(
+                    &sym,
+                    offset,
+                    &bin.display_module,
+                    self.elide_generics,
+                );
+            }
+        }
+        if self.frame_labels {
+            format!("unknown ([buildid:{}]) <{offset:#x}>", build_id_hex(&id))
+        } else {
+            // Even with labels off the identity must survive: a bare offset
+            // would masquerade as a virtual address.
+            format!("buildid:{}+{offset:#x}", build_id_hex(&id))
+        }
+    }
+
     /// Symbolize a single stack and return frame names.
     ///
     /// `user` carries the symbolization context and per-process address
     /// cache for a live process; `None` means the process has exited, in
-    /// which case user addresses cannot be symbolized (no /proc/<pid>/maps)
-    /// and are rendered as `unknown ([exited]) <addr>` (or raw hex with
-    /// labels disabled). Kernel addresses go through the shared
-    /// `kernel_cache`.
+    /// which case raw user addresses cannot be symbolized (no
+    /// /proc/<pid>/maps) and are rendered as `unknown ([exited]) <addr>`
+    /// (or raw hex with labels disabled). Build-id frames don't need the
+    /// process at all: they resolve through the store either way. Kernel
+    /// addresses go through the shared `kernel_cache`.
+    #[allow(clippy::too_many_arguments)]
     fn symbolize_stack_frames(
         &self,
         symbolizer: &mut Symbolizer,
@@ -1053,6 +1313,8 @@ impl StackRecorder {
         user: Option<(&UserSymbolizeCtx<'_>, &mut HashMap<u64, String>)>,
         kernel_src: &Source<'_>,
         kernel_cache: &mut HashMap<u64, String>,
+        bid_store: &mut BuildIdStore,
+        bid_cache: &mut HashMap<([u8; 20], u64), String>,
     ) -> Vec<String> {
         let mut frame_names = Vec::with_capacity(
             stack.user_stack.len() + stack.kernel_stack.len() + stack.py_stack.len(),
@@ -1065,25 +1327,38 @@ impl StackRecorder {
         // Symbolize user addresses (middle segment of the root-to-leaf array)
         match user {
             Some((ctx, user_cache)) => {
-                for &addr in &stack.user_stack {
-                    let frame_name = match user_cache.get(&addr) {
-                        Some(name) => name.clone(),
-                        None => {
-                            let name = self.symbolize_user_addr(symbolizer, ctx, addr);
-                            user_cache.insert(addr, name.clone());
-                            name
-                        }
+                for frame in &stack.user_stack {
+                    let frame_name = match frame {
+                        UserFrame::Ip(addr) => match user_cache.get(addr) {
+                            Some(name) => name.clone(),
+                            None => {
+                                let name = self.symbolize_user_addr(symbolizer, ctx, *addr);
+                                user_cache.insert(*addr, name.clone());
+                                name
+                            }
+                        },
+                        UserFrame::BuildId { id, offset } => self.symbolize_build_id_frame(
+                            symbolizer, bid_store, bid_cache, *id, *offset,
+                        ),
                     };
                     frame_names.push(frame_name);
                 }
             }
             None => {
-                for &addr in &stack.user_stack {
-                    if self.frame_labels {
-                        frame_names.push(format!("unknown ([exited]) <{addr:#x}>"));
-                    } else {
-                        frame_names.push(format!("0x{addr:x}"));
-                    }
+                for frame in &stack.user_stack {
+                    let frame_name = match frame {
+                        UserFrame::Ip(addr) => {
+                            if self.frame_labels {
+                                format!("unknown ([exited]) <{addr:#x}>")
+                            } else {
+                                format!("0x{addr:x}")
+                            }
+                        }
+                        UserFrame::BuildId { id, offset } => self.symbolize_build_id_frame(
+                            symbolizer, bid_store, bid_cache, *id, *offset,
+                        ),
+                    };
+                    frame_names.push(frame_name);
                 }
             }
         }
@@ -1170,25 +1445,16 @@ fn format_symbolized_frame_forced_module(
     format!("{name} ({module_name}{location_info}) <{addr:#x}>")
 }
 
-/// Create a debuginfod dispatcher if debuginfod is available in the environment
-fn create_debuginfod_dispatcher() -> Option<Arc<ProcessDispatcher>> {
+/// Create a shared debuginfod client if debuginfod is available in the
+/// environment. Backs both the process dispatcher (path-keyed fetches for
+/// live processes) and the build-id store (id-keyed fetches, which need no
+/// process at all).
+fn create_debuginfod_client() -> Option<Arc<CachingClient>> {
     match Client::from_env() {
         Ok(Some(client)) => match CachingClient::from_env(client) {
             Ok(caching_client) => {
                 println!("Debuginfod enabled: using debuginfod for symbol resolution");
-
-                // Wrap the CachingClient in an Arc so it can be shared across threads.
-                // The closure below will take ownership of this Arc (via the `move` keyword),
-                // storing it as part of the closure's captured state. When the closure is
-                // called during symbolization, it will clone the Arc to pass to
-                // dispatch_process_with_client. The CachingClient itself remains shared
-                // across all threads (only the Arc reference is cloned, not the client).
-                // The closure and its captured Arc<CachingClient> will live as long as the
-                // StackRecorder that owns the process_dispatcher field.
-                let client = Arc::new(caching_client);
-                Some(Arc::new(Box::new(move |info: ProcessMemberInfo<'_>| -> Result<Option<Box<dyn Resolve>>, BlazeErr> {
-                    dispatch_process_with_client(info, client.clone())
-                }) as ProcessDispatcher))
+                Some(Arc::new(caching_client))
             }
             Err(e) => {
                 println!("Failed to create caching debuginfod client: {e}, using default resolver");
@@ -1204,6 +1470,20 @@ fn create_debuginfod_dispatcher() -> Option<Arc<ProcessDispatcher>> {
             None
         }
     }
+}
+
+/// Wrap the shared debuginfod client as a blazesym process dispatcher.
+///
+/// The closure takes ownership of one Arc clone; each dispatch clones the
+/// Arc again (the client itself is shared, not copied). The closure and its
+/// captured Arc live as long as the StackRecorder that owns the
+/// process_dispatcher field.
+fn create_debuginfod_dispatcher(client: Arc<CachingClient>) -> Arc<ProcessDispatcher> {
+    Arc::new(Box::new(
+        move |info: ProcessMemberInfo<'_>| -> Result<Option<Box<dyn Resolve>>, BlazeErr> {
+            dispatch_process_with_client(info, client.clone())
+        },
+    ) as ProcessDispatcher)
 }
 
 /// Callback function for process dispatcher that fetches debug info using debuginfod
@@ -1255,11 +1535,51 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
 
         if has_stack {
             let kstack_vec = Vec::from(&event.kernel_stack[..event.kernel_stack_length as usize]);
-            let ustack_vec = Vec::from(&event.user_stack[..event.user_stack_length as usize]);
+            // One user_stack region, two entry formats; the per-event
+            // user_stack_format flag says which one this record carries
+            // (self-describing — the parse never depends on recorder-side
+            // configuration). user_stack_length counts entries of that
+            // format; it is BPF-computed from the walker's return value,
+            // but clamp anyway — a short (zero-extended) record must never
+            // index past the region.
+            let ulen = event.user_stack_length as usize;
+            let user_frames: Vec<UserFrame> =
+                if event.user_stack_format == USER_STACK_FORMAT_BUILD_ID {
+                    event.user_stack[..ulen.min(event.user_stack.len())]
+                        .iter()
+                        .filter_map(|e| match e.status {
+                            BUILD_ID_STATUS_VALID => Some(UserFrame::BuildId {
+                                id: e.build_id,
+                                offset: e.offset_or_ip,
+                            }),
+                            BUILD_ID_STATUS_IP => Some(UserFrame::Ip(e.offset_or_ip)),
+                            // EMPTY (or anything unknown): no frame.
+                            _ => None,
+                        })
+                        .collect()
+                } else {
+                    // Raw-IP format: the region holds packed u64 addresses from
+                    // its start (the reservation covered only those bytes).
+                    // SAFETY: stack_event is Plain (repr(C)); the region starts
+                    // u64-aligned (it follows u64-aligned fields in a struct of
+                    // alignment 8), MAX_STACK_DEPTH u64s (288B) fit inside the
+                    // MAX_STACK_DEPTH 32-byte entries (1152B), and the record
+                    // was zero-extended to the full struct size on copy.
+                    let ips: &[u64] = unsafe {
+                        std::slice::from_raw_parts(
+                            event.user_stack.as_ptr() as *const u64,
+                            event.user_stack.len(),
+                        )
+                    };
+                    ips[..ulen.min(ips.len())]
+                        .iter()
+                        .map(|&addr| UserFrame::Ip(addr))
+                        .collect()
+                };
             let stack_key = (event.task.tgidpid >> 32) as i32;
             let py_stack = self.psr.get_pystack_from_event(&event);
 
-            let stack = Stack::new(&kstack_vec, &ustack_vec, &py_stack);
+            let stack = Stack::from_frames(&kstack_vec, user_frames, &py_stack);
             let tid = event.task.tgidpid as i32;
             let tgid = stack_key; // tgid for process-specific symbolization
 
@@ -1296,40 +1616,80 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
 mod tests {
     use super::*;
 
+    /// Raw addresses as Ip frames (the classic-capture shape).
+    fn ips(addrs: &[u64]) -> Vec<UserFrame> {
+        addrs.iter().map(|&a| UserFrame::Ip(a)).collect()
+    }
+
+    fn bid_frame(seed: u8, offset: u64) -> UserFrame {
+        UserFrame::BuildId {
+            id: [seed; 20],
+            offset,
+        }
+    }
+
     #[test]
     fn test_filter_and_reverse_user_stack() {
         // Test zero filtering
-        assert_eq!(filter_and_reverse_user_stack(&[0, 0x1000, 0]), vec![0x1000]);
+        assert_eq!(
+            filter_and_reverse_user_stack(&[0, 0x1000, 0]),
+            ips(&[0x1000])
+        );
 
         // Test reversal
         assert_eq!(
             filter_and_reverse_user_stack(&[0x1000, 0x2000]),
-            vec![0x2000, 0x1000]
+            ips(&[0x2000, 0x1000])
         );
 
         // Test MAX_USER_ADDR boundary - address at boundary should be kept
         assert_eq!(
             filter_and_reverse_user_stack(&[0x1000, MAX_USER_ADDR]),
-            vec![MAX_USER_ADDR, 0x1000]
+            ips(&[MAX_USER_ADDR, 0x1000])
         );
 
         // Test garbage addresses above MAX_USER_ADDR are filtered
         assert_eq!(
             filter_and_reverse_user_stack(&[0x1000, MAX_USER_ADDR + 1]),
-            vec![0x1000]
+            ips(&[0x1000])
         );
 
         // Test typical garbage from bad frame pointer unwinding (instruction bytes)
         assert_eq!(
             filter_and_reverse_user_stack(&[0x7f0000001000, 0xc48348d88948ff31]),
-            vec![0x7f0000001000]
+            ips(&[0x7f0000001000])
         );
 
         // Empty stack
-        assert_eq!(filter_and_reverse_user_stack(&[]), Vec::<u64>::new());
+        assert_eq!(filter_and_reverse_user_stack(&[]), Vec::<UserFrame>::new());
 
         // All zeros
-        assert_eq!(filter_and_reverse_user_stack(&[0, 0, 0]), Vec::<u64>::new());
+        assert_eq!(
+            filter_and_reverse_user_stack(&[0, 0, 0]),
+            Vec::<UserFrame>::new()
+        );
+    }
+
+    #[test]
+    fn test_filter_and_reverse_user_frames() {
+        // The garbage filter applies to Ip fallback frames only; build-id
+        // frames carry file offsets, for which the virtual-address bound is
+        // meaningless (offset 0 is a legitimate file offset).
+        let frames = vec![
+            UserFrame::Ip(0),                 // filtered: zero addr
+            bid_frame(1, 0),                  // kept: offset 0 is valid
+            UserFrame::Ip(MAX_USER_ADDR + 1), // filtered: garbage addr
+            bid_frame(2, u64::MAX),           // kept: any offset
+            UserFrame::Ip(0x1000),            // kept
+        ];
+        assert_eq!(
+            filter_and_reverse_user_frames(frames),
+            vec![
+                UserFrame::Ip(0x1000),
+                bid_frame(2, u64::MAX),
+                bid_frame(1, 0)
+            ]
+        );
     }
 
     #[test]
@@ -1411,7 +1771,7 @@ mod tests {
             (
                 Stack {
                     kernel_stack: vec![0xffffffff81000000, 0xffffffff82000000],
-                    user_stack: vec![0x7f0000001000],
+                    user_stack: ips(&[0x7f0000001000]),
                     py_stack: py.clone(),
                 },
                 42,
@@ -1420,7 +1780,7 @@ mod tests {
             (
                 Stack {
                     kernel_stack: vec![],
-                    user_stack: vec![0x1000, 0x2000, 0x3000],
+                    user_stack: ips(&[0x1000, 0x2000, 0x3000]),
                     py_stack: vec![],
                 },
                 -1,
@@ -1429,21 +1789,36 @@ mod tests {
             (
                 Stack {
                     kernel_stack: vec![],
-                    user_stack: vec![],
+                    user_stack: ips(&[]),
                     py_stack: py,
                 },
                 i32::MAX,
                 i64::MAX,
             ),
+            // Build-id mode stacks interleave BuildId and Ip-fallback
+            // frames; both tags must round-trip.
+            (
+                Stack {
+                    kernel_stack: vec![0xffffffff81000000],
+                    user_stack: vec![
+                        bid_frame(0xab, 0x1234),
+                        UserFrame::Ip(0x7f0000002000),
+                        bid_frame(0x01, u64::MAX),
+                    ],
+                    py_stack: vec![],
+                },
+                7,
+                8,
+            ),
         ];
         for (stack, tgid, id) in &stacks {
             spill.push(stack.clone(), *tgid, *id);
         }
-        assert_eq!(spill.total(), 3);
+        assert_eq!(spill.total(), 4);
         assert!(spill.fallback.is_empty());
 
         let (mut reader, durable) = spill.take_reader().expect("reader");
-        assert_eq!(durable, 3);
+        assert_eq!(durable, 4);
         for (stack, tgid, id) in &stacks {
             let (rstack, rtgid, rid) = read_spill_record(&mut reader).unwrap().unwrap();
             assert_eq!(&rstack, stack);
@@ -1463,7 +1838,7 @@ mod tests {
         for i in 0..n {
             let stack = Stack {
                 kernel_stack: vec![i],
-                user_stack: vec![i + 1],
+                user_stack: ips(&[i + 1]),
                 py_stack: vec![],
             };
             spill.push(stack, i as i32, i as i64);
@@ -1496,7 +1871,7 @@ mod tests {
             spill.push(
                 Stack {
                     kernel_stack: vec![i],
-                    user_stack: vec![],
+                    user_stack: ips(&[]),
                     py_stack: vec![],
                 },
                 i as i32,
@@ -1507,7 +1882,7 @@ mod tests {
         spill.push(
             Stack {
                 kernel_stack: vec![99],
-                user_stack: vec![],
+                user_stack: ips(&[]),
                 py_stack: vec![],
             },
             99,
@@ -1523,7 +1898,7 @@ mod tests {
             spill.push(
                 Stack {
                     kernel_stack: vec![i],
-                    user_stack: vec![],
+                    user_stack: ips(&[]),
                     py_stack: vec![],
                 },
                 i as i32,
@@ -1533,7 +1908,7 @@ mod tests {
         spill.fallback.push((
             Stack {
                 kernel_stack: vec![99],
-                user_stack: vec![],
+                user_stack: ips(&[]),
                 py_stack: vec![],
             },
             99,
@@ -1557,7 +1932,7 @@ mod tests {
         let mut spill = StackSpill::new();
         let stack = Stack {
             kernel_stack: vec![1],
-            user_stack: vec![2],
+            user_stack: ips(&[2]),
             py_stack: vec![],
         };
         spill.push(stack.clone(), 5, 9);
@@ -1574,12 +1949,12 @@ mod tests {
 
         let a = Stack {
             kernel_stack: vec![0xffffffff81000000],
-            user_stack: vec![0x1000],
+            user_stack: ips(&[0x1000]),
             py_stack: vec![],
         };
         let b = Stack {
             kernel_stack: vec![0xffffffff81000000],
-            user_stack: vec![0x2000],
+            user_stack: ips(&[0x2000]),
             py_stack: vec![],
         };
 
@@ -1611,7 +1986,7 @@ mod tests {
         let h = (RandomState::new(), RandomState::new());
         let a = Stack {
             kernel_stack: vec![0xffffffff81000000],
-            user_stack: vec![0x1000],
+            user_stack: ips(&[0x1000]),
             py_stack: vec![],
         };
         let b = a.clone();
@@ -1621,17 +1996,66 @@ mod tests {
         // Different contents must produce a different key
         let c = Stack {
             kernel_stack: vec![0xffffffff81000000],
-            user_stack: vec![0x1001],
+            user_stack: ips(&[0x1001]),
             py_stack: vec![],
         };
         assert_ne!(stack_dedup_hash(&h, &a, 1), stack_dedup_hash(&h, &c, 1));
         // Moving an address between kernel and user stacks must change the key
         let d = Stack {
             kernel_stack: vec![],
-            user_stack: vec![0xffffffff81000000, 0x1000],
+            user_stack: ips(&[0xffffffff81000000, 0x1000]),
             py_stack: vec![],
         };
         assert_ne!(stack_dedup_hash(&h, &a, 1), stack_dedup_hash(&h, &d, 1));
+        // An Ip frame and a BuildId frame whose offset equals the address
+        // must not alias — the variant (and the id bytes) are part of the key.
+        let e = Stack {
+            kernel_stack: vec![0xffffffff81000000],
+            user_stack: vec![bid_frame(0, 0x1000)],
+            py_stack: vec![],
+        };
+        assert_ne!(stack_dedup_hash(&h, &a, 1), stack_dedup_hash(&h, &e, 1));
+        // Same offset, different build-id: different key.
+        let f = Stack {
+            kernel_stack: vec![0xffffffff81000000],
+            user_stack: vec![bid_frame(1, 0x1000)],
+            py_stack: vec![],
+        };
+        assert_ne!(stack_dedup_hash(&h, &e, 1), stack_dedup_hash(&h, &f, 1));
+    }
+
+    /// The user_stack region is ONE tail-positioned array sized for the
+    /// build-id entry format; raw-IP mode packs u64s from its start and the
+    /// BPF side reserves only `offsetof(user_stack) + 36 * 8` bytes for it.
+    /// The region must therefore be the LAST field (a shorter raw-IP
+    /// reservation would truncate anything after it), and the raw-IP u64
+    /// view requires the region to start u64-aligned. Also pins the mirror
+    /// struct's layout to the kernel's bpf_stack_build_id (s32 + 20 bytes +
+    /// u64 at offset 24 = 32 bytes).
+    #[test]
+    fn test_stack_event_user_stack_region_layout() {
+        use crate::systing_core::types::systing_stack_build_id;
+        use std::mem::{align_of, offset_of, size_of};
+        assert_eq!(size_of::<systing_stack_build_id>(), 32);
+        let region = offset_of!(stack_event, user_stack);
+        let full = size_of::<stack_event>();
+        assert_eq!(
+            full - region,
+            36 * size_of::<systing_stack_build_id>(),
+            "user_stack must be the final field of stack_event \
+             (raw-IP reservations stop partway into it)"
+        );
+        assert_eq!(
+            region % align_of::<u64>(),
+            0,
+            "the region must start u64-aligned for the raw-IP packed view"
+        );
+        let ip_reserve = region + 36 * size_of::<u64>();
+        eprintln!(
+            "stack_event reservation: raw-ip={ip_reserve}B build-id={full}B \
+             ratio={:.2}",
+            full as f64 / ip_reserve as f64
+        );
     }
 
     #[test]
@@ -1667,7 +2091,7 @@ mod tests {
         let live_id = rec.interner.intern(
             Stack {
                 kernel_stack: vec![],
-                user_stack: vec![live_addr],
+                user_stack: ips(&[live_addr]),
                 py_stack: vec![],
             },
             self_tgid,
@@ -1679,7 +2103,7 @@ mod tests {
         let dead_id = rec.interner.intern(
             Stack {
                 kernel_stack: vec![],
-                user_stack: vec![dead_addr],
+                user_stack: ips(&[dead_addr]),
                 py_stack: vec![],
             },
             dead_tgid,
@@ -1710,7 +2134,7 @@ mod tests {
         let plain_id = rec_plain.interner.intern(
             Stack {
                 kernel_stack: vec![],
-                user_stack: vec![dead_addr],
+                user_stack: ips(&[dead_addr]),
                 py_stack: vec![],
             },
             dead_tgid,
@@ -1741,7 +2165,7 @@ mod tests {
         let live_id = rec.interner.intern(
             Stack {
                 kernel_stack: vec![],
-                user_stack: vec![live_addr],
+                user_stack: ips(&[live_addr]),
                 py_stack: vec![],
             },
             self_tgid,
@@ -1751,7 +2175,7 @@ mod tests {
         let dead_id = rec.interner.intern(
             Stack {
                 kernel_stack: vec![],
-                user_stack: vec![dead_addr],
+                user_stack: ips(&[dead_addr]),
                 py_stack: vec![],
             },
             dead_tgid,
@@ -1780,5 +2204,126 @@ mod tests {
             dead.frame_names[0],
             format!("unknown ([exited]) <{dead_addr:#x}>")
         );
+    }
+
+    /// Build-id mode, the deferred path: a dead-process frame whose
+    /// build-id no source knows must render the full id and offset (that
+    /// identity is what makes it resolvable offline), not `[exited]` hex.
+    #[test]
+    fn test_finish_inner_build_id_deferred_render() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        rec.set_build_id_mode(true);
+        rec.set_spill_dir(dir.path());
+
+        let dead_tgid = i32::MAX - 1;
+        let id_bytes = [0x5au8; 20];
+        let dead_id = rec.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![UserFrame::BuildId {
+                    id: id_bytes,
+                    offset: 0x1234,
+                }],
+                py_stack: vec![],
+            },
+            dead_tgid,
+        );
+
+        let mut collector = crate::record::InMemoryCollector::new();
+        rec.finish_inner(&mut collector).unwrap();
+        let stacks = &collector.data().stacks;
+        let dead = stacks.iter().find(|s| s.id == dead_id).expect("dead stack");
+        assert_eq!(
+            dead.frame_names[0],
+            format!("unknown ([buildid:{}]) <0x1234>", "5a".repeat(20))
+        );
+    }
+
+    /// Build-id mode, the resolution path this design exists for: a frame
+    /// of a DEAD process symbolizes because a LIVE process (here: the test
+    /// binary itself) still maps the binary, whose build-id the store
+    /// indexes during the live pass. Skips (with a note) when the test
+    /// binary carries no GNU build-id note — linker-dependent.
+    #[test]
+    fn test_finish_inner_build_id_dead_frame_resolves_via_live_fill() {
+        let exe = std::fs::read_link("/proc/self/exe").unwrap();
+        let Ok(Some(own_bid)) = read_elf_build_id(&exe) else {
+            eprintln!("skipping: test binary has no GNU build-id note");
+            return;
+        };
+        let mut id = [0u8; 20];
+        let bytes: &[u8] = &own_bid;
+        let n = bytes.len().min(20);
+        id[..n].copy_from_slice(&bytes[..n]);
+
+        // File offset of marker_fn inside our own executable, derived from
+        // /proc/self/maps (addr - segment start + segment file offset).
+        let addr = marker_fn as fn() -> u64 as usize as u64;
+        let maps = std::fs::read_to_string("/proc/self/maps").unwrap();
+        let mut offset = None;
+        for line in maps.lines() {
+            let mut parts = line.split_whitespace();
+            let (Some(range), Some(_perms), Some(off)) = (parts.next(), parts.next(), parts.next())
+            else {
+                continue;
+            };
+            let Some((lo, hi)) = range.split_once('-') else {
+                continue;
+            };
+            let (Ok(lo), Ok(hi), Ok(off)) = (
+                u64::from_str_radix(lo, 16),
+                u64::from_str_radix(hi, 16),
+                u64::from_str_radix(off, 16),
+            ) else {
+                continue;
+            };
+            if lo <= addr && addr < hi {
+                offset = Some(addr - lo + off);
+                break;
+            }
+        }
+        let offset = offset.expect("marker_fn must be inside a mapping of our own exe");
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        rec.set_build_id_mode(true);
+        rec.set_spill_dir(dir.path());
+
+        // The live stack makes pass 2 visit our own tgid and index our
+        // executable mappings by build-id; the dead stack then resolves
+        // against that fill even though its tgid has no /proc entry.
+        let self_tgid = std::process::id() as i32;
+        let live_id = rec.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![UserFrame::BuildId { id, offset }],
+                py_stack: vec![],
+            },
+            self_tgid,
+        );
+        let dead_tgid = i32::MAX - 1;
+        let dead_id = rec.interner.intern(
+            Stack {
+                kernel_stack: vec![],
+                user_stack: vec![UserFrame::BuildId { id, offset }],
+                py_stack: vec![],
+            },
+            dead_tgid,
+        );
+
+        let mut collector = crate::record::InMemoryCollector::new();
+        rec.finish_inner(&mut collector).unwrap();
+        let stacks = &collector.data().stacks;
+
+        for (which, sid) in [("live", live_id), ("dead", dead_id)] {
+            let s = stacks.iter().find(|s| s.id == sid).expect(which);
+            let frame = &s.frame_names[0];
+            assert!(
+                frame.contains("marker_fn"),
+                "{which} build-id frame should resolve to marker_fn via the \
+                 live-fill store, got: {frame}"
+            );
+        }
     }
 }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -588,6 +588,11 @@ pub struct Config {
     pub continuous: u64,
     /// Collect Python stack traces
     pub collect_pystacks: bool,
+    /// Capture user stacks as (build-id, file offset) pairs instead of raw
+    /// IPs (BPF_F_USER_BUILD_ID), so frames of exited processes remain
+    /// symbolizable from a build-id-keyed store and unresolved frames keep a
+    /// durable identity (`unknown ([buildid:<hex>]) <0x<offset>>`)
+    pub collect_build_id: bool,
     /// Explicit PIDs for pystacks (bypasses auto-discovery)
     pub pystacks_pids: Vec<u32>,
     /// Enable debug output for pystacks
@@ -693,6 +698,7 @@ impl Default for Config {
             trace_event_config: Vec::new(),
             continuous: 0,
             collect_pystacks: false,
+            collect_build_id: false,
             pystacks_pids: Vec::new(),
             pystacks_debug: false,
             enable_debuginfod: false,
@@ -1003,6 +1009,35 @@ where
         // unbounded userspace queue.
         if tx.send(event).is_err() {
             // Receiver has been dropped, we can silently ignore this
+            return -1;
+        }
+        0
+    })?;
+    builder.build()
+}
+
+/// Like [`create_ring`] but tolerant of records shorter than `T`: the record
+/// zero-extends into a default `T`. The stack ring needs this because classic
+/// (non-build-id) reservations stop at `offsetof(stack_event, user_stack_bid)`
+/// — the same variable-length contract the memory ring has always used.
+fn create_ring_zero_extend<'a, T>(
+    map: &dyn libbpf_rs::MapCore,
+    tx: SyncSender<T>,
+) -> Result<libbpf_rs::RingBuffer<'a>, libbpf_rs::Error>
+where
+    T: Default + Plain + 'a,
+{
+    let mut builder = RingBufferBuilder::new();
+    builder.add(map, move |data: &[u8]| {
+        let mut event = T::default();
+        let len = data.len().min(std::mem::size_of::<T>());
+        // SAFETY: T is Plain (repr(C), no padding invariants) and
+        // default-initialized; we copy at most sizeof(T) bytes from the
+        // BPF-produced ringbuf record into its leading bytes.
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), &mut event as *mut T as *mut u8, len);
+        }
+        if tx.send(event).is_err() {
             return -1;
         }
         0
@@ -1548,6 +1583,13 @@ fn configure_recorder(opts: &Config, recorder: &Arc<SessionRecorder>) {
         let duration_nanos = Duration::from_secs(opts.continuous).as_nanos() as u64;
         set_ringbuf_duration(recorder, duration_nanos);
     }
+    if opts.collect_build_id {
+        recorder
+            .stack_recorder
+            .lock()
+            .unwrap()
+            .set_build_id_mode(true);
+    }
     if opts.no_frame_labels {
         recorder
             .stack_recorder
@@ -2063,7 +2105,7 @@ fn setup_ringbuffers<'a>(
             event_rxs.push(event_rx);
             rings.push((format!("events_{i}"), ring));
         } else if name.starts_with("ringbuf_stack") {
-            let ring = create_ring::<stack_event>(&map, stack_tx.clone())?;
+            let ring = create_ring_zero_extend::<stack_event>(&map, stack_tx.clone())?;
             rings.push((name.to_string(), ring));
         } else if name.starts_with("ringbuf_perf_counter")
             && required.contains("perf_counter_ringbufs")
@@ -2294,6 +2336,9 @@ fn configure_bpf_skeleton(
         }
         if collect_pystacks {
             rodata.tool_config.collect_pystacks = 1;
+        }
+        if opts.collect_build_id {
+            rodata.tool_config.collect_build_id = 1;
         }
         if opts.syscalls {
             rodata.tool_config.collect_syscalls = 1;

--- a/tests/build_id_record.rs
+++ b/tests/build_id_record.rs
@@ -1,0 +1,199 @@
+//! End-to-end test for `--collect-build-id`: user frames of a process that
+//! exits before end-of-trace symbolization resolve by NAME, because the
+//! build-id capture makes their identity process-independent.
+//!
+//! The dead process is a child running this test binary itself, so the
+//! binary is guaranteed to still be mapped by a live process (us) at
+//! symbolization time — the store's host-wide live-process index picks it
+//! up (we are alive, even though we were never sampled: the trace is
+//! pid-filtered to the child) and the dead child's (build-id, offset)
+//! frames resolve against it. That is the exact population the flag
+//! exists for: `systing record -- short_cmd`.
+//!
+//! To run:
+//! ```
+//! ./scripts/run-integration-tests.sh build_id_record
+//! ```
+
+mod common;
+
+use common::workload::SLOW_MACHINE_BUDGET;
+use systing::{systing, Config};
+use tempfile::TempDir;
+
+/// Not a real test: a busy-loop child process for
+/// test_build_id_dead_process_symbolization, run as systing's traced
+/// command via `<test-binary> --exact burner_helper_busy_loop`.
+/// Deliberately NOT `#[ignore]`: the VM integration runner selects ignored
+/// tests (`--ignored`), and this helper must be excluded there while
+/// staying spawnable by exact name. The loop is wall-clock bound (not
+/// iteration bound) so TCG slowdown cannot shrink its lifetime, and two
+/// seconds is enough on-CPU time for the sampler even when the consumer
+/// side lags. The test binary carries a full symbol table and (linker
+/// permitting) a GNU build-id note; samples landing here are
+/// name-resolvable if and only if the dead-process path has something to
+/// resolve against.
+#[test]
+fn burner_helper_busy_loop() {
+    use std::time::{Duration, Instant};
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut counter: u64 = 0;
+    while Instant::now() < deadline {
+        counter = std::hint::black_box(counter.wrapping_add(1));
+    }
+    assert!(counter > 0);
+}
+
+/// Frame-name census of one recorded trace of a single short-lived burner
+/// child. Returns (burner_named, exited, buildid_deferred) frame counts.
+///
+/// The burner runs as systing's traced command, which pins the whole
+/// lifecycle to events instead of machine-speed guesses (QEMU TCG
+/// stretches BPF setup to tens of seconds): the forked child blocks until
+/// tracing is attached before it execs, so the burner cannot burn out
+/// before the window opens, and the recording stops because the child
+/// exited and was reaped, so the burner is gone from /proc before
+/// end-of-trace symbolization runs.
+fn record_and_count(collect_build_id: bool) -> (usize, usize, usize) {
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
+    use std::time::Instant;
+    use systing::traced_command::spawn_traced_child;
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let trace_path = dir.path().join("trace.pb");
+    let own_binary = std::env::current_exe().expect("current_exe");
+
+    let child = spawn_traced_child(&[
+        own_binary
+            .to_str()
+            .expect("test binary path not utf-8")
+            .to_string(),
+        "--exact".to_string(),
+        "burner_helper_busy_loop".to_string(),
+    ])
+    .expect("failed to fork burner child");
+
+    let start = Instant::now();
+    let config = Config {
+        duration: 300, // backstop only: the child's exit stops the trace
+        collect_build_id,
+        output_dir: dir.path().to_path_buf(),
+        output: trace_path,
+        ..Config::default()
+    };
+    systing(config, Some(child)).expect("systing recording failed");
+    let elapsed = start.elapsed();
+    eprintln!("  recording stopped after {:.1}s", elapsed.as_secs_f64());
+    assert!(
+        elapsed < SLOW_MACHINE_BUDGET,
+        "recording should stop when the burner exits; took {:.1}s \
+         (duration backstop reached - child-exit stop broken?)",
+        elapsed.as_secs_f64()
+    );
+
+    let stack_parquet = dir.path().join("stack.parquet");
+    assert!(stack_parquet.exists(), "[build-id] stack.parquet not found");
+    let file = File::open(&stack_parquet).expect("Failed to open stack.parquet");
+    let reader = ParquetRecordBatchReaderBuilder::try_new(file)
+        .expect("Failed to create reader")
+        .build()
+        .expect("Failed to build reader");
+
+    let mut burner_named = 0usize;
+    let mut exited = 0usize;
+    let mut buildid_deferred = 0usize;
+    for batch_result in reader {
+        let batch = batch_result.expect("Failed to read batch");
+        let Some(frame_names_col) = batch.column_by_name("frame_names") else {
+            continue;
+        };
+        use arrow::array::{Array, ListArray, StringArray};
+        let list_array = frame_names_col
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("frame_names should be a ListArray");
+        for i in 0..list_array.len() {
+            if list_array.is_null(i) {
+                continue;
+            }
+            let inner = list_array.value(i);
+            let string_array = inner
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .expect("frame_names inner should be StringArray");
+            for j in 0..string_array.len() {
+                if string_array.is_null(j) {
+                    continue;
+                }
+                let frame = string_array.value(j);
+                if frame.contains("burner_helper_busy_loop") {
+                    burner_named += 1;
+                }
+                if frame.contains("[exited]") {
+                    exited += 1;
+                }
+                if frame.contains("[buildid:") || frame.starts_with("buildid:") {
+                    buildid_deferred += 1;
+                }
+            }
+        }
+    }
+    (burner_named, exited, buildid_deferred)
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_build_id_dead_process_symbolization() {
+    // The premise: this test binary must carry a GNU build-id note, or the
+    // kernel walker has nothing to extract and the whole run is vacuous.
+    // Fail loudly rather than skip — the VM gate builds with a toolchain
+    // that emits the note, so absence there is a real regression.
+    {
+        use blazesym::helper::read_elf_build_id;
+        let exe = std::env::current_exe().expect("current_exe");
+        let bid = read_elf_build_id(&exe).expect("reading own build-id");
+        assert!(
+            bid.is_some(),
+            "test binary carries no GNU build-id note; the build-id e2e \
+             cannot run (check linker flags in the test environment)"
+        );
+    }
+
+    // Negative control first: with the flag off, the burner must have been
+    // sampled (its pid renders [exited] frames), none of its frames may
+    // resolve by name, and no frame may carry build-id vocabulary. This
+    // proves the traced child gets sampled, is reliably gone by
+    // symbolization time, and that the mode is genuinely off — which run 2
+    // inherits.
+    eprintln!("Recording without --collect-build-id (negative control)...");
+    let (named_off, exited_off, bid_off) = record_and_count(false);
+    eprintln!("  control: burner_named={named_off} exited={exited_off} buildid={bid_off}");
+    assert!(
+        exited_off > 0,
+        "[build-id control] expected [exited] frames from the dead burner, got none \
+         (burner not sampled? sampling misconfigured?)"
+    );
+    assert_eq!(
+        named_off, 0,
+        "[build-id control] burner frames resolved with the flag off - \
+         the burner survived to the live pass, control is invalid"
+    );
+    assert_eq!(
+        bid_off, 0,
+        "[build-id control] build-id frame vocabulary with the flag off"
+    );
+
+    // With build-id capture on, the same dead burner resolves by name: the
+    // kernel walker recorded (build-id, offset) pairs, and the live pass
+    // indexes this very binary (mapped by us) into the store.
+    eprintln!("Recording with --collect-build-id...");
+    let (named_on, exited_on, bid_on) = record_and_count(true);
+    eprintln!("  build-id: burner_named={named_on} exited={exited_on} buildid={bid_on}");
+    assert!(
+        named_on > 0,
+        "[build-id] no burner frames resolved by name; kernel build-id \
+         capture or the store's live fill is not working \
+         (exited={exited_on} buildid-deferred={bid_on})"
+    );
+}


### PR DESCRIPTION
## Summary

Adds `--collect-build-id`: user stacks are captured as **(build-id, file
offset)** pairs instead of raw virtual addresses, so a frame's identity no
longer depends on its process being alive at end-of-trace symbolization.
Frames of exited processes resolve by name whenever a build-id-keyed
store knows the binary — and when it doesn't, they render as
`unknown ([buildid:<hex>]) <0x<offset>>`: a durable, aggregatable
identity that can be resolved offline later, unlike a raw ASLR-slid hex
address. Off by default; the off configuration is byte- and
instruction-identical to before this change.

## Why

Processes that exit before end-of-trace symbolization render as
`unknown ([exited]) <hex>` — on fork/exec-heavy hosts (CI) that is
20-40% of CPU samples. #165 attacked this with live capture (per-sample
hints, /proc sweeps, fd pins) and was reverted (#171): its per-sample
work ran under sched-path locks, which is exactly the overhead class
#126 exists to keep out of the probes.

This is the opposite approach: **let the kernel attach the identity at
walk time, and move all resolution to the end of the trace.**
`bpf_get_stack` already supports `BPF_F_USER_BUILD_ID` — the kernel's
stack walker (the same mechanism perf uses) resolves each user frame
against the mapped file's ELF build-id note and emits
`(build_id[20], file_offset)` instead of an IP. The extraction is
kernel-internal, bounded, and trylock-guarded: where it cannot walk
safely (contended mmap lock, missing note, anonymous mapping) it falls
back to the raw IP with `BPF_STACK_BUILD_ID_IP` status, so capture is
never worse than today. No systing code runs per frame; probes stay
lookup-only.

Symbolization then becomes a pure lookup:

    (build_id, offset) -> build-id-keyed store -> name

Dead processes stop being a special case at all. A side benefit: the
result cache is keyed by `(build_id, offset)` and is fully
process-independent — one resolution serves every process that ever
mapped that binary, where the per-process address caches could not
share anything across tgids.

Binaries with no host-visible backing file get the same durability:
sandbox runtimes that map guest executables through memfd (unopenable
from the host by path) still carry ELF notes the kernel can read at
walk time, so those frames gain a resolvable identity for the first
time.

## Design

**Capture (BPF):** the event carries **one** `user_stack` region,
tail-positioned and sized for the 32-byte build-id entries. A rodata
knob (`tool_config.collect_build_id`) selects the walk: build-id mode
fills the region with `bpf_stack_build_id`-shaped entries and reserves
it fully; raw-IP mode packs u64 addresses into the same region and
reserves only the bytes it uses (`offsetof(user_stack) + depth * 8` —
byte-for-byte the pre-change reservation), with the ring consumer
zero-extending short records (the memory ring's established
variable-length pattern). A `user_stack_format` flag on the event makes
every record self-describing: the capture mode is fixed per run, so
the flag is belt-and-braces for downstream readers rather than
load-bearing. Because the knob is `const volatile` rodata, the verifier
prunes the dead arm at load time (same mechanism the `no_irq` gate
documents), so flag-off adds zero executed instructions and zero
reservation bytes. A layout test pins the region's tail position and
u64 alignment (the packed-IP view depends on both) and the mirror
struct's equivalence to the kernel's `bpf_stack_build_id` (also
`_Static_assert`ed on the BPF side).

**Store (userspace, end-of-trace):** `src/build_id_store.rs`. Fill
sources in trust order:

1. `.build-id` debug directories (`/usr/lib/debug/.build-id/xx/rest`) —
   trusted: the path is derived from the id, so a traced process cannot
   choose which file answers for an id it doesn't own.
2. debuginfod (with `--enable-debuginfod`) — trusted for the same
   reason (queried by id). The client is now shared between the
   existing process dispatcher and the store.
3. Live binaries — opportunistic: one host-wide pass at symbolization
   start indexes every live process's executable mappings by their
   build-id note, read via namespace-immune `/proc/<pid>/map_files`
   links (falling back to the maps path where map_files needs
   privileges the caller lacks). Host-wide rather than
   sampled-processes-only because the binaries a dead process mapped
   are often held open only by processes that were never sampled — the
   `systing record -- short_cmd` shape, where the traced command dies
   and its binary lives on in the unsampled parent. Nothing here runs
   during capture.

Live fills **never override** a trusted entry and never overwrite
anything already stored: a binary carrying a copied build-id note can
only affect the rendering of ids that no trusted source knows, which is
the same capability class as forging sample content outright. The store
caps its entries (16384) with LRU eviction, so unique-build-id storms
bound memory instead of growing it.

**Ordering:** the live-process index runs before any symbolization
pass, so exited-process stacks resolve in the existing first pass with
its emit-immediately memory behavior — no pass restructuring.

**Rendering:** store hits render normally (module = binary basename for
live fills, `[buildid:<hex8>]` for id-derived sources; the trailing
`<...>` slot carries the file offset — the frame's identity within the
module). Store misses keep the full id:
`unknown ([buildid:<40-hex>]) <0x<offset>>`. The full id is the point —
truncating it would break offline re-resolution.

**Deliberately absent** (the entire reverted-#165 machinery class):
hint ringbufs, seen-LRU maps, /proc sweeps at capture time, map_files
pins, fd caches, exec-invalidation handlers. Nothing accumulates during
capture, so there is nothing to bound.

## Cost

Paid **only when the flag is on**:

- Stack-ring reservations grow from 2720B to 3584B per event (1.32x)
  in the pystacks build — the one region at 32B entries instead of 8B.
  Without pystacks compiled in the base record is much smaller, so the
  ratio is steeper (~640B -> ~1500B, ~2.4x); sizing the stack rings
  accordingly is part of opting in. (A dual-walk shape that emits raw
  IPs plus a per-binary sideband was considered and is the fallback if
  this ratio ever matters; the flat capture is simpler and the numbers
  are pinned by `test_stack_event_user_stack_region_layout`.)
- The kernel does the note extraction inside `bpf_get_stack` (page-
  cache reads, `mmap_read_trylock`, IP fallback on contention — no
  sleeping, no IO, no locks taken by our code).
- End-of-trace: one /proc maps read per live process plus one ELF-note
  read per distinct executable mapping (the host-wide index; hundreds
  of milliseconds on busy hosts, in the teardown path), and one
  `.build-id` stat (plus optional debuginfod fetch, memoized per id)
  per unique build-id.

Flag off: reservation sizes, BPF instruction streams (rodata prune),
and all userspace paths are unchanged; the spill format gains a 1-byte
frame tag (run-internal file, no compatibility surface).

Object-level check (base vs branch, `llvm-objdump -d`, x86_64): **zero
instruction delta in every BPF program section** — sched, perf, IRQ,
network, memory programs are unchanged except relocated call-target
constants. The gated arms live in `emit_stack_event_with_ts`'s block
graph in `.text` (net −14 instructions vs base — the single-region
layout generates tighter code), and the build-id arm is pruned at load
when `collect_build_id` is 0 — the same rodata dead-code elimination
the `no_irq` gate documents. The BPF object also compiles clean for
aarch64 (layout `_Static_assert` included).

## Validation

- 450/450 lib tests, `clippy -D warnings`, `fmt` clean. New unit
  coverage: store trust-precedence (live never overrides trusted,
  misses memoized, LRU cap eviction), spill round-trip of mixed
  build-id/IP frames, dedup-hash discrimination (an IP and an equal
  offset must not alias; different ids must not alias), deferred-render
  format, and the layout pin.
- `test_finish_inner_build_id_dead_frame_resolves_via_live_fill`: a
  dead-tgid stack whose build-id frame resolves to a named symbol
  because a live process (the test itself) maps the binary — the core
  promise, proven without a VM.
- New `build_id_record` integration test (VM): records a traced child
  that exits before symbolization, negative-control first (flag off:
  frames render `[exited]`, zero build-id vocabulary), then asserts the
  same dead process's frames resolve **by name** with the flag on. Its
  first run caught a real gap — a pid-filtered trace samples no live
  process, so a sampled-tgids-only fill had nothing to index (frames
  stayed in the deferred form, end-to-end capture proven but no
  names) — which is what made the live fill host-wide.
- Full VM gate: 9/9 existing targets pass with the flag off, plus the
  new target run explicitly (both at this head).

## Follow-ups (out of scope here)

- Memory-recorder stacks keep raw-IP capture in v0; adopting the same
  tail-array pattern there is mechanical once this shape settles.
- An artifact-store fill source (build-id -> symbols service) — the
  store's source ranking already leaves room for it.
- A post-hoc re-resolution pass over emitted traces (the rendered
  frames carry everything it needs).
