### PR TITLE
skills: update trace/analyze docs to match the current CLI and schema

### DIFF
--- a/skills/systing-analyze/SKILL.md
+++ b/skills/systing-analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: systing-analyze
-description: Analyze a systing trace database (.duckdb). Use when the user asks about a systing trace — flamegraphs, scheduling latency, CPU hotspots, network behavior, off-CPU time, TPU op/metric data, or any question about what's in a trace.duckdb file. Orchestrates the systing-analyze MCP tools (trace_info, query, flamegraph, sched_stats, cpu_stats, network_*).
+description: Analyze a systing trace database (.duckdb). Use when the user asks about a systing trace — flamegraphs, scheduling latency, CPU hotspots, network behavior, memory/allocation activity, off-CPU time, TPU op/metric data, or any question about what's in a trace.duckdb file. Orchestrates the systing-analyze MCP tools (trace_info, query, flamegraph, sched_stats, cpu_stats, network_*).
 ---
 
 # Analyzing systing traces
@@ -9,25 +9,28 @@ Systing stores traces in **DuckDB**. The `systing-analyze` MCP server exposes st
 
 ## Recommended workflow
 
-1. **`trace_info`** — Always start here. Pass the `path` to the `.duckdb` file. Returns trace IDs, time range, available tables/row counts, and top processes. This also caches the DB so later calls can omit `path`.
+1. **`trace_info`** — Always start here. Pass the `path` to the `.duckdb` file. Returns trace IDs, time range, per-trace system/platform info (kernel, arch, hypervisor, cpufreq driver, sampling event/period), non-empty tables with row counts, and the top 25 processes by thread count. This also caches the DB so later calls can omit `path`.
 2. **`list_tables`** / **`describe_table`** — Discover schema for ad-hoc queries.
 3. **High-level tools** for common questions — see below.
-4. **`query`** — For anything the high-level tools don't cover, write SQL. Results cap at 10k rows; use `LIMIT`/`OFFSET` for more.
+4. **`query`** — For anything the high-level tools don't cover, write SQL. Results cap at 10k rows (`truncated: true` when hit); use `LIMIT`/`OFFSET` for more. The DB is opened read-only.
 
 ## Tool cheatsheet
 
 | Question | Tool | Notes |
 |---|---|---|
 | What's in this trace? | `trace_info` | First call; pass `path` |
-| Where is CPU time going? | `flamegraph` | filter `stack_type=cpu`; optionally filter by `pid` or `tid` |
-| Why is the process blocked / off-CPU? | `flamegraph` | filter `stack_type=uninterruptible` (D-state) or `interruptible` (S-state) |
-| Is the scheduler oversubscribed? Latency? | `sched_stats` | no filter = whole-trace; `pid` = per-thread breakdown; `tid` = single thread |
-| Which CPUs are busy / idle? | `cpu_stats` | per-CPU utilization, IRQ time, runqueue depth |
-| What's the network doing? | `network_connections` | per-connection bytes, retransmit rate |
+| Where is CPU time going? | `flamegraph` | `stack_type="cpu"` (default); optionally `pid`/`tid` |
+| Why is the process blocked / off-CPU? | `flamegraph` | `stack_type="uninterruptible-sleep"` (D) or `"interruptible-sleep"` (S), or `"all-sleep"` |
+| Is the scheduler oversubscribed? Latency? | `sched_stats` | no filter = whole-trace ranking; `pid` = per-thread breakdown; `tid` = single thread with end-state distribution |
+| Which CPUs are busy / idle? | `cpu_stats` | per-CPU utilization, idle%, IRQ/softIRQ time, runqueue depth p50/p90/p99 |
+| What's the network doing? | `network_connections` | per-connection bytes, retransmit % |
 | Interface-level network? | `network_interfaces` | per-interface, per-protocol breakdown |
-| Both sides of a connection (multi-node)? | `network_socket_pairs` | matched socket pairs across traces |
-| What ran on the TPU? Duty cycle? HBM? | `query` | no dedicated tool yet — see TPU schema below |
+| Both sides of a connection (multi-node)? | `network_socket_pairs` | matched socket pairs, within or across traces |
+| Memory / allocations? | `query` | no dedicated tool — see memory schema below |
+| What ran on the TPU? Duty cycle? HBM? | `query` | no dedicated tool — see TPU schema below |
 | Anything else | `query` | raw SQL; see schema below |
+
+There is also a CLI with the same analyses: `systing-analyze query|stacktrace flamegraph|sched stats|sched cpu-stats|network connections|network interfaces|network socket-pairs` (and `systing-analyze mcp` to start this server).
 
 ## Key schema for `query`
 
@@ -41,53 +44,104 @@ All `ts` columns are **nanoseconds** from an arbitrary epoch. Convert durations:
 ### Stack traces
 Two representations exist:
 
