### PR TITLE
Pin clap_complete to 4.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
 dependencies = [
  "clap",
 ]
@@ -2709,7 +2709,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3518,7 +3518,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix 0.38.41",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
The ^4.5 requirement resolves to 4.6.8, but downstream consumers build hermetically against a curated crate mirror that currently carries 4.6.1, so shell-completion builds 404 there. The 4.6.2-4.6.8 delta is immaterial for the completions systing generates.

Side effect of re-resolution: two dependency-list entries (socket2, tempfile) now reference the older windows-sys already present in the lock; both windows-sys versions remain resolved, and neither affects Linux builds.