### PR TITLE
stack_recorder: teach build-id live dispatch about gVisor pool mappings

### DIFF
--- a/src/sandbox_maps.rs
+++ b/src/sandbox_maps.rs
@@ -256,6 +256,29 @@ impl ProcessMaps {
             .collect()
     }
 
+    /// Virtual addresses of executable memfd mappings whose offset range
+    /// contains `offset`. Exists for gVisor's `runsc-memory` pool: under
+    /// systrap the kernel's build-id walker reports a guest island frame's
+    /// offset relative to the pool memfd (not the original ELF), so the
+    /// `virt_candidates` lookup finds nothing; the address
+    /// `start + (offset - e.offset)` is where that pool offset is mapped,
+    /// which is an island inside the guest image. Deliberately name-agnostic
+    /// (any memfd, matching [`Self::bridge_for`]'s scope, not
+    /// `GVISOR_MEMFDS`): correctness comes from the caller bridging each
+    /// candidate and verifying the bridged neighbor's build-id note, which
+    /// makes a coincidental match on some other runtime's exec memfd
+    /// harmless. Returns addresses to bridge, never (offset, link) pairs —
+    /// the pool offset itself is meaningless as an ELF file offset, and only
+    /// the island's file-backed neighbors identify the real binary.
+    pub fn pool_candidates_for_offset(&self, offset: u64) -> Vec<u64> {
+        self.entries
+            .iter()
+            .filter(|e| e.exec && matches!(e.backing, Backing::Memfd(_)))
+            .filter(|e| e.offset <= offset && offset - e.offset < e.end - e.start)
+            .map(|e| e.start + (offset - e.offset))
+            .collect()
+    }
+
     fn entry_for(&self, addr: u64) -> Option<&MapEntry> {
         // Entries are in address order as read from /proc.
         self.entries
@@ -516,6 +539,29 @@ mod tests {
         assert_eq!(c.len(), 2);
         assert_eq!(c[0].0, 0x401000, "a: 0x400000 + (0x2000 - 0x1000)");
         assert_eq!(c[1].0, 0x7f0000002000, "b: base + 0x2000");
+    }
+
+    #[test]
+    fn test_pool_candidates_containment_and_exclusions() {
+        let pm = ProcessMaps::parse(510, STUB_MAPS, "");
+
+        // A pool offset inside the exec island 4c2000-4c3000 (memfd pgoff
+        // 0x3ff1f000) reconstructs to its island address — the kernel reports
+        // guest island frames at this pool offset, and this is where it maps.
+        let c = pm.pool_candidates_for_offset(0x3ff1f500);
+        assert_eq!(c, vec![0x4c2500], "island start + (offset - pgoff)");
+
+        // The exec island 64000-69000 (memfd pgoff 0x3ff26000).
+        assert_eq!(pm.pool_candidates_for_offset(0x3ff26800), vec![0x64800]);
+
+        // A real ELF file offset (0x1000) belongs to no pool mapping's
+        // offset range — the pool path must not spuriously claim it.
+        assert!(pm.pool_candidates_for_offset(0x1000).is_empty());
+
+        // The rw-s memfd 711000-714000 (pgoff 0x3fe00000) is NOT executable,
+        // so an offset in its range yields no candidate — only exec pool
+        // mappings carry code frames.
+        assert!(pm.pool_candidates_for_offset(0x3fe00800).is_empty());
     }
 
     #[test]

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -660,19 +660,40 @@ fn note_to_id(bytes: &[u8]) -> [u8; 20] {
 }
 
 /// Locate a (build-id, file offset) frame in a live process's own address
-/// space: find the file-backed executable mapping that both contains the
-/// file offset and carries the frame's build-id note, and return the
-/// virtual address the offset is mapped at there. `None` — no containing
-/// mapping, note unreadable, or note mismatch (including island-relative
-/// offsets, whose pool ranges never match a file mapping) — sends the
-/// frame down the store path unchanged.
+/// space and return the virtual address to symbolize, or `None` to send the
+/// frame down the store path unchanged. Two cases:
+///
+/// 1. Ordinary file-backed text: the offset is a real ELF file offset; find
+///    the file-backed executable mapping that both contains it and carries
+///    the frame's build-id note, and return where that offset is mapped.
+///
+/// 2. gVisor guest islands: under systrap the kernel reports a guest frame's
+///    offset relative to the `runsc-memory` pool memfd, so no file mapping
+///    matches. Reconstruct the island address from the pool mapping and keep
+///    it only if it bridges to a real file — [`ProcessMaps::bridge_for`]'s
+///    neighbour-congruence is the disambiguator, and the bridged neighbour's
+///    own ELF note must match the frame's build-id (the pool memfd's note is
+///    unreliable, but the neighbour file's is authoritative). A coincidental
+///    pool-offset match that does not bridge, or bridges to a different
+///    binary, falls through to the store path unchanged.
 fn reconstruct_build_id_addr(
     maps: Option<&ProcessMaps>,
     id: &[u8; 20],
     file_offset: u64,
 ) -> Option<u64> {
-    for (addr, link) in maps?.virt_candidates_for_file_offset(file_offset) {
+    let maps = maps?;
+    for (addr, link) in maps.virt_candidates_for_file_offset(file_offset) {
         if let Ok(Some(bid)) = read_elf_build_id(&link) {
+            if note_to_id(&bid) == *id {
+                return Some(addr);
+            }
+        }
+    }
+    for addr in maps.pool_candidates_for_offset(file_offset) {
+        let Some(bridge) = maps.bridge_for(addr) else {
+            continue;
+        };
+        if let Ok(Some(bid)) = read_elf_build_id(&bridge.map_files_path) {
             if note_to_id(&bid) == *id {
                 return Some(addr);
             }
@@ -1751,6 +1772,26 @@ mod tests {
         );
         assert_eq!(pm.virt_candidates_for_file_offset(0x1000).len(), 1);
         assert_eq!(reconstruct_build_id_addr(Some(&pm), &[1; 20], 0x1000), None);
+
+        // gVisor island shape: a pool-relative offset finds no file candidate
+        // but reconstructs to an island address that bridges to its congruent
+        // file neighbours. With the neighbour's note unreadable (fixture tgid
+        // doesn't exist) the pool path declines too, sending the frame to the
+        // store path rather than resolving against an unconfirmed binary.
+        let guest = crate::sandbox_maps::ProcessMaps::parse(
+            -42,
+            "400000-4c2000 r-xs 00000000 00:13 426 /root/bin/guestbox\n\
+             4c2000-4c3000 r-xs 3ff1f000 00:01 4   /memfd:runsc-memory (deleted)\n\
+             4c3000-4cd000 r-xs 000c3000 00:13 426 /root/bin/guestbox",
+            "guestbox",
+        );
+        assert!(guest.virt_candidates_for_file_offset(0x3ff1f500).is_empty());
+        assert_eq!(guest.pool_candidates_for_offset(0x3ff1f500), vec![0x4c2500]);
+        assert!(guest.bridge_for(0x4c2500).is_some());
+        assert_eq!(
+            reconstruct_build_id_addr(Some(&guest), &[1; 20], 0x3ff1f500),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

#179 routes live-process build-id frames through the live symbolization cascade by locating the frame's (build-id, file offset) in the process's own file-backed executable mappings. That search deliberately matches only file-backed mappings, so a frame whose offset is not a real ELF file offset declines to the store path. gVisor guest frames are exactly that case, and the store can't save them: under systrap the kernel's build-id walker can report a guest frame against the `runsc-memory` pool memfd with a pool-relative offset, so the store looks up the right ELF at a meaningless offset and renders `module:unknown`.

This PR adds a pool-aware second search. When no file-backed mapping matches, executable memfd mappings whose offset range contains the frame's offset yield candidate addresses. A candidate is accepted only if the island bridge (#137) maps it to a congruent file-backed neighbour AND that neighbour's own ELF build-id note matches the frame's build-id. Accepted frames route through `symbolize_user_addr` — the same live cascade that already resolves these frames when build-id mode is off. Anything that doesn't bridge, or bridges to a binary whose note mismatches, declines to the store path exactly as before.

## Why the offsets are pool-relative

Verified on stock runsc (release-20260622.0) in a VM: guest text is mostly file-backed (donated FDs, real file offsets — those resolve fine through #179), but systrap patches syscall sites through 4KB `runsc-memory` memfd islands interleaved in guest text. The islands carry a copy of the guest ELF — opening an island via `map_files` returns ELF magic — so the kernel's build-id read on an island frame finds the binary's real note, while the island vma's pgoff is pool-relative (e.g. `0x3fe3e000` into the pool, not into the ELF). The result is `BuildId { id: <real note>, offset: <pool offset> }`: the file-candidate search cannot match it by construction, and the store hits the right module but misses the symbol.

On a gVisor-based Kubernetes cluster this renders the guest application set (compilers, node, libpython, libjvm — binaries that resolve correctly with the flag off) as `module:unknown` in build-id mode, leaving the treated arm ~6pp worse in leaf resolution than control in a node-level A/B.

## Design constraints

- Flag-off behavior is untouched: `UserFrame::BuildId` frames only exist in build-id mode, and nothing outside that path changed.
- The store path stays the sole handler for exited processes — this only adds a live-process recovery before falling back.
- Decline-safe: the pool path can never resolve a frame against an unconfirmed binary. The bridged neighbour's ELF note is the authority; the memfd's own note is a patched copy and is never trusted.
- `virt_candidates_for_file_offset` keeps its file-backed contract; the pool search is a separate method so non-build-id callers keep clean semantics.

## Open question (bounded)

On stock runsc the islands are ~2% of guest text — enough to prove the mechanism, but possibly not the whole gap if a managed-Kubernetes runsc build pool-backs more guest text than stock. The search handles both cases identically (any executable pool mapping containing the offset is a candidate), so this changes nothing about the fix; a post-deploy A/B on the same cluster will show whether any residual class remains.

## Testing

- Unit fixtures for the pool search: containment math against island mappings, non-executable pool mappings excluded, real ELF file offsets never claimed by the pool path.
- Decline-safety: a pool candidate that bridges but whose neighbour note cannot be verified falls back to the store path (asserted with a fixture whose bridge target cannot exist).
- The positive resolution path needs a live runsc guest, so it is exercised by the deploy A/B rather than a unit fixture.
- cargo fmt / build / clippy (`-D warnings`) / test green locally: 459 passed / 0 failed in the main suite; the kernel-requiring integration tests are environment-ignored locally and covered by CI.