-**Flattened (easier)** — `stack` table: one row per sampled stack with `frame_names` as an array (leaf-to-root order). Joins to `stack_sample` on `stack_id`.
+**Interned (the normal one)** — `stack_sample` → `stack` → `frame`:
+- `stack_sample(ts, utid, cpu, stack_id, stack_event_type)`. `stack_event_type`: `0` = uninterruptible sleep, `1` = CPU, `2` = interruptible sleep.
+- `stack(id, frame_ids BIGINT[], depth, leaf_name)`. **`frame_ids` is root-to-leaf** (outermost caller first, innermost executing frame last); `leaf_name` is the last frame's name.
+- `frame(id, name)` — interned strings, dense per-trace ids.
+- Join on **both** `trace_id` and the id: `JOIN stack s ON s.trace_id = ss.trace_id AND s.id = ss.stack_id`.
+- The `stack_frames` **view** reconstructs a `frame_names VARCHAR[]` column (root-to-leaf) for ad-hoc queries — convenient but slower than joining `frame` directly.
+
 ```sql
--- Top 10 hottest leaf functions (on-CPU samples)
-SELECT frame_names[1] AS leaf, count(*) AS samples
-FROM stack_sample JOIN stack USING (stack_id)
-WHERE stack_event_type = 1  -- 1=cpu, 0=uninterruptible, 2=interruptible
+-- Top 10 hottest leaf functions (on-CPU samples) — leaf_name avoids any join
+SELECT leaf_name, count(*) AS samples
+FROM stack_sample ss
+JOIN stack s ON s.trace_id = ss.trace_id AND s.id = ss.stack_id
+WHERE ss.stack_event_type = 1  -- 1=cpu, 0=uninterruptible, 2=interruptible
 GROUP BY 1 ORDER BY 2 DESC LIMIT 10;
+
+-- Samples containing a given frame anywhere in the stack
+SELECT count(*)
+FROM stack_sample ss
+JOIN stack_frames sf ON sf.trace_id = ss.trace_id AND sf.id = ss.stack_id
+WHERE list_contains(sf.frame_names, 'do_futex_wait');
 ```
 
-**Normalized (Perfetto-style)** — `perf_sample` → `stack_profile_callsite` (parent-child tree) → `stack_profile_frame` → `stack_profile_symbol`. Use when you need mapping/build-id info. Walk the `parent_id` chain to reconstruct stacks.
+**Normalized (Perfetto-style)** — `perf_sample` → `stack_profile_callsite` (parent-child tree) → `stack_profile_frame` → `stack_profile_symbol` / `stack_profile_mapping`. Use when you need mapping/build-id info. Walk the `parent_id` chain to reconstruct stacks.
+
+### Sample weighting
+`sysinfo.sample_event` / `sysinfo.sample_period` say what one CPU sample represents: `sample_period` **cycles** for `cpu-cycles` (so sample density tracks cycles consumed, not wall time — use `sched_slice` for time, and `cpu_info` min/max/base frequencies in kHz to convert), or `sample_period` **nanoseconds** for `cpu-clock`. NULL/absent in traces from systing < 1.9 (adaptive frequency mode, nominally 1000 Hz).
 
 ### Scheduling
-`sched_slice`: one row per scheduled slice.
-- `ts`, `dur` — nanoseconds
-- `utid`, `cpu`
-- `end_state`: `1`=S (interruptible sleep), `2`=D (uninterruptible sleep), others = preempted/running
-- `end_state_str` — human-readable state string
+`sched_slice(ts, dur, cpu, utid, end_state, priority)`: one row per scheduled slice.
+- `end_state` is a **bitmask of the task state at slice end**, not an enum, and there is **no `end_state_str` column**:
+  - `NULL` → preempted (still runnable)
+  - `& 1` → interruptible sleep (S)
+  - `& 2` → uninterruptible sleep (D)
+  - `& 4` stopped, `& 8` traced, `& 16` exit/dead, `& 32` exit/zombie
+  - Test bits (`end_state & 2 != 0`), don't compare for equality — compound states occur.
+
+Related: `thread_state(ts, dur, utid, state, cpu)`, `wakeup_new`, `process_exit`, `irq_slice(irq, name, ret)`, `softirq_slice(vec)`.
 
 ```sql
 -- Longest uninterruptible-sleep episodes
 SELECT t.name, ss.dur/1e6 AS ms, ss.ts
-FROM sched_slice ss JOIN thread t USING (utid)
-WHERE end_state = 2
-ORDER BY dur DESC LIMIT 20;
+FROM sched_slice ss JOIN thread t ON t.trace_id = ss.trace_id AND t.utid = ss.utid
+WHERE ss.end_state & 2 != 0
+ORDER BY ss.dur DESC LIMIT 20;
 ```
 
 ### Network
