### PR TITLE
network: attribute flows to their network namespace inode [bump minor]

### DIFF
--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -271,3 +271,28 @@ SCHEMA_VERSION bump); `callsites` tables written by older systing-util
 binaries from spec-compliant inputs carry the inverted parent/depth shape and
 cannot be distinguished in-band — re-import with a fixed binary if the tree
 direction matters.
+
+## Schema Version 13 (systing 1.12.0) — 2026-07-29
+
+`network_socket` and `network_interface` each gain a `netns_inum BIGINT` column:
+the inode of the network namespace that owns the socket (for a flow row) or the
+interface/IP (for an interface row). It lets a reader attribute a flow to its
+owning netns — and therefore its pod — by joining
+`network_socket.netns_inum = network_interface.netns_inum`, instead of matching
+the socket's `src_ip` against the interface map. The IP match cannot
+disambiguate loopback (every netns has `127.0.0.1`/`::1` on `lo`), so
+intra-pod-localhost flows were unattributable before; the netns inode is
+unambiguous. It also attributes inbound flows (whose `src_ip` is the remote
+peer, not a local interface) and IPv4-mapped-IPv6 sockets correctly.
+
+### New columns
+- `network_socket.netns_inum` (BIGINT): read in BPF from the socket's
+  `struct sock` (`sk->__sk_common.skc_net.net->ns.inum`) at send/recv event
+  emission; the netns is stable over the socket's lifetime. `0` when the sock
+  pointer was unavailable.
+- `network_interface.netns_inum` (BIGINT): the inode of the enumerated netns
+  (the same value userspace reads from `/proc/<pid>/ns/net`), emitted alongside
+  the existing `namespace` display string by the per-namespace interface walk.
+
+Pre-v13 databases and traces have neither column; readers join on `netns_inum`
+where present and fall back to the `src_ip`→interface heuristic otherwise.

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -293,6 +293,11 @@ struct network_event {
 	u32 recv_seq_start;    // TCP copied_seq at recvmsg entry (TCP recv only)
 	u32 recv_seq_end;      // TCP copied_seq at recvmsg exit (TCP recv only)
 	u32 rcv_nxt_at_entry;  // TCP rcv_nxt at entry - kernel's next expected seq (TCP recv only)
+	u64 netns_inum;    // Inode of the socket's network namespace (sk->__sk_common.skc_net).
+	                   // Lets the fold attribute a flow to its owning netns (hence pod)
+	                   // directly, instead of inferring it from src_ip against the
+	                   // interface map — which cannot disambiguate loopback (every netns
+	                   // has 127.0.0.1). 0 when the sock pointer was unavailable.
 };
 
 enum packet_event_type {
@@ -335,6 +340,7 @@ struct packet_event {
 	u32 sndbuf_used;   // Bytes in send buffer (sk_wmem_queued) - shows buffer drain on ACK
 	u32 sndbuf_limit;  // Max send buffer size (sk_sndbuf)
 	u64 socket_id;     // Unique socket ID for correlation with network events
+	u64 netns_inum;    // Inode of the socket's network namespace (see network_event.netns_inum).
 	u8 is_retransmit;  // 1 if this packet is a TCP retransmit, 0 otherwise
 	u8 is_zero_window_probe;  // 1 if this is a zero window probe (sender-side)
 	u8 probe_count;           // Number of probes sent (icsk_probes_out)
@@ -2752,6 +2758,19 @@ static int handle_sendmsg_entry(struct sock *sk, struct msghdr *msg, enum networ
 	return 0;
 }
 
+// Read the inode of a socket's network namespace from a struct sock pointer.
+// The netns is stable over the socket's lifetime, so reading it at event-emit
+// time is equivalent to reading it at socket creation. Returns 0 if sk_ptr is
+// null. The inode matches what userspace reads via /proc/<pid>/ns/net, so the
+// fold can join a flow's netns_inum to the interface map's per-netns inode.
+static __always_inline u64 read_sk_netns_inum(u64 sk_ptr)
+{
+	if (!sk_ptr)
+		return 0;
+	struct sock *sk = (struct sock *)sk_ptr;
+	return BPF_CORE_READ(sk, __sk_common.skc_net.net, ns.inum);
+}
+
 static int handle_sendmsg_exit(void *ctx, int ret)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
@@ -2805,6 +2824,7 @@ static int handle_sendmsg_exit(void *ctx, int ret)
 
 	// Copy socket_id for correlation
 	event->socket_id = info->socket_id;
+	event->netns_inum = read_sk_netns_inum(info->sk_ptr);
 
 	bpf_ringbuf_submit(event, flags);
 	bpf_map_delete_elem(&pending_network_sends, &tgidpid);
@@ -2931,6 +2951,7 @@ static int handle_recvmsg_exit(void *ctx, int ret)
 
 	// Copy socket_id for correlation
 	event->socket_id = info->socket_id;
+	event->netns_inum = read_sk_netns_inum(info->sk_ptr);
 
 	// Copy TCP receive sequence tracking fields (TCP only)
 	if (info->protocol == NETWORK_TCP) {
@@ -3139,6 +3160,7 @@ int BPF_KPROBE(udp_send_skb_entry, struct sk_buff *skb, struct flowi4 *fl4, stru
 	// Look up socket ID for this socket with full 4-tuple
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	event->sndbuf_used = 0;
 	event->sndbuf_limit = 0;
@@ -3209,6 +3231,7 @@ int BPF_KPROBE(udp_queue_rcv_one_skb_entry, struct sock *sk, struct sk_buff *skb
 	// Look up socket ID
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	event->sndbuf_used = 0;
 	event->sndbuf_limit = 0;
@@ -3279,6 +3302,7 @@ int BPF_KPROBE(udp_enqueue_schedule_skb_entry, struct sock *sk, struct sk_buff *
 	// Look up socket ID
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	event->sndbuf_used = 0;
 	event->sndbuf_limit = 0;
@@ -3340,6 +3364,7 @@ int BPF_KPROBE(tcp_transmit_skb_entry, struct sock *sk, struct sk_buff *skb, int
 	// Look up socket ID for this socket with full 4-tuple
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	// Read send buffer state from socket
 	int wmem_queued = 0;
@@ -3413,6 +3438,7 @@ static __always_inline int emit_tcp_packet_event(struct sock *sk, struct sk_buff
 	// Look up socket ID for this socket with full 4-tuple
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	// Read send buffer state from socket
 	int wmem_queued = 0;
@@ -3456,6 +3482,7 @@ static __always_inline int emit_udp_packet_event(struct sock *sk, struct sk_buff
 	// Look up socket ID for this socket with full 4-tuple
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	event->sndbuf_used = 0;
 	event->sndbuf_limit = 0;
@@ -3599,6 +3626,7 @@ int BPF_KPROBE(tcp_rcv_established_entry, struct sock *sk, struct sk_buff *skb)
 	// Look up socket ID for this socket with full 4-tuple
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	event->sndbuf_used = 0;
 	event->sndbuf_limit = 0;
@@ -3662,6 +3690,7 @@ int BPF_KPROBE(tcp_queue_rcv_entry, struct sock *sk, struct sk_buff *skb, bool *
 	// Look up socket ID
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	event->sndbuf_used = 0;
 	event->sndbuf_limit = 0;
@@ -3724,6 +3753,7 @@ int BPF_PROG(skb_copy_datagram_iovec, const struct sk_buff *skb, int len)
 	// Look up socket ID
 	pkt_event->socket_id = lookup_socket_id(sk, pkt_event->src_addr, pkt_event->src_port,
 						 pkt_event->dest_addr, pkt_event->dest_port);
+	pkt_event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	pkt_event->sndbuf_used = 0;
 	pkt_event->sndbuf_limit = 0;
@@ -3807,6 +3837,7 @@ int BPF_KPROBE(tcp_send_probe0_entry, struct sock *sk)
 	// Get socket ID for correlation
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	bpf_ringbuf_submit(event, flags);
 	return 0;
@@ -3909,6 +3940,7 @@ int BPF_KPROBE(tcp_send_ack_entry, struct sock *sk)
 	// Get socket ID for correlation
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	// Initialize persist timer fields (receiver-side ACK events don't have this info)
 	event->icsk_pending = 0;
@@ -4026,6 +4058,7 @@ int BPF_KPROBE(tcp_retransmit_timer_entry, struct sock *sk)
 	// Get socket ID for correlation
 	event->socket_id = lookup_socket_id(sk, event->src_addr, event->src_port,
 					     event->dest_addr, event->dest_port);
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 
 	// Read persist timer state
 	bpf_probe_read_kernel(&event->icsk_pending, sizeof(event->icsk_pending), &icsk->icsk_pending);
@@ -4385,6 +4418,7 @@ int BPF_KPROBE(sk_stream_wait_memory_entry, struct sock *sk, long *timeo)
 	event->event_type = PACKET_MEM_PRESSURE;
 	event->cpu = bpf_get_smp_processor_id();
 	event->socket_id = *socket_id_ptr;
+	event->netns_inum = read_sk_netns_inum(sk_ptr);
 	event->protocol = NETWORK_TCP;
 
 	// Read socket addresses
@@ -4666,6 +4700,7 @@ int BPF_PROG(inet_sock_set_state, const struct sock *sk, int oldstate, int newst
 	__builtin_memcpy(event->dest_addr, dest_addr, 16);
 	event->dest_port = dest_port;
 	event->socket_id = socket_id;
+	event->netns_inum = read_sk_netns_inum((u64)sk);
 	event->old_state = (u8)oldstate;
 	event->new_state = (u8)newstate;
 

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -133,7 +133,7 @@ pub struct TraceImportMapping {
 }
 
 /// Current schema version. See SCHEMA_CHANGES.md for history.
-pub const SCHEMA_VERSION: u32 = 12;
+pub const SCHEMA_VERSION: u32 = 13;
 
 /// All data tables in the DuckDB schema (excludes the `_traces` metadata table).
 pub const DATA_TABLES: &[&str] = &[
@@ -425,7 +425,8 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
             namespace VARCHAR,
             interface_name VARCHAR,
             ip_address VARCHAR,
-            address_type VARCHAR
+            address_type VARCHAR,
+            netns_inum BIGINT
         );
 
         -- Socket connection metadata (extracted from socket track names)
@@ -522,6 +523,7 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
         CREATE TABLE IF NOT EXISTS network_socket (
             trace_id VARCHAR,
             socket_id BIGINT,
+            netns_inum BIGINT,
             protocol VARCHAR,
             address_family VARCHAR,
             src_ip VARCHAR,

--- a/src/network_recorder.rs
+++ b/src/network_recorder.rs
@@ -367,6 +367,7 @@ impl NetworkRecorder {
         src_port: u16,
         dest_addr: &[u8; 16],
         dest_port: u16,
+        netns_inum: u64,
         ts: i64,
     ) -> Result<bool> {
         use crate::systing_core::types::{network_address_family, network_protocol};
@@ -411,6 +412,7 @@ impl NetworkRecorder {
         // Emit NetworkSocketRecord
         collector.add_network_socket(NetworkSocketRecord {
             socket_id: socket_id as i64,
+            netns_inum: netns_inum as i64,
             protocol: protocol_str,
             address_family: af_str,
             src_ip,
@@ -455,6 +457,7 @@ impl NetworkRecorder {
             event.src_port,
             &event.dest_addr,
             event.dest_port,
+            event.netns_inum,
             ts,
         )?;
 
@@ -542,6 +545,7 @@ impl NetworkRecorder {
             event.src_port,
             &event.dest_addr,
             event.dest_port,
+            event.netns_inum,
             ts,
         )?;
 

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -2023,12 +2023,14 @@ fn build_network_interface_batch(
         StringBuilder::with_capacity(records.len(), records.len() * 16);
     let mut ip_address_builder = StringBuilder::with_capacity(records.len(), records.len() * 45);
     let mut address_type_builder = StringBuilder::with_capacity(records.len(), records.len() * 4);
+    let mut netns_inum_builder = Int64Builder::with_capacity(records.len());
 
     for record in records {
         namespace_builder.append_value(&record.namespace);
         interface_name_builder.append_value(&record.interface_name);
         ip_address_builder.append_value(&record.ip_address);
         address_type_builder.append_value(&record.address_type);
+        netns_inum_builder.append_value(record.netns_inum);
     }
 
     Ok(RecordBatch::try_new(
@@ -2038,6 +2040,7 @@ fn build_network_interface_batch(
             Arc::new(interface_name_builder.finish()),
             Arc::new(ip_address_builder.finish()),
             Arc::new(address_type_builder.finish()),
+            Arc::new(netns_inum_builder.finish()),
         ],
     )?)
 }
@@ -2390,6 +2393,7 @@ fn build_network_socket_batch(
     schema: &Arc<Schema>,
 ) -> Result<RecordBatch> {
     let mut socket_id_builder = Int64Builder::with_capacity(records.len());
+    let mut netns_inum_builder = Int64Builder::with_capacity(records.len());
     let mut protocol_builder = StringBuilder::with_capacity(records.len(), records.len() * 3);
     let mut address_family_builder = StringBuilder::with_capacity(records.len(), records.len() * 4);
     let mut src_ip_builder = StringBuilder::with_capacity(records.len(), records.len() * 45);
@@ -2401,6 +2405,7 @@ fn build_network_socket_batch(
 
     for record in records {
         socket_id_builder.append_value(record.socket_id);
+        netns_inum_builder.append_value(record.netns_inum);
         protocol_builder.append_value(&record.protocol);
         address_family_builder.append_value(&record.address_family);
         src_ip_builder.append_value(&record.src_ip);
@@ -2415,6 +2420,7 @@ fn build_network_socket_batch(
         schema.clone(),
         vec![
             Arc::new(socket_id_builder.finish()),
+            Arc::new(netns_inum_builder.finish()),
             Arc::new(protocol_builder.finish()),
             Arc::new(address_family_builder.finish()),
             Arc::new(src_ip_builder.finish()),

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -1331,6 +1331,7 @@ impl SessionRecorder {
                         interface_name: iface.name.clone(),
                         ip_address: ipv4.to_string(),
                         address_type: "ipv4".to_string(),
+                        netns_inum: netns_info.inode as i64,
                     })?;
                 }
 
@@ -1341,6 +1342,7 @@ impl SessionRecorder {
                         interface_name: iface.name.clone(),
                         ip_address: ipv6.to_string(),
                         address_type: "ipv6".to_string(),
+                        netns_inum: netns_info.inode as i64,
                     })?;
                 }
             }

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -282,6 +282,10 @@ pub struct NetworkInterfaceRecord {
     pub interface_name: String,
     pub ip_address: String,
     pub address_type: String,
+    /// Inode of the network namespace this interface/IP belongs to. Lets the
+    /// fold join a flow's `network_socket.netns_inum` to its owning netns
+    /// without going through the IP (unambiguous for loopback). 0 if unknown.
+    pub netns_inum: i64,
 }
 
 /// Socket connection record.
@@ -421,6 +425,10 @@ pub struct NetworkPacketRecord {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NetworkSocketRecord {
     pub socket_id: i64,
+    /// Inode of the socket's network namespace. Joins `network_interface.netns_inum`
+    /// to attribute the flow to its owning netns (hence pod) directly, without
+    /// inferring from src_ip (which cannot disambiguate loopback). 0 if unknown.
+    pub netns_inum: i64,
     pub protocol: String,
     pub address_family: String,
     pub src_ip: String,

--- a/src/trace/schema.rs
+++ b/src/trace/schema.rs
@@ -202,6 +202,7 @@ pub fn network_interface_schema() -> Arc<Schema> {
         Field::new("interface_name", DataType::Utf8, false),
         Field::new("ip_address", DataType::Utf8, false),
         Field::new("address_type", DataType::Utf8, false),
+        Field::new("netns_inum", DataType::Int64, false),
     ]))
 }
 
@@ -385,6 +386,7 @@ pub fn network_packet_schema() -> Arc<Schema> {
 pub fn network_socket_schema() -> Arc<Schema> {
     Arc::new(Schema::new(vec![
         Field::new("socket_id", DataType::Int64, false),
+        Field::new("netns_inum", DataType::Int64, false),
         Field::new("protocol", DataType::Utf8, false),
         Field::new("address_family", DataType::Utf8, false),
         Field::new("src_ip", DataType::Utf8, false),


### PR DESCRIPTION
Adds a `netns_inum` column to `network_socket` and `network_interface` (schema v13): for a flow row, the inode of the network namespace that owns the socket, read in BPF at event emission; for an interface row, the inode of the namespace the interface was enumerated in (the per-namespace walk already computes this inode for its namespace names).

## Why

Flow-to-namespace attribution currently matches the socket's `src_ip` against the per-namespace interface map. That match cannot disambiguate loopback, because every namespace has `127.0.0.1`/`::1` on `lo`, so intra-namespace localhost traffic is unattributable. Inbound flows (whose recorded source is the remote peer) and IPv4-mapped-IPv6 sockets also attribute wrongly or not at all. The namespace inode is unambiguous: a reader joins `network_socket.netns_inum = network_interface.netns_inum` and gets the owning namespace (and hence the container) directly.

## Mechanics

- BPF: a `read_sk_netns_inum()` helper — one null-guarded CO-RE read of `sk->__sk_common.skc_net.net->ns.inum` — stamped at all 16 socket-bearing emission sites (2 network events from `info->sk_ptr`, 14 packet events from `sk`). The 5 packet paths with no socket pointer leave the field 0; both event reserves memset their buffers, so "unknown" is a real 0, never garbage.
- A socket's netns is stable for its lifetime, so reading at emission equals reading at creation. Readers treat 0 as "unattributed" — the pre-change behavior. A wrong attribution is not possible, only a missing one.
- Rust: both records carry `netns_inum` (i64) through models → recorder → arrow schema → parquet writer → DuckDB DDL. `SCHEMA_VERSION` 12→13 with a `SCHEMA_CHANGES.md` entry. `Cargo.toml` untouched (version is assigned at merge).

## Testing

- `cargo build --tests` green — compiles the CO-RE read against vmlinux BTF, which validates the field chain exists with the right types.
- `cargo fmt --check` and `cargo clippy --workspace --no-default-features -- -D warnings`: clean.
- `cargo test --lib`: 454 passed (schema round-trip and fold tests).
- Runtime verification: the VM integration rig was unavailable in this environment, so runtime behavior is validated at first deployment on a multi-namespace node, per a written gate: BPF load-proof on the production kernel; sampled `network_socket.netns_inum` nonzero and distinct across namespaces; join against `network_interface.netns_inum` with ~0 mismatches (the BPF read and a userspace `stat` of `/proc/<pid>/ns/net` return the same nsfs inode by construction); exact match to a known workload's namespace inode; root-namespace sockets carrying the init-ns inode; and the no-socket packet paths reading 0. This PR is write-only — nothing consumes the new column yet — so the deploy-time validation carries no consumer risk. It covers the trace-level tables this PR writes; downstream consumers are validated separately when they land.
