### PR TITLE
Use per-attach-point kernel stack skip; perf-event samples skip zero

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -46,7 +46,18 @@
 #define PF_KTHREAD 0x00200000
 
 #define MAX_STACK_DEPTH 36
+/* Kernel-stack frames to skip on TRACEPOINT-attached captures, covering
+ * the BPF/tracing entry glue between the traced site and the program
+ * (bpf_trace_run*, __traceiter_*). The exact glue depth varies by
+ * kernel version, so some kernels leak residual glue frames past this
+ * skip; fold-side leaf handling owns that remainder. Perf-event
+ * sampling captures must NOT use this: there the walk starts at the
+ * sample's interrupted registers -- no glue exists, and a nonzero skip
+ * discards the interrupted IP plus real return addresses (every kernel
+ * "leaf" becomes its third-level caller).
+ */
 #define SKIP_STACK_DEPTH 3
+#define PERF_EVENT_SKIP_STACK_DEPTH 0
 #define NR_RINGBUFS 8
 
 /* Mirror of the kernel's struct bpf_stack_build_id (filled by bpf_get_stack
@@ -1649,7 +1660,8 @@ static void record_task_info(struct task_info *info, struct task_struct *task)
 }
 
 static void emit_stack_event_with_ts(void *ctx, struct task_struct *task,
-				     enum stack_event_type type, u64 ts)
+				     enum stack_event_type type, u64 ts,
+				     u64 kernel_skip)
 {
 	struct stack_event *event;
 	long len = 0;
@@ -1744,7 +1756,7 @@ static void emit_stack_event_with_ts(void *ctx, struct task_struct *task,
 	}
 
 	len = bpf_get_stack(ctx, &event->kernel_stack,
-			    sizeof(event->kernel_stack), SKIP_STACK_DEPTH);
+			    sizeof(event->kernel_stack), kernel_skip);
 	if (len > 0)
 		event->kernel_stack_length = len / sizeof(u64);
 	else
@@ -1755,7 +1767,7 @@ static void emit_stack_event_with_ts(void *ctx, struct task_struct *task,
 static void emit_stack_event(void *ctx, struct task_struct *task,
 			     enum stack_event_type type)
 {
-	emit_stack_event_with_ts(ctx, task, type, 0);
+	emit_stack_event_with_ts(ctx, task, type, 0, SKIP_STACK_DEPTH);
 }
 
 static int trace_irq_event(struct irqaction *action, int irq, int ret, bool enter)
@@ -1931,10 +1943,12 @@ static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev
 	 */
 	if (!tool_config.no_sleep_stack_traces) {
 		if (prev_state & TASK_UNINTERRUPTIBLE)
-			emit_stack_event_with_ts(ctx, prev, STACK_SLEEP_UNINTERRUPTIBLE, ts);
+			emit_stack_event_with_ts(ctx, prev, STACK_SLEEP_UNINTERRUPTIBLE, ts,
+						 SKIP_STACK_DEPTH);
 		else if (!tool_config.no_interruptible_stack_traces &&
 			 prev_state & TASK_INTERRUPTIBLE)
-			emit_stack_event_with_ts(ctx, prev, STACK_SLEEP_INTERRUPTIBLE, ts);
+			emit_stack_event_with_ts(ctx, prev, STACK_SLEEP_INTERRUPTIBLE, ts,
+						 SKIP_STACK_DEPTH);
 	}
 	return 0;
 }
@@ -2251,8 +2265,17 @@ int systing_perf_event_clock(void *ctx)
 	 */
 	u64 ts = bpf_ktime_get_boot_ns();
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	/*
+	 * No stack skip on this path: a perf-event program's
+	 * bpf_get_stack() walks from the sample's interrupted registers,
+	 * not through tracepoint glue. The shared skip here discarded the
+	 * interrupted IP plus the first two real return addresses, so
+	 * every kernel leaf in sampled profiles rendered as its
+	 * third-level caller.
+	 */
 	if (!tool_config.no_cpu_stack_traces)
-		emit_stack_event_with_ts(ctx, task, STACK_RUNNING, ts);
+		emit_stack_event_with_ts(ctx, task, STACK_RUNNING, ts,
+					 PERF_EVENT_SKIP_STACK_DEPTH);
 	read_counters(ctx, task);
 
 	if (tool_config.collect_memory && trace_task(task)) {


### PR DESCRIPTION
Kernel "leaves" in sampled CPU profiles are currently the third-level caller of what actually executed: the shared `SKIP_STACK_DEPTH = 3` is right for tracepoint-attached captures, where it skips BPF/tracing entry glue, but wrong for the perf-event sampler, whose stack walk starts at the sample's interrupted registers with no glue to skip. This PR passes the skip per attach point: 0 on the perf-event path, the unchanged 3 everywhere else.

Evidence from production data (2-hour windows):

- Pure-leaf kernel functions (`clear_page_erms`, `rep_movs_alternative`, `pv_native_safe_halt`, qspinlock slowpath) appear as CPU-sample kernel leaves in 48,886 of 2.39 billion rows — 0.002%, effectively never. They cannot all be absent; the skip was consuming them.
- The 3-frame shift reconciled an active incident's numbers exactly: lock slowpath spin sits three frames below each lock site, so spin rendered as the lock sites' callers (`dd_dispatch_request`'s slowpath spin as `__blk_mq_sched_dispatch_requests`, and the same pattern at the insert and merge sites).

Deliberately out of scope: the tracepoint-side skip stays 3. Sleep-stack data shows the glue depth above sched tracepoints varies by kernel version (two distinct residual-glue leaf patterns in production), so no constant is right on every kernel; that residue is handled at fold time by name, version-independently, on the consumer side.

Consumer note: leaf-keyed pattern matching downstream is calibrated against today's shifted data, so kernel-leaf spectra change where this deploys and leaf-prefix detectors get re-keyed alongside; that work is tracked and lands with or immediately behind the deployment.

Tested: cargo check/clippy/fmt clean; `trace_validation` and `perf_counter` integration suites green in the vmtest VM (v6.12-bpf kernel). Post-deploy verification: pure-leaf functions appear as leaves, and the leaf spectrum agrees with an interrupted-IP sampler over the same window.

Mechanism-precedent check: the only prior change to skip semantics is #184 (stop capturing kernel stacks on fault events — the same family, a shared constant applied to a context it does not fit); no per-attach-point differentiation previously existed.