-- `network_syscall` — sendmsg/recvmsg calls: `ts`, `dur`, `utid`, `event_type`, `socket_id`, `bytes`, buffer usage.
-- `network_packet` — packet-level: `seq`, `length`, `is_retransmit`, `srtt_ms`, `drop_reason_str`, `tcp_flags`.
-- `network_socket` — socket metadata: `socket_id`, `protocol`, src/dest IP:port.
-- Join syscall/packet → socket on `socket_id`.
+- `network_syscall` — sendmsg/recvmsg: `ts`, `dur`, `utid`, `event_type` (`sendmsg`/`recvmsg`), `socket_id`, `bytes`, send-buffer fill (`sndbuf_used/limit/fill_pct`), recv-side (`recv_seq_start/end`, `rcv_nxt`, `bytes_available`).
+- `network_packet` — packet-level: `seq`, `length`, `tcp_flags`, `is_retransmit`, `retransmit_count`, `rto_ms`, `srtt_ms`, windows (`snd_wnd`, `rcv_wnd`, zero-window probes), qdisc (`qlen`, `qdisc_backlog`, `qdisc_latency_us`), drops (`drop_reason`, `drop_reason_str`), TCP state changes (`old_state_str`, `new_state_str`).
+- `network_socket` — socket metadata: `socket_id`, `netns_inum`, `protocol`, `address_family`, src/dest IP:port, first/last seen ts.
+- `network_poll` — poll/epoll/select events per socket.
+- `network_interface` — local interface metadata (namespace, name, IPs, `netns_inum`).
+- `network_dns` — IP→hostname, only when the trace was captured with `--resolve-addresses`.
+- Join syscall/packet → socket on `socket_id` (plus `trace_id`).
 
 ```sql
 -- Retransmits by connection
 SELECT s.src_ip, s.src_port, s.dest_ip, s.dest_port,
        count(*) FILTER (WHERE p.is_retransmit) AS retransmits,
        count(*) AS total_packets
-FROM network_packet p JOIN network_socket s USING (socket_id)
+FROM network_packet p
+JOIN network_socket s ON s.trace_id = p.trace_id AND s.socket_id = p.socket_id
 GROUP BY 1,2,3,4 HAVING retransmits > 0
 ORDER BY retransmits DESC;
 ```
 
+### Memory
+From the `memory` / `memory-alloc` recorders. `stack_id` columns join to `stack.id` like sample stacks.
+
+- `memory_rss(ts, utid, member, size)` — RSS tracking. `member`: `0`=file, `1`=anon, `2`=swap, `3`=shmem, `-1`=hiwater_rss, `-2`=total_vm (the negatives are synthetic periodic `mm_struct` samples).
+- `memory_map(ts, utid, event_type, addr, size, prot, flags, stack_id)` — mmap/munmap/brk.
+- `memory_fault(ts, utid, addr, error_code, stack_id)` — user page faults (sampled 1-in-N, default 97).
+- `memory_alloc(ts, utid, op, addr, size, old_addr, stack_id)` — malloc/calloc/realloc/free uprobes.
+
+```sql
+-- Anon RSS over time for the biggest process
+SELECT p.name, r.ts, r.size
+FROM memory_rss r
+JOIN thread t ON t.trace_id = r.trace_id AND t.utid = r.utid
+JOIN process p ON p.trace_id = t.trace_id AND p.upid = t.upid
+WHERE r.member = 1 ORDER BY r.ts;
+
+-- Allocation hotspots by stack leaf
+SELECT s.leaf_name, count(*) AS allocs, sum(a.size) AS bytes
+FROM memory_alloc a
+JOIN stack s ON s.trace_id = a.trace_id AND s.id = a.stack_id
+WHERE a.op = 'malloc'
+GROUP BY 1 ORDER BY bytes DESC LIMIT 20;
+```
+
+### Counters and slices
+`counter(ts, track_id, value)` + `counter_track(id, name, unit)` for perf counters and CPU frequency; `slice`/`track`/`args` and `instant`/`instant_args` for custom trace events and markers.
+
 ### TPU
-No dedicated MCP tool yet — use `query`. Three tables:
+No dedicated MCP tool — use `query`. Three tables:
 
 - **`tpu_device`** — one row per TPU core. `id` (join key), `device_ordinal`, `chip_id`, `core_id`, `hostname`, `device_type`, `topology_{x,y,z}`, `clock_rate_ghz`, `hbm_size_bytes`, `hbm_bandwidth_gbps`.
