### PR TITLE
network: keep one socket identity across state transitions

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -1103,8 +1103,22 @@ static __always_inline u64 get_or_create_socket_id(
 
 	// Check if we already have metadata for this socket
 	existing = bpf_map_lookup_elem(&socket_metadata_map, &identity_key);
-	if (existing)
+	if (existing) {
+		// Seed the sk-keyed map on the hit path too: a socket that
+		// merges into a persistent tuple entry (client port reuse
+		// within the capture) must still resolve sk-first at its
+		// terminal transitions, or its close falls back to the
+		// anonymous degraded-tuple identity. Guarded on a bound
+		// src_port — seeding from a port-less connect-start hit
+		// would pin the socket to a shared per-destination port-0
+		// entry for its whole lifecycle.
+		if (src_port != 0) {
+			u64 sk_ptr = (u64)sk;
+			bpf_map_update_elem(&sk_socket_id_map, &sk_ptr,
+					    &existing->socket_id, BPF_ANY);
+		}
 		return existing->socket_id;
+	}
 
 	// Create new socket metadata
 	metadata.socket_id = generate_socket_id();
@@ -4673,15 +4687,32 @@ int BPF_PROG(inet_sock_set_state, const struct sock *sk, int oldstate, int newst
 			      dest_addr, &dest_port) < 0)
 		return 0;
 
-	// Get or create socket ID - use get_or_create_socket_id so that
-	// early transitions (SYN_SENT, SYN_RECV -> ESTABLISHED) create
-	// socket entries even before any sendmsg/recvmsg occurs.
-	// Note: tgidpid may not be the socket owner in softirq/timer context,
-	// but get_or_create_socket_id does not use it for identification.
+	// Socket identity: reuse the socket's EXISTING id first (sk-keyed
+	// lookup). State transitions fire with degraded tuples at both ends
+	// of the lifecycle — the connect-start transition (CLOSE ->
+	// SYN_SENT) fires in tcp_v4_connect() before the ephemeral port is
+	// assigned, and transitions to CLOSE observably arrive with the
+	// bound port already zeroed (every anonymous close row reads
+	// src_port=0 in production traces) — so the tuple-keyed
+	// get_or_create minted a SECOND, anonymous src_port=0 identity for
+	// terminal transitions and a socket's opens and closes landed on
+	// different flow rows. The sk-first lookup pins the whole
+	// lifecycle to one identity. get_or_create remains the fallback
+	// for a socket whose first-ever observed event is a state change
+	// (it also seeds sk_socket_id_map for the next event).
+	// Note: tgidpid may not be the socket owner in softirq/timer
+	// context, but get_or_create_socket_id does not use it for
+	// identification.
 	u64 tgidpid = bpf_get_current_pid_tgid();
-	u64 socket_id = get_or_create_socket_id(
-		(struct sock *)sk, NETWORK_TCP, af,
-		src_addr, src_port, dest_addr, dest_port, tgidpid);
+	u64 sk_key = (u64)sk;
+	u64 socket_id = 0;
+	u64 *sid = bpf_map_lookup_elem(&sk_socket_id_map, &sk_key);
+	if (sid && *sid)
+		socket_id = *sid;
+	else
+		socket_id = get_or_create_socket_id(
+			(struct sock *)sk, NETWORK_TCP, af,
+			src_addr, src_port, dest_addr, dest_port, tgidpid);
 	if (socket_id == 0)
 		return 0;
 
@@ -4721,6 +4752,14 @@ int BPF_PROG(inet_sock_set_state, const struct sock *sk, int oldstate, int newst
 			struct tw_pending_info empty = {};
 			bpf_map_update_elem(&pending_tw, &tw_key, &empty, BPF_ANY);
 		}
+		// This sk is being destroyed on BOTH paths that reach here
+		// with a raw CLOSE — a real close, and the TIME_WAIT rewrite
+		// (tcp_time_wait() frees this sk via tcp_done(); the
+		// timewait sock carries on under its own pointer, tracked by
+		// the tw kprobes, which captured the id before this fires).
+		// Drop the sk-keyed identity so a recycled sk allocation
+		// mints a fresh id instead of inheriting this lifecycle's.
+		bpf_map_delete_elem(&sk_socket_id_map, &sk_key);
 	}
 
 	bpf_ringbuf_submit(event, flags);

--- a/src/network_recorder.rs
+++ b/src/network_recorder.rs
@@ -311,8 +311,16 @@ pub struct NetworkRecorder {
     min_ts: Option<u64>,
 
     // Streaming support fields
-    /// Track which sockets have had their NetworkSocketRecord emitted
-    seen_sockets: HashSet<SocketId>,
+    /// Track which sockets have had their NetworkSocketRecord emitted,
+    /// and whether that record carried a bound (nonzero) src_port. A
+    /// socket whose identity is created by a pre-bind state transition
+    /// (connect-start fires before the ephemeral port is assigned)
+    /// emits its first record with src_port=0; when a later event
+    /// arrives carrying the bound tuple, ONE upgraded record is
+    /// emitted for the same socket_id so the trace carries the real
+    /// tuple. Readers keep one row per socket by preferring the
+    /// bound-port row.
+    seen_sockets: HashMap<SocketId, bool>,
     /// Collector for streaming records during recording
     streaming_collector: Option<Box<dyn RecordCollector + Send>>,
     /// Next record ID counters for streaming
@@ -328,6 +336,27 @@ impl ThreadAwareRecorder for NetworkRecorder {
     }
 }
 
