### PR TITLE
stack_recorder: bound the file-backed symbol cache with evict()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,8 +677,8 @@ dependencies = [
 
 [[package]]
 name = "blazesym"
-version = "0.2.5"
-source = "git+https://github.com/libbpf/blazesym.git?rev=862c2cf5d424307456322d2c68fe86c591baece2#862c2cf5d424307456322d2c68fe86c591baece2"
+version = "0.2.6"
+source = "git+https://github.com/libbpf/blazesym.git?rev=8705da0a8cec2bb27f897ac732e27121f9be7936#8705da0a8cec2bb27f897ac732e27121f9be7936"
 dependencies = [
  "cpp_demangle",
  "crc32fast",
@@ -1150,7 +1150,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1225,7 +1225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2709,7 +2709,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3046,7 +3046,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3518,7 +3518,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix 0.38.41",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bitfield = "0.19.0"
 # 0.2.x releases (where Sym::code_info became Option<Box<CodeInfo>>), so
 # `cargo install` without --locked picked an incompatible version. An exact pin
 # keeps fresh resolutions reproducible.
-blazesym = { git = "https://github.com/libbpf/blazesym.git", rev = "862c2cf5d424307456322d2c68fe86c591baece2" }
+blazesym = { git = "https://github.com/libbpf/blazesym.git", rev = "8705da0a8cec2bb27f897ac732e27121f9be7936" }
 clap = { version = "4.5.20", features = ["derive"] }
 ctrlc = "3.4"
 dashmap = "6"

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -21,7 +21,7 @@ use crate::utid::{ThreadAwareRecorder, UtidGenerator};
 use blazesym::helper::{read_elf_build_id, ElfResolver};
 use blazesym::symbolize::source::{Elf, Kernel, Process, Source};
 use blazesym::symbolize::{
-    cache, Input, ProcessMemberInfo, ProcessMemberType, Resolve, Sym, Symbolizer,
+    cache, evict, Input, ProcessMemberInfo, ProcessMemberType, Resolve, Sym, Symbolizer,
 };
 use blazesym::Error as BlazeErr;
 use blazesym::Pid;
@@ -384,6 +384,25 @@ fn current_anon_rss_bytes() -> Option<u64> {
     Some(resident.saturating_sub(shared) * page_size)
 }
 
+/// Approximate file-backed RSS of this process in bytes — the resident
+/// *shared* pages from /proc/self/statm, which is exactly the term
+/// [`current_anon_rss_bytes`] subtracts. During symbolization this is
+/// dominated by blazesym's `FileCache`, which mmaps every ELF/`.so` it
+/// touches and never evicts; that cache grows with the count of distinct
+/// binaries symbolized and is file-backed, not heap, so the anon budget
+/// above is blind to it. Watching this axis is what lets the evict valve
+/// fire on the symbol-file cache rather than only on parse-time heap.
+fn current_file_rss_bytes() -> Option<u64> {
+    let s = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let mut it = s.split_whitespace();
+    let _size = it.next()?;
+    let _resident = it.next()?;
+    let shared: u64 = it.next()?.parse().ok()?;
+    // SAFETY: sysconf is always safe to call; _SC_PAGESIZE cannot fail.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64;
+    Some(shared * page_size)
+}
+
 /// Number of second-tier spill files alive-process stacks are hashed into
 /// during `finish()`. The recording-phase spill is a single file (one fd, one
 /// sequential write stream on the hot path); at symbolization time stacks of
@@ -405,6 +424,48 @@ fn symbolizer_memory_budget() -> u64 {
         .map(|limit| limit / 2)
         .unwrap_or(DEFAULT_BUDGET)
         .clamp(256 << 20, 16 << 30)
+}
+
+/// Budget for the file-backed symbol cache — blazesym's mmap'd ELF/`.so`
+/// `FileCache`, measured by [`current_file_rss_bytes`]. Distinct from the
+/// anon [`symbolizer_memory_budget`] above, and the reason this fix exists:
+/// the file cache runs ~3 GiB and deterministic on the fleet (every capture
+/// symbolizes the same common-binary set), dominates the tracer's ~3.9 GiB
+/// peak, and is invisible to the anon watch — so it needs its own, tighter
+/// bound. Kept well under the anon budget so the symbolization footprint
+/// leaves headroom in the cgroup for the later DuckDB build phase, which is
+/// where large captures OOM. cgroup/8 targets ~1 GiB on an 8Gi slice.
+fn symbolizer_file_budget() -> u64 {
+    const DEFAULT_BUDGET: u64 = 1 << 30; // 1 GiB
+    crate::duckdb::detect_cgroup_memory_limit()
+        .map(|limit| limit / 8)
+        .unwrap_or(DEFAULT_BUDGET)
+        .clamp(256 << 20, 4 << 30)
+}
+
+/// Plan which touched ELF files to evict, fattest-first, so that the estimated
+/// file-backed RSS after eviction falls to `budget` or below. Returns the paths
+/// in eviction order; empty when already at or under budget. The on-disk `size`
+/// is an upper bound on the resident drop a single evict yields, so the plan is
+/// conservative — if a pass under-sheds, the valve re-fires on the next check
+/// interval. Kept pure and deterministic (size descending, ties broken by path)
+/// so the eviction policy is unit-testable without a live symbolizer.
+fn plan_evictions(touched_elf: &HashMap<PathBuf, u64>, file_rss: u64, budget: u64) -> Vec<PathBuf> {
+    if file_rss <= budget {
+        return Vec::new();
+    }
+    let mut by_size: Vec<(&PathBuf, u64)> = touched_elf.iter().map(|(p, &s)| (p, s)).collect();
+    by_size.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    let mut est = file_rss;
+    let mut plan = Vec::new();
+    for (path, size) in by_size {
+        if est <= budget {
+            break;
+        }
+        plan.push(path.clone());
+        est = est.saturating_sub(size);
+    }
+    plan
 }
 
 /// Memory-bounded interner for unique (stack, tgid) pairs, shared by the
@@ -1230,28 +1291,80 @@ impl StackRecorder {
         // further rebuilds would only thrash re-parsing, so the valve waits for
         // real growth above the floor before firing again.
         let memory_budget = symbolizer_memory_budget();
+        let file_budget = symbolizer_file_budget();
         const VALVE_CHECK_INTERVAL: usize = 8192;
         const REBUILD_GROWTH_MARGIN: u64 = 256 << 20;
         let mut rebuild_floor: u64 = 0;
-        let mut maybe_rebuild = |this: &Self, symbolizer: &mut Symbolizer| {
-            let Some(anon) = current_anon_rss_bytes() else {
-                return;
+        // The valve watches BOTH memory axes. The file-backed symbol cache
+        // (blazesym's mmap'd ELFs — see [`current_file_rss_bytes`]) is the
+        // dominant, deterministic term of the tracer's footprint and is
+        // invisible to `current_anon_rss_bytes`, so when it exceeds its
+        // budget we surgically `evict(Elf)` the fattest touched binaries —
+        // releasing their mmaps drops rss_file while keeping the rest of the
+        // warm cache — and fall back to a full rebuild only for anon growth
+        // (parse-time heap) a targeted evict can't reach. `touched_elf` (ELF
+        // path → on-disk size, the fattest-first key) is a parameter so the
+        // Pass-2 loop can keep populating it between valve calls.
+        let mut maybe_evict_or_rebuild =
+            |this: &Self, symbolizer: &mut Symbolizer, touched_elf: &mut HashMap<PathBuf, u64>| {
+                if let Some(file_rss) = current_file_rss_bytes() {
+                    let mut evicted = 0usize;
+                    for path in plan_evictions(touched_elf, file_rss, file_budget) {
+                        // A failed eviction only means blazesym holds that entry
+                        // until the symbolizer is dropped; not worth failing
+                        // symbolization over. `path` is the map_files link, which
+                        // is blazesym's elf_cache key (its EntryPath maps_file /
+                        // actual_path) for a live Process source, so this releases
+                        // the mmap and its fd; the VM gate confirms the rss_file
+                        // drop empirically.
+                        if symbolizer
+                            .evict(&evict::Evict::from(evict::Elf::new(path.clone())))
+                            .is_ok()
+                        {
+                            touched_elf.remove(&path);
+                            evicted += 1;
+                        }
+                    }
+                    if evicted > 0 {
+                        // SAFETY: malloc_trim is always safe to call on glibc.
+                        unsafe {
+                            libc::malloc_trim(0);
+                        }
+                        eprintln!(
+                            "Note: evicted {evicted} symbol-file cache entries to \
+                             stay under file budget ({} MiB)",
+                            file_budget >> 20
+                        );
+                    }
+                }
+
+                let Some(anon) = current_anon_rss_bytes() else {
+                    return;
+                };
+                if anon <= memory_budget
+                    || anon <= rebuild_floor.saturating_add(REBUILD_GROWTH_MARGIN)
+                {
+                    return;
+                }
+                *symbolizer = this.create_symbolizer();
+                // A full rebuild drops the whole cache, so the touched-ELF set
+                // no longer reflects what blazesym holds.
+                touched_elf.clear();
+                // SAFETY: malloc_trim is always safe to call on glibc.
+                unsafe {
+                    libc::malloc_trim(0);
+                }
+                rebuild_floor = current_anon_rss_bytes().unwrap_or(anon);
+                eprintln!(
+                    "Note: symbolizer caches rebuilt to stay under memory budget ({} MiB)",
+                    memory_budget >> 20
+                );
             };
-            if anon <= memory_budget || anon <= rebuild_floor.saturating_add(REBUILD_GROWTH_MARGIN)
-            {
-                return;
-            }
-            *symbolizer = this.create_symbolizer();
-            // SAFETY: malloc_trim is always safe to call on glibc.
-            unsafe {
-                libc::malloc_trim(0);
-            }
-            rebuild_floor = current_anon_rss_bytes().unwrap_or(anon);
-            eprintln!(
-                "Note: symbolizer caches rebuilt to stay under memory budget ({} MiB)",
-                memory_budget >> 20
-            );
-        };
+
+        // ELF paths symbolized this pass → on-disk size, the fattest-first
+        // key for `maybe_evict_or_rebuild`. Populated per-tgid from each
+        // process's exec-file maps as Pass 2 walks the buckets.
+        let mut touched_elf: HashMap<PathBuf, u64> = HashMap::new();
 
         // Guest-side sandbox snapshot, taken lazily on the first gVisor
         // process encountered and shared by every group after it.
@@ -1286,6 +1399,23 @@ impl StackRecorder {
                 // frame labels for its whole group. `None` (process raced to
                 // exit, unreadable maps) degrades to plain symbolization.
                 let maps_info = ProcessMaps::load(tgid);
+                // Record this process's mapped ELF files so the valve can evict
+                // the fattest ones when the symbol-file cache exceeds its budget.
+                // exec_file_links yields (map_files link, display path). We key
+                // by the map_files link — `/proc/<pid>/map_files/<start>-<end>` —
+                // because that is byte-for-byte blazesym's elf_cache key for a
+                // live Process source (its `EntryPath::maps_file`, the cache
+                // `actual_path`; the display/maps-text path is only the module
+                // name and evicts nothing). The link is also namespace-immune:
+                // `metadata` follows it to the backing file for the size even
+                // when the process's maps-text path does not resolve from here.
+                if let Some(maps) = maps_info.as_ref() {
+                    for (link, _display) in maps.exec_file_links() {
+                        touched_elf.entry(link).or_insert_with_key(|p| {
+                            std::fs::metadata(p).map(|m| m.len()).unwrap_or(0)
+                        });
+                    }
+                }
                 // For sandbox processes, the guest process this stub mirrors
                 // (if any). The sandbox snapshot is taken once, on first
                 // contact with a gVisor process.
@@ -1315,7 +1445,7 @@ impl StackRecorder {
 
                 for (i, (stack, stack_id)) in stacks.into_iter().enumerate() {
                     if i > 0 && i % VALVE_CHECK_INTERVAL == 0 {
-                        maybe_rebuild(self, &mut symbolizer);
+                        maybe_evict_or_rebuild(self, &mut symbolizer, &mut touched_elf);
                     }
                     let frame_names = self.symbolize_stack_frames(
                         &mut symbolizer,
@@ -1330,7 +1460,7 @@ impl StackRecorder {
                     emit_stack_record(collector, stack_id, frame_names)?;
                 }
 
-                maybe_rebuild(self, &mut symbolizer);
+                maybe_evict_or_rebuild(self, &mut symbolizer, &mut touched_elf);
             }
         }
 
@@ -2735,5 +2865,74 @@ mod tests {
                  live-fill store, got: {frame}"
             );
         }
+    }
+
+    /// Build a touched-ELF map (path -> on-disk size) for eviction-plan tests.
+    fn touched(entries: &[(&str, u64)]) -> HashMap<PathBuf, u64> {
+        entries
+            .iter()
+            .map(|&(p, s)| (PathBuf::from(p), s))
+            .collect()
+    }
+
+    #[test]
+    fn plan_evictions_empty_when_at_or_under_budget() {
+        let t = touched(&[("/a", 100), ("/b", 200)]);
+        assert!(
+            plan_evictions(&t, 500, 1000).is_empty(),
+            "under budget evicts nothing"
+        );
+        assert!(
+            plan_evictions(&t, 1000, 1000).is_empty(),
+            "exactly at budget evicts nothing"
+        );
+    }
+
+    #[test]
+    fn plan_evictions_fattest_first_stops_once_under() {
+        let t = touched(&[("/small", 100), ("/big", 800), ("/mid", 400)]);
+        // rss 1500, budget 1000: shed >=500. Fattest first, /big (800) alone
+        // brings the estimate to 700 <= 1000, so the plan stops after it.
+        assert_eq!(plan_evictions(&t, 1500, 1000), vec![PathBuf::from("/big")]);
+    }
+
+    #[test]
+    fn plan_evictions_continues_until_enough_shed() {
+        let t = touched(&[("/a", 100), ("/b", 120), ("/c", 90)]);
+        // rss 1000, budget 700: shed >=300. Fattest first: b(120)->880,
+        // a(100)->780, c(90)->690 <= 700.
+        assert_eq!(
+            plan_evictions(&t, 1000, 700),
+            vec![
+                PathBuf::from("/b"),
+                PathBuf::from("/a"),
+                PathBuf::from("/c")
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_evictions_deterministic_on_size_ties() {
+        let t = touched(&[("/z", 500), ("/a", 500)]);
+        // Equal sizes: tie broken by path ascending, so /a is chosen first and
+        // alone (500 -> 700 <= 800) — deterministic regardless of map order.
+        assert_eq!(plan_evictions(&t, 1200, 800), vec![PathBuf::from("/a")]);
+    }
+
+    #[test]
+    fn symbolizer_file_budget_within_clamp() {
+        let b = symbolizer_file_budget();
+        assert!(
+            ((256u64 << 20)..=(4u64 << 30)).contains(&b),
+            "file budget {b} must stay within the [256 MiB, 4 GiB] clamp"
+        );
+    }
+
+    #[test]
+    fn current_file_rss_bytes_reads_own_statm() {
+        // A running process always has resident shared pages (libc and friends),
+        // so the file-backed axis reads as a positive value from our own statm.
+        let v = current_file_rss_bytes().expect("statm is readable for self");
+        assert!(v > 0, "file-backed RSS should be > 0 for a running process");
     }
 }

--- a/tests/symbolizer_evict.rs
+++ b/tests/symbolizer_evict.rs
@@ -1,0 +1,85 @@
+//! Runtime confirmation that evicting by systing's `map_files` link releases
+//! the blazesym elf_cache entry (its open file descriptor) — the observed
+//! counterpart to the source-verified key match in `stack_recorder.rs`:
+//! `exec_file_links`' `/proc/pid/map_files/<start>-<end>` link is byte-for-byte
+//! blazesym's `EntryPath::maps_file`, which is the elf_cache key (`actual_path`).
+//!
+//! `#[ignore]`, run only under the vng rig: reading `/proc/<pid>/map_files/`
+//! requires CAP_SYS_ADMIN. The systing tracer has it (BPF needs it) but an
+//! unprivileged `cargo test` does not, and without it blazesym's own stat of
+//! the map_files path fails EPERM before it can cache — so this must run where
+//! the tracer runs, privileged. The vng rig boots the test as root.
+
+use std::path::PathBuf;
+
+use blazesym::symbolize::source::{Process, Source};
+use blazesym::symbolize::{evict, Input, Symbolizer};
+use blazesym::Pid;
+use systing::sandbox_maps::ProcessMaps;
+
+/// Number of open fds in /proc/self/fd whose target is one of `backing`.
+/// blazesym's FileCache holds one open `File` (fd) per cached ELF, so this
+/// count drops when the corresponding entry is evicted.
+fn count_fds_to(backing: &[PathBuf]) -> usize {
+    let mut n = 0;
+    if let Ok(rd) = std::fs::read_dir("/proc/self/fd") {
+        for entry in rd.flatten() {
+            if let Ok(target) = std::fs::read_link(entry.path()) {
+                if backing.contains(&target) {
+                    n += 1;
+                }
+            }
+        }
+    }
+    n
+}
+
+#[test]
+#[ignore = "needs CAP_SYS_ADMIN for /proc/pid/map_files; runs under the vng rig"]
+fn evict_by_map_files_link_releases_elf_cache_fd() {
+    let pid = std::process::id() as i32;
+    let maps = ProcessMaps::load(pid).expect("read own /proc/<pid>/maps");
+    let links = maps.exec_file_links();
+    assert!(!links.is_empty(), "self must have mapped executable files");
+
+    let backing: Vec<PathBuf> = links
+        .iter()
+        .filter_map(|(link, _display)| std::fs::read_link(link).ok())
+        .collect();
+    assert!(
+        !backing.is_empty(),
+        "map_files links must resolve to backing files (needs CAP_SYS_ADMIN)"
+    );
+
+    let mut symbolizer = Symbolizer::new();
+    // Symbolize an address in this test binary's own text so blazesym opens and
+    // caches the backing ELF via its map_files path, holding an fd.
+    let proc_src = Source::Process(Process::new(Pid::from(pid as u32)));
+    let addr = evict_by_map_files_link_releases_elf_cache_fd as fn() as usize as u64;
+    let sym_result = symbolizer.symbolize_single(&proc_src, Input::AbsAddr(addr));
+    assert!(
+        sym_result.is_ok(),
+        "symbolization must succeed under the tracer's privilege: {sym_result:?}"
+    );
+
+    let before = count_fds_to(&backing);
+    assert!(
+        before > 0,
+        "blazesym must hold at least one cached ELF fd after symbolizing"
+    );
+
+    // Evict every mapped ELF by its map_files link — the exact key the valve in
+    // stack_recorder.rs uses. A wrong key would be a silent no-op that left the
+    // fd count unchanged.
+    for (link, _display) in &links {
+        symbolizer
+            .evict(&evict::Evict::from(evict::Elf::new(link.clone())))
+            .expect("evict returns Ok");
+    }
+
+    let after = count_fds_to(&backing);
+    assert!(
+        after < before,
+        "evict via map_files link must release cached ELF fds: before={before} after={after}"
+    );
+}


### PR DESCRIPTION
## What this does

The symbolization phase already has a memory valve that rebuilds the blazesym
symbolizer when it grows too large, but it watches only anonymous RSS. The
dominant cost is the file-backed symbol cache: blazesym mmaps every ELF and
`.so` it symbolizes and never releases them, and the anon watch cannot see
that. In practice the cache runs about 3 GiB and is the largest single term of
the tracer's roughly 3.9 GiB peak. This change adds a second budget on the
file-backed axis, and when that budget is exceeded it evicts the fattest cached
binaries with blazesym's `evict()` (fattest-first, releasing their mmaps)
before falling back to the existing full rebuild. The tracer's per-capture peak
drops by roughly 3 GiB.

## Why it matters

Two out-of-memory classes need this headroom, both on an 8 GiB memory slice:
- Whole-system captures on high-core hosts, where the symbol cache alone
  approaches the slice.
- Long on-demand captures (720 seconds) on busy nodes, where the tracer stacks
  the symbol cache on top of the DuckDB build phase and is killed partway
  through, so users get only partial results.

## Re-land history

This re-lands work that was reverted, so the precedent is on the record:
- The `evict()` API this consumes was added upstream in
  [blazesym#1613](https://github.com/libbpf/blazesym/pull/1613) (merged).
- It was first consumed by
  [#170](https://github.com/josefbacik/systing/pull/170), which bumped blazesym
  and added a count-based watermark on the exited-process snapshot.
- [#170](https://github.com/josefbacik/systing/pull/170) was reverted the same
  day by [#171](https://github.com/josefbacik/systing/pull/171) as collateral in
  an unrelated rollback (the #165 machinery), not because of `evict()`.

This change is broader than a re-land of #170. #170 bounded only the
exited-process snapshot, by entry count; it never touched the live-process
cache, which is where the roughly 3 GiB actually lives. This bounds the live
cache on the file-backed RSS axis and evicts by resident size.

## The eviction key

blazesym keys its ELF cache by each mapping's `/proc/<pid>/map_files/<start>-<end>`
path (its `EntryPath::maps_file`, the cache's `actual_path`), not the
`/proc/<pid>/maps` text path. Evicting by the wrong path is a silent no-op. This
change evicts by the map_files link that `ProcessMaps::exec_file_links` yields,
which is byte-for-byte the format blazesym constructs. An integration test
(`tests/symbolizer_evict.rs`, run under the privileged vng rig) confirms at
runtime that evicting by that link releases the cached file descriptor.

## Mechanism

<details>
<summary>Why the anon watch was blind to the file cache</summary>

`current_anon_rss_bytes()` computes resident minus shared from
`/proc/self/statm`. The shared term it subtracts is exactly the file-backed
symbol cache, because mmap'd ELFs are resident-shared rather than heap. So the
existing `symbolizer_memory_budget` check never fires on the file cache no
matter how large the cache grows. The confirming signature is that the tracer's
`rss_file` is flat at about 3 GiB across hosts; a sawtooth would show if a valve
were bounding it.

The fix watches the file-backed axis directly. `current_file_rss_bytes()` reads
the statm shared term, and `symbolizer_file_budget()` (cgroup/8) is held well
under the anon budget so the symbolization footprint leaves cgroup headroom for
the later DuckDB phase, which is where long captures run out of memory. When the
file budget is exceeded the valve evicts the fattest touched binaries by on-disk
size until back under budget, then falls back to a full rebuild only for anon
growth that a targeted evict cannot reach.

The file valve deliberately has no growth-floor anti-thrash (unlike the anon
rebuild path): a tight bound is correct for OOM prevention, and re-parsing a
re-touched evicted binary is the accepted cost, mitigated by fattest-first.
</details>

## Testing

- Unit tests for the eviction planner (fattest-first order, stops once under
  budget, deterministic tie-break) and the budget/RSS helpers.
- `tests/symbolizer_evict.rs` (vng, privileged): evicting by the map_files link
  releases blazesym's cached fd — the runtime counterpart to the source-verified
  key.
- `memory_recorder` passes under vng: the change is benign in the normal
  recording path (the valve does not fire below budget).

The roughly 3 GiB per-capture reduction is measured on a real node after deploy.
A vng VM lacks the binary diversity to grow the cache to fleet scale, so this
change proves the mechanism here, not the fleet magnitude.

## Note on Cargo.lock

The blazesym 0.2.6 bump re-resolved `windows-sys` to 0.59.0 across the tree.
Those are `cfg(windows)`-only dependencies with no effect on the Linux build.

<!-- version intentionally not touched: bump-on-merge assigns it at merge -->