-- **`tpu_op`** — XLA op execution slices (from `--tpu-profile`). `ts`, `dur` (ns), `tpu_device_id` (FK → tpu_device.id), `op_name`, `category`, `stream`, `group_id`, `flops`, `bytes_accessed`, `bytes_hbm`, `bytes_cmem`, `bytes_vmem`.
+- **`tpu_op`** — XLA op execution slices (from `--tpu-profile`). `ts`, `dur` (ns), `tpu_device_id` (FK → `tpu_device.id`), `op_name`, `category`, `stream`, `group_id`, `flops`, `bytes_accessed`, `bytes_hbm`, `bytes_cmem`, `bytes_vmem`.
 - **`tpu_metric`** — polled runtime counters (from `--tpu-metrics`). `ts`, `device_id` (ordinal), `metric_name`, `value`. Default metrics: `tpu.runtime.tensorcore.dutycycle.percent`, `tpu.runtime.hbm.memory.usage.bytes`.
 
 ```sql
@@ -107,8 +161,8 @@ FROM tpu_metric
 WHERE metric_name = 'tpu.runtime.tensorcore.dutycycle.percent'
 ORDER BY device_id, ts;
 
--- Correlate TPU gaps with host-side blocking: find intervals where no TPU op
--- is running for >1ms and check sched_slice for what the host thread was doing
+-- Correlate TPU gaps with host-side blocking: intervals with no TPU op
+-- running for >1ms; check sched_slice for what the host thread was doing
 WITH gaps AS (
   SELECT ts + dur AS gap_start,
          lead(ts) OVER (PARTITION BY tpu_device_id ORDER BY ts) AS gap_end
@@ -121,37 +175,42 @@ ORDER BY gap_ms DESC LIMIT 20;
 ```
 
 ### Multi-trace databases
-Tables have a `trace_id` column. Filter on it when the DB contains multiple captures.
+Every table has a `trace_id` column. Always include it in joins, and filter on it when the DB contains multiple captures (`_traces` lists them, with the systing version that produced each).
 
 ## Using `flamegraph`
 
-The `flamegraph` tool returns folded-stack output (one line per unique stack, semicolon-separated frames root→leaf, space, sample count). Filter options:
-- `stack_type` — `cpu` / `uninterruptible` / `interruptible` / `all`
+Returns `stacks` (array of `{frames, count}`), `metadata` (total_samples, unique_stacks, time_range, stack_type), and `folded` — folded-stack text (semicolon-separated frames root→leaf, space, count) for inferno / brendangregg's FlameGraph. Parameters:
+- `stack_type` — `"cpu"` (default), `"interruptible-sleep"`, `"uninterruptible-sleep"`, `"all-sleep"`, `"all"`
 - `pid` / `tid` — restrict to a process or thread
-- `min_samples` — drop noise
+- `start_time` / `end_time` — seconds offset from trace start
+- `min_count` — minimum sample count per stack (default 1)
+- `top_n` — keep the top N stacks (default 500)
 - `trace_id` — for multi-trace DBs
-
-Pipe the result into your preferred flamegraph renderer, or just scan for the heaviest stacks in the text.
 
 ## Common investigation patterns
 
 **"Why is my process slow?"**
-1. `sched_stats` with `pid` — is it on-CPU (CPU-bound), or mostly sleeping (blocked)?
-2. If CPU-bound → `flamegraph stack_type=cpu pid=<pid>` for hotspots.
-3. If blocked → `flamegraph stack_type=uninterruptible pid=<pid>` (I/O, locks) and `stack_type=interruptible` (waits, timers).
+1. `sched_stats` with `pid` — is it on-CPU (CPU-bound), or mostly sleeping (blocked)? Note `d_sleep_seconds` is approximate: it folds in runqueue latency after the sleep.
+2. If CPU-bound → `flamegraph stack_type="cpu" pid=<pid>` for hotspots.
+3. If blocked → `flamegraph stack_type="uninterruptible-sleep" pid=<pid>` (I/O, locks) and `"interruptible-sleep"` (waits, timers).
 
 **"Is the machine overloaded?"**
-1. `cpu_stats` — look for CPUs with near-zero idle % and high runqueue depth percentiles.
-2. `sched_stats` (no filter) — check preemption rates and CPU migrations.
+1. `cpu_stats` — CPUs with near-zero idle % and high runqueue depth percentiles. (Runqueue estimates model sleep→wake→run cycles only, exclude preempted threads, and are event-weighted, not time-weighted.)
+2. `sched_stats` (no filter) — preemption rates and CPU migrations.
 
 **"Network slow / dropping?"**
-1. `network_connections` — any connection with high retransmit rate?
-2. `query` on `network_packet` — filter `drop_reason_str IS NOT NULL` for kernel drop reasons.
-3. `query` on `network_syscall` — sort by `dur` to find stalled recv/send calls.
+1. `network_connections` — any connection with a high retransmit rate?
+2. `query` on `network_packet` — `drop_reason_str IS NOT NULL` for kernel drop reasons; `qdisc_latency_us` for queueing.
+3. `query` on `network_syscall` — sort by `dur` for stalled recv/send, and check `sndbuf_fill_pct` / `bytes_available`.
+
+**"Memory growing?"**
+1. `query` on `memory_rss` — anon (`member=1`) trend per process.
+2. `query` on `memory_map` — large mmaps grouped by `stack_id` → `stack.leaf_name`.
+3. `query` on `memory_alloc` — allocation hotspots. Only trust alloc/free pairing if the trace used `--memory-alloc-sample-rate 1`.
 
 **"TPU underutilized?"**