+/// Decide whether a NetworkSocketRecord should be emitted for this
+/// sighting of `socket_id`, updating the seen-map. True on first sight,
+/// and ONCE more as an upgrade when the first record was emitted from a
+/// pre-bind event (src_port=0) and this sighting carries the bound port
+/// — after the upgrade the id is marked bound and never re-emits. A
+/// port-less sighting never downgrades a bound mark.
+fn should_emit_socket_record(
+    seen_sockets: &mut HashMap<SocketId, bool>,
+    socket_id: SocketId,
+    src_port: u16,
+) -> bool {
+    match seen_sockets.get(&socket_id) {
+        Some(true) => false,
+        Some(false) if src_port == 0 => false,
+        _ => {
+            seen_sockets.insert(socket_id, src_port != 0);
+            true
+        }
+    }
+}
+
 impl NetworkRecorder {
     pub fn new(utid_generator: Arc<UtidGenerator>, resolve_addresses: bool) -> Self {
         Self {
@@ -336,7 +365,7 @@ impl NetworkRecorder {
             hostname_cache: HashMap::new(),
             resolve_addresses,
             min_ts: None,
-            seen_sockets: HashSet::new(),
+            seen_sockets: HashMap::new(),
             streaming_collector: None,
             next_syscall_id: 1,
             next_packet_id: 1,
@@ -355,8 +384,10 @@ impl NetworkRecorder {
         self.streaming_collector = Some(collector);
     }
 
-    /// Helper to emit NetworkSocketRecord if not yet seen for this socket.
-    /// Returns true if a new socket record was emitted.
+    /// Helper to emit NetworkSocketRecord if not yet seen for this socket,
+    /// or ONCE more as an upgrade when the first record was emitted from a
+    /// pre-bind event (src_port=0) and this event carries the bound tuple.
+    /// Returns true if a record was emitted.
     #[allow(clippy::too_many_arguments)]
     fn maybe_emit_socket_record(
         &mut self,
@@ -372,13 +403,9 @@ impl NetworkRecorder {
     ) -> Result<bool> {
         use crate::systing_core::types::{network_address_family, network_protocol};
 
-        // Check if we've already emitted a record for this socket
-        if self.seen_sockets.contains(&socket_id) {
+        if !should_emit_socket_record(&mut self.seen_sockets, socket_id, src_port) {
             return Ok(false);
         }
-
-        // Mark as seen
-        self.seen_sockets.insert(socket_id);
 
         // Get collector (must be present in streaming mode)
         let collector = self.streaming_collector.as_mut().ok_or_else(|| {
@@ -1112,5 +1139,51 @@ mod tests {
         assert_eq!(tcp_state_name(12), "NEW_SYN_RECV");
         assert_eq!(tcp_state_name(13), "UNKNOWN");
         assert_eq!(tcp_state_name(255), "UNKNOWN");
+    }
+}
+
+#[cfg(test)]
+mod socket_record_emission_tests {
+    use super::*;
+
+    /// The upgrade lifecycle (the close-storm RCA's recorder half): a
+    /// socket first seen via a pre-bind event emits a port-less record,
+    /// the first bound-tuple sighting emits exactly one upgrade, and
+    /// nothing after that re-emits.
+    #[test]
+    fn upgrade_emits_once_after_portless_first_sight() {
+        let mut seen = HashMap::new();
+        // First sight, pre-bind (connect-start): emit the port-less record.
+        assert!(should_emit_socket_record(&mut seen, 42, 0));
+        // More pre-bind sightings: no re-emit.
+        assert!(!should_emit_socket_record(&mut seen, 42, 0));
+        // Bound tuple arrives: the ONE upgrade.
+        assert!(should_emit_socket_record(&mut seen, 42, 33000));
+        // Nothing re-emits afterwards — bound, port-less, or otherwise.
+        assert!(!should_emit_socket_record(&mut seen, 42, 33000));
+        assert!(!should_emit_socket_record(&mut seen, 42, 0));
+        assert!(!should_emit_socket_record(&mut seen, 42, 44000));
+    }
+
+    /// A socket first seen with its bound tuple behaves exactly as
+    /// before this change: one record, no upgrades, and a later
+    /// port-less sighting (a terminal transition) never re-emits.
+    #[test]
+    fn bound_first_sight_is_single_emission() {
+        let mut seen = HashMap::new();
+        assert!(should_emit_socket_record(&mut seen, 7, 443));
+        assert!(!should_emit_socket_record(&mut seen, 7, 443));
+        assert!(!should_emit_socket_record(&mut seen, 7, 0));
+        assert!(!should_emit_socket_record(&mut seen, 7, 443));
+    }
+
+    /// Distinct sockets track independently.
+    #[test]
+    fn sockets_are_independent() {
+        let mut seen = HashMap::new();
+        assert!(should_emit_socket_record(&mut seen, 1, 0));
+        assert!(should_emit_socket_record(&mut seen, 2, 80));
+        assert!(should_emit_socket_record(&mut seen, 1, 1024));
+        assert!(!should_emit_socket_record(&mut seen, 2, 0));
     }
 }

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -412,6 +412,13 @@ pub struct NetworkPacketRecord {
 /// Replaces socket_connection with a cleaner schema (no track_id needed).
 /// Socket info extracted directly from BPF events for true streaming.
 ///
+/// Normally one record per socket per capture. A socket whose identity
+/// was created by a pre-bind state transition (connect-start fires
+/// before the ephemeral port is assigned) emits its first record with
+/// `src_port` 0 and ONE upgraded record with the bound tuple when a
+/// later event carries it — readers keeping one row per `socket_id`
+/// should prefer the row whose `src_port` is nonzero.
+///
 /// # Fields
 /// - `socket_id`: Unique socket ID (primary key)
 /// - `protocol`: "TCP" or "UDP"


### PR DESCRIPTION
A socket's opens and closes can land on different flow rows, because the socket identity key is (sk pointer, 4-tuple) and state transitions fire with degraded tuples at both ends of a connection's life: connect-start fires before the ephemeral port is assigned, and transitions to CLOSE observably arrive with the bound port already zeroed — every anonymous close row reads `src_port=0` in production traces. The tuple-keyed lookup therefore mints a second, anonymous `src_port=0` identity for terminal transitions. On a production cluster with aggressive readiness probing, the anonymous rows were 68% of all socket rows and closes exceeded opens by ~500x on the busiest port.

**The fix, two halves.**
1. **BPF**: `inet_sock_set_state` reuses the socket's existing identity via the sk-keyed map (`sk_socket_id_map`) before falling back to tuple-keyed creation, so the whole lifecycle lands on one identity; the fallback still creates an identity for sockets whose first observed event is a state change. When the tracepoint fires with a raw CLOSE — both the real-close path and the TIME_WAIT rewrite destroy this sk — the sk-keyed entry is deleted so a recycled allocation mints a fresh identity. Net map traffic goes down on the common path: one lookup replaces get-or-create's lookup/insert/re-lookup. The timewait kprobes are unaffected: they capture the id at `tcp_time_wait` entry, before `tcp_done` fires this tracepoint.
2. **Recorder**: a socket created at connect-start emits its first record with a port-less tuple, so the recorder now emits ONE upgraded record when a later event reveals the bound tuple (tracked by flipping the seen-set to a map of socket_id → carried-a-bound-port). Readers keeping one row per socket prefer the row with the nonzero port; the `NetworkSocketRecord` doc states the contract.

**Disclosed behavior notes.**
- An application that retries `connect()` on the same failed socket now merges its attempts onto one flow row (the tuple-keyed metadata entry from the first attempt matches the retry's identical pre-bind tuple): counts accumulate on one row rather than spreading across rows, which is the desired aggregate for re-dialers. Sockets recycled by the allocator get fresh identities via the delete-at-destroy, and a socket that merges into a persistent tuple entry through client-port reuse is re-seeded into the sk-keyed map (guarded on a bound port) so its terminal transitions still resolve to the merged identity.
- The sk-keyed map has no UDP destroy hook, so dead UDP socket entries persist for the lifetime of a capture (bounded: ~10s continuous, minutes for on-demand); a very UDP-heavy node could fill the map's 10240 slots during a long on-demand trace, degrading TCP seeding to the fallback path. A `udp_destroy_sock` hook or an LRU map is the follow-up if that shows up in practice.
- A connect-start that hits a predecessor's persistent port-less tuple entry attributes that single event to the predecessor's identity (one polluted event, invisible to open/close accounting) — the bound-port guard on hit-path seeding keeps the pollution to that one event rather than the socket's whole lifecycle.

**Validation.** `cargo test` full suite green (461 lib tests including three new emission-lifecycle tests; integration suites green), fmt and clippy clean, and the BPF change compiled through skeleton generation against real vmlinux BTF (straight-line map operations, no new loops). Runtime behavior is validated at the first deployment the same way this codebase's recent BPF changes were: state-change rows carrying stable socket identities end-to-end — opens and closes joining on one `socket_id` with a bound tuple — checked on real traffic before any consumer depends on it.

No schema change: table shapes are untouched (`SCHEMA_VERSION` unchanged); the upgrade record is a content-level contract documented on the record type.