-1. `query` on `tpu_metric` — look at `tensorcore.dutycycle.percent`; sustained low values mean the device is starved.
-2. `query` on `tpu_op` — find large gaps between consecutive ops on the same device (see gap query above).
+1. `query` on `tpu_metric` — `tensorcore.dutycycle.percent`; sustained low values mean the device is starved.
+2. `query` on `tpu_op` — large gaps between consecutive ops on the same device (see gap query above).
 3. Cross-reference gap timestamps with `sched_slice` / `flamegraph` on the host to find what the feeding process was doing (sleeping? blocked on recv? GIL?).
 
 ## Arguments

--- a/skills/systing-trace/SKILL.md
+++ b/skills/systing-trace/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: systing-trace
-description: Capture a Linux system trace with systing. Use when the user wants to profile, trace, or record system activity (scheduling, stacks, network, syscalls, Python stacks, TPU ops/metrics) into a DuckDB or Perfetto file. Guides correct invocation of the `systing` binary as root, choosing recorders, targeting PIDs/cgroups/commands, and output formats.
+description: Capture a Linux system trace with systing. Use when the user wants to profile, trace, or record system activity (scheduling, stacks, network, memory, syscalls, Python stacks, TPU ops/metrics) into a DuckDB or Perfetto file. Guides correct invocation of the `systing` binary as root, choosing recorders, targeting PIDs/cgroups/commands, and output formats.
 ---
 
 # Capturing a trace with `systing`
 
-`systing` is a BPF-based Linux tracer. It captures scheduling events, stack traces, network activity, syscalls, and more into a DuckDB database (or Perfetto trace) for later analysis.
+`systing` is a BPF-based Linux tracer. It captures scheduling events, IRQs, stack traces, network activity, memory events, syscalls, and more into a DuckDB database (or Perfetto trace) for later analysis.
 
 ## Prerequisites
 
-- **Must run as root** (BPF requires privileges). Use `sudo`.
-- Output: prefer `--output foo.duckdb` for analysis with the `systing-analyze` MCP server.
+- **Must run as root**, or hold `CAP_BPF` + `CAP_PERFMON` (`CAP_SYS_ADMIN` also works). Use `sudo`.
+- Output: prefer `--output foo.duckdb` for analysis with the `systing-analyze` MCP server. **The default is `trace.pb`** (Perfetto), so always pass `--output` explicitly when you want DuckDB.
 
 ## Common invocations
 
@@ -35,22 +35,29 @@ sudo systing -c /sys/fs/cgroup/my.slice -d 30 --output trace.duckdb
 sudo systing -d 5 --output trace.duckdb
 ```
 
+`-d 0` (the default) means "run until Ctrl-C, or until the `--` command exits".
+
 ## Recorders (what to capture)
 
-List available recorders:
+List available recorders and their defaults:
 ```bash
 systing --list-recorders
 ```
 
 | Recorder | Default | Captures |
 |---|---|---|
-| `sched` | on | Scheduler events (context switches, runqueue) |
-| `cpu-stacks` | on | On-CPU stack samples (perf) |
+| `sched` | on | Scheduler events (context switches, wakeups, runqueue) |
+| `irq` | on | IRQ and softirq events (`irq_handler_*`, `softirq_*`) |
+| `cpu-stacks` | on | On-CPU perf stack samples |
 | `sleep-stacks` | on | Uninterruptible sleep (D-state) stacks |
 | `interruptible-stacks` | on | Interruptible sleep (S-state) stacks |
-| `syscalls` | off | All syscall entry/exit |
-| `network` | off | TCP/UDP packets, syscalls, retransmits, RTT |
-| `markers` | off | Userspace marker events (via `faccessat2`) |
+| `syscalls` | off | All syscall entry/exit (`raw_syscalls:sys_enter`/`sys_exit`) |
+| `network` | off | Base network recorder: socket/TCP connection state tracking |
+| `network-syscalls` | off | Network syscall-level tracing (send/recv bytes, buffer fill, stalls) — no per-packet probes |
+| `network-packets` | off | Packet-level tracing (sendmsg, recvmsg, qdisc, drops, retransmits, RTT) |
+| `memory` | off | RSS tracking, mmap/munmap/brk, page faults |
+| `memory-alloc` | off | Heap allocator uprobes (malloc/calloc/realloc/free) with stacks |
+| `markers` | off | Userspace marker events (`faccessat2` with `mode=-975`) |
 | `tpu` | off | TPU op-level profile via XLA runtime gRPC (port 8466) |
 | `tpu-metrics` | off | TPU runtime metrics polling (port 8431, lightweight) |
 
@@ -59,32 +66,85 @@ Enable extras with `--add-recorder`:
 sudo systing --add-recorder network --add-recorder syscalls -d 10 --output trace.duckdb
 ```
 
-Or restrict to only specific recorders with `--only-recorder`:
+Or restrict to only specific recorders with `--only-recorder` (disables every default first):
 ```bash
 sudo systing --only-recorder sched --only-recorder network -d 10 --output trace.duckdb
 ```
 
+### Recorder dependencies and companions
+
+- `--add-recorder network` **also enables `network-packets`** (the common investigation shape). `--only-recorder network` is state-only: connection/state tracking with no per-packet kprobes.
+- `network-packets` and `network-syscalls` each require the base `network` recorder and enable it implicitly.
+- `memory-alloc` requires and implicitly enables `memory`.
+- Recorders that are on by default can also be turned off directly: `--no-sched`, `--no-irq`, `--no-cpu-stack-traces`, `--no-sleep-stack-traces`, `--no-interruptible-stack-traces`, `-n`/`--no-stack-traces` (all stacks).
+
 ## Key options
 
+### Targeting and duration
 | Flag | Purpose |
 |---|---|
-| `-p <PID>` | Target a specific process (repeatable) |
-| `-c <CGROUP>` | Target a cgroup path |
-| `-d <SEC>` | Duration in seconds (0 = until Ctrl-C or command exits) |
-| `--output <PATH>` | Output file; `.duckdb` extension → DuckDB, `.pb`/`.perfetto` → Perfetto |
+| `-p, --pid <PID>` | Target a specific process (repeatable) |
+| `-c, --cgroup <CGROUP>` | Target a cgroup path |
+| `-d, --duration <SEC>` | Duration in seconds (default `0` = until Ctrl-C or command exits) |
+| `--continuous <SEC>` | Rolling-window mode: keep only the last `<SEC>` seconds in the ring buffers. Cannot be combined with a `-- <command>` |
+| `-v, --verbose` | Increase verbosity (repeatable) |
+
+### Output
+| Flag | Purpose |
+|---|---|
+| `--output <PATH>` | Output file, format from extension: `.duckdb`, `.pb`/`.perfetto`, `.systing`/`.systing.gz` (profile export, see `docs/PROFILE_EXPORT_FORMAT.md`). Default `trace.pb` |
 | `--output-dir <DIR>` | Directory for intermediate parquet files (default `./traces`) |
-| `--collect-pystacks` | Enable Python stack symbolization (resolves Python frames in user stacks) |
-| `--enable-debuginfod` | Better symbol resolution (requires `DEBUGINFOD_URLS` env var) |
-| `--no-stack-traces` | Disable all stack trace collection |
-| `--marker-threshold <N>` | Stop after N marker instant events |
-| `--marker-duration-threshold <MS>` | Stop when any marker range exceeds MS milliseconds |
-| `--ringbuf-size-mib <N>` | Increase BPF ring buffer size if seeing lost events |
-| `--sw-event` | Use software event for sampling (for VMs without PMU) |
-| `--tpu-profile` | Enable TPU op profiling (shortcut for `--add-recorder tpu`) |
-| `--tpu-service-addr <HOST:PORT>` | Override auto-discovery for the TPU profiler service (port 8466) |
-| `--tpu-metrics` | Enable TPU metrics polling (shortcut for `--add-recorder tpu-metrics`) |
-| `--tpu-metrics-addr <HOST:PORT>` | Override auto-discovery for the TPU metrics service (port 8431) |
-| `--tpu-metrics-interval <MS>` | Polling interval for TPU metrics (default 1000 ms) |
+| `--parquet-only` | Skip final trace generation, keep only the parquet files |
+| `--stream <URI>` | Stream parquet over a socket instead of writing to disk: `vsock://CID:PORT`, `unix:///path.sock`, `tcp://host:port` (tcp is unauthenticated — trusted networks only) |
+
+### Sampling and counters
+| Flag | Purpose |
+|---|---|
+| `--sample-freq <HZ>` | CPU stack-sampling rate per CPU (default 1000). Fixed-period mode: exact with `--sw-event`, and the rate at max CPU frequency for `cpu-cycles` |
+| `-s, --sw-event` | Use a software clock event for sampling (VMs without a PMU) |
+| `--perf-counter <NAME>` | Sample a hardware/software counter, e.g. `instructions`, `cycles`, `topdown*` (repeatable) |
+| `--cpu-frequency` | Record CPU frequency tracks |
+
+### Symbolization
+| Flag | Purpose |
+|---|---|
+| `--collect-pystacks` | Resolve Python frames in user stacks |
+| `--pystacks-debug` | Debug output for Python stack tracing |
+| `--enable-debuginfod` | Better symbol resolution (requires `DEBUGINFOD_URLS`) |
+| `--collect-build-id` | Store user frames as (build-id, file offset) so exited processes stay symbolizable offline |
+| `--symbolize-names-only` | ELF symbol tables only — no DWARF, no line info, no inline frames. Bounds symbolization memory on hosts with many debug binaries |
+| `--symbolize-elide-generics` | Collapse generic/template args in symbol names longer than 256 bytes |
+| `--no-frame-labels` | Render unsymbolized frames as bare hex instead of contextual labels |
+| `--no-gopclntab` | Don't symbolize stripped Go binaries from `.gopclntab` |
+| `--no-gvisor-guest-maps` | Don't query gVisor sandboxes' control sockets for guest maps |
+
+### Memory recorder tuning
+| Flag | Purpose |
+|---|---|
+| `--memory-fault-sample-rate <N>` | Sample 1 in N user page faults (default 97; 0/1 = all) |
+| `--memory-rss-threshold-bytes <N>` | Min byte drift between `rss_stat` events (default `max(16 MiB, 64*nr_cpus*page_size)`; 0 = every event) |
+| `--memory-alloc-sample-rate <N>` | Sample 1 in N allocator calls (default 1). Values > 1 sample alloc/free independently, so alloc/free pairing for leak detection is unreliable — hotspot profiling only |
+| `--memory-alloc-lib <LIB>` | Override allocator library. Absolute path = host namespace verbatim; bare name resolved per-pid via `/proc/<pid>/maps` |
+| `--memory-alloc-symbol-prefix <P>` | Prefix for malloc/free symbol names (e.g. `je_` for prefixed jemalloc) |
+
+### Custom events, markers, misc
+| Flag | Purpose |
+|---|---|
+| `--trace-event <EVENT>` / `--trace-event-pid <PID>` | Attach to additional probe points |
+| `--trace-event-config <FILE>` | JSON config defining custom events/tracks/stop triggers (see `docs/TRACE_CONFIG_FORMAT.md`) |
+| `--marker-threshold <N>` | Stop after N marker instant events — **requires `--continuous`** |
+| `--marker-duration-threshold <MS>` | Stop when a marker range exceeds MS ms — **requires `--continuous`** |
+| `--ringbuf-size-mib <N>` | Increase BPF ring buffer size if events are lost |
+| `--resolve-addresses` | Resolve network IPs to hostnames via DNS (off by default) |
+
+### TPU
+| Flag | Purpose |
+|---|---|
+| `--tpu-profile` | Op-level TPU profile (same as `--add-recorder tpu`); **requires a fixed `--duration`** |
+| `--tpu-service-addr <HOST:PORT>` | Override auto-discovery for the profiler service (port 8466) |
+| `--tpu-metrics` | Metrics polling (same as `--add-recorder tpu-metrics`) |
+| `--tpu-metrics-addr <HOST:PORT>` | Override auto-discovery for the metrics service (port 8431) |
+| `--tpu-metrics-interval <MS>` | Metrics polling interval (default 1000 ms) |
 
 ## TPU profiling
 
@@ -92,10 +152,10 @@ Systing can talk to the XLA/TPU runtime's gRPC services to correlate TPU activit
 
 Two modes (use either or both):
 
-- **`--tpu-profile`** — Full op-level profile. Connects to the XLA profiler service (port 8466), captures an XSpace profile for the trace duration, and records per-op timing, flops, and memory-bytes into `tpu_op` / `tpu_device` tables. Heavier; only available while a workload is actively running.
-- **`--tpu-metrics`** — Lightweight polling. Connects to the RuntimeMetricService (port 8431), samples counters (duty cycle, HBM usage, latency distributions) at `--tpu-metrics-interval` into the `tpu_metric` table. Always available while the runtime is up.
+- **`--tpu-profile`** — Full op-level profile. Connects to the XLA profiler service (port 8466), captures an XSpace profile for the trace duration, and records per-op timing, flops, and memory bytes into `tpu_op` / `tpu_device`. Heavier; only available while a workload is actively running, and requires a fixed `--duration`.
+- **`--tpu-metrics`** — Lightweight polling. Connects to the RuntimeMetricService (port 8431), samples counters (duty cycle, HBM usage, latency distributions) at `--tpu-metrics-interval` into `tpu_metric`. Always available while the runtime is up.
 
-**Auto-discovery**: By default systing scans `/proc/net/tcp` (across all network namespaces) for a single listener on the well-known port and connects to it, using `setns` if the service is in a container's netns. If discovery finds zero listeners it errors ("Is a TPU workload running?"); if it finds multiple you must disambiguate with `--tpu-service-addr` / `--tpu-metrics-addr`.
+**Auto-discovery**: By default systing scans `/proc/net/tcp` (across all network namespaces) for a single listener on the well-known port and connects to it, using `setns` if the service is in a container's netns. Zero listeners → error ("Is a TPU workload running?"); multiple listeners → disambiguate with `--tpu-service-addr` / `--tpu-metrics-addr`.
 
 ```bash
 # Op-level TPU profile + host scheduling for 10s
@@ -111,18 +171,21 @@ sudo systing --tpu-profile --tpu-service-addr 127.0.0.1:8466 -d 10 --output trac
 
 ## Output formats
 
-- **`.duckdb`** — Recommended. Queryable with `systing-analyze` CLI and MCP tools.
-- **`.pb` / `.perfetto`** — Perfetto trace, viewable at [ui.perfetto.dev](https://ui.perfetto.dev).
+- **`.duckdb`** — Recommended. Queryable with the `systing-analyze` CLI and MCP tools.
+- **`.pb` / `.perfetto`** — Perfetto trace, viewable at [ui.perfetto.dev](https://ui.perfetto.dev). This is the default if `--output` is omitted.
+- **`.systing` / `.systing.gz`** — Line-oriented profile summary (interned stacks + counts + thread metadata), no DuckDB needed. See `docs/PROFILE_EXPORT_FORMAT.md`.
 - **`--parquet-only`** — Skip final output, keep raw parquet files in `--output-dir`.
 
 ## After capturing
 
-Once you have a `.duckdb` file, use the **`systing-analyze` MCP tools** (if available) or the `systing-analyze` CLI to analyze it. See the `/systing-analyze` skill.
+Once you have a `.duckdb` file, use the **`systing-analyze` MCP tools** (if available) or the `systing-analyze` CLI to analyze it. See the `systing-analyze` skill.
 
 ## Troubleshooting
 
-- **"Operation not permitted"** → run with `sudo`.
+- **"Operation not permitted"** → run with `sudo` (or grant `CAP_BPF`+`CAP_PERFMON`).
 - **Lost events / ring buffer full** → increase `--ringbuf-size-mib` (e.g. `64`).
 - **No stack frames resolved** → add `--enable-debuginfod` with `DEBUGINFOD_URLS` set, or install debug symbols for the target binaries.
-- **VM without hardware perf counters** → add `--sw-event`.
-- **"No TPU profiler/metrics service detected"** → the XLA runtime isn't listening on 8466/8431. Make sure a TPU workload is running. If it's in a non-host netns systing will find it automatically; if there are multiple listeners, pass `--tpu-service-addr` / `--tpu-metrics-addr`.
+- **Symbolization eating memory** (CI hosts, many debug binaries) → `--symbolize-names-only`, and `--symbolize-elide-generics` for heavily generic Rust/C++.
+- **VM without hardware perf counters** → add `-s`/`--sw-event`.
+- **`--marker-threshold` rejected** → marker thresholds require `--continuous <seconds>`.
+- **"No TPU profiler/metrics service detected"** → the XLA runtime isn't listening on 8466/8431. Make sure a TPU workload is running. If it's in a non-host netns systing will find it automatically; with multiple listeners, pass `--tpu-service-addr` / `--tpu-metrics-addr`.


### PR DESCRIPTION
Both `SKILL.md` files had drifted from the code. Everything below was verified against `systing --list-recorders` / `--help` (v1.11.37), `src/duckdb.rs`, `src/analyze/`, and `src/mcp.rs`, and the SQL examples were run against a local trace database.

## `skills/systing-trace/SKILL.md`

- **Recorder table was stale**: missing `irq` (on by default), `memory`, `memory-alloc`, and the network recorder split into `network` (connection state only) / `network-syscalls` / `network-packets`. Documented the companion and dependency rules from `process_recorder_options()` — notably that `--add-recorder network` also enables `network-packets` while `--only-recorder network` is state-only.
- Noted that `--output` defaults to `trace.pb`, plus the `.systing` / `.systing.gz` profile-export format.
- Added the flags that were missing entirely: `--sample-freq`, `--perf-counter`, `--cpu-frequency`, `--continuous`, `--stream`, `--collect-build-id`, `--symbolize-names-only`, `--symbolize-elide-generics`, `--no-frame-labels`, `--no-gopclntab`, `--no-gvisor-guest-maps`, `--resolve-addresses`, the `--memory-*` tuning set, and the `--no-sched` / `--no-irq` / `--syscalls` toggles. Options are now grouped by area instead of one flat table.
- Recorded the two constraints the CLI enforces: marker thresholds require `--continuous`, and `--tpu-profile` requires a fixed `--duration`.

## `skills/systing-analyze/SKILL.md`

- **`flamegraph` stack types were wrong**: `uninterruptible` / `interruptible` are rejected by `StackTypeFilter::from_str`; the accepted values are `cpu`, `uninterruptible-sleep`, `interruptible-sleep`, `all-sleep`, `all`. Also `min_samples` → `min_count`, and `top_n` / `start_time` / `end_time` were undocumented.
- **Stack schema was stale**: `stack` holds `frame_ids BIGINT[]` + `leaf_name` (the `frame_names` column now lives in the `stack_frames` view), the join key is `stack.id` rather than `stack_id`, and frames are ordered **root-to-leaf** — so the old `frame_names[1] AS leaf` example named the outermost caller, not the leaf.
- **`sched_slice` has no `end_state_str`**, and `end_state` is a bitmask, so the `end_state = 2` example silently missed compound states. Documented the bits and the `NULL` = preempted case.
- Joins now include `trace_id` throughout, which multi-trace databases require.
- New sections: memory tables (with the `memory_rss.member` encoding, including the synthetic `-1`/`-2` values), counters/slices, `sysinfo.sample_event` / `sample_period` weighting with `cpu_info`, the `systing-analyze` CLI subcommands, and a "memory growing?" investigation pattern.

Docs only — no code or schema changes, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)