### PR TITLE
Fix rss_stat attribution in reclaim context; add passive thrash sampling [bump minor]

### DIFF
--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -296,3 +296,51 @@ peer, not a local interface) and IPv4-mapped-IPv6 sockets correctly.
 
 Pre-v13 databases and traces have neither column; readers join on `netns_inum`
 where present and fall back to the `src_ip`→interface heuristic otherwise.
+
+## Schema Version 14 (unreleased) — 2026-08-11
+
+`memory_rss` gains an `external BOOLEAN` column and three synthetic members
+(-3/-4/-5), fixing rss_stat attribution in reclaim context and adding passive
+per-task thrash signals.
+
+### Attribution fix (no column)
+rss_stat events are now attributed to the mm's owner rather than to the task
+that happened to be running. Reclaim (`try_to_unmap_one`) decrements the
+victim's counters from the reclaimer's context, so reclaim-driven RSS drops of
+a traced process were previously dropped in cgroup-targeted mode (kswapd fails
+the filter) and misattributed to the reclaimer in whole-system mode (with the
+threshold batching state keyed by the wrong tgid). The common self-update case
+is unchanged, and a process's own exit teardown stays self-attributed — even
+when `mm_update_next_owner()` has already cleared `mm->owner` — so per-process
+RSS still falls to zero at exit. On the classic (non-BTF) fallback attach path
+the raw tracepoint carries no mm pointer, so remote updates are dropped there
+instead of misattributed.
+
+### New columns
+- `memory_rss.external` (BOOLEAN): true when the counter update was performed
+  from outside the process's own thread group — an external reclaimer (kswapd,
+  khugepaged, another process's direct reclaim, a `memory.reclaim` /
+  `process_madvise` writer) evicted or migrated the process's pages. False for
+  the process's own faults/maps/unmaps/exit teardown, for synthetic members,
+  and for exit-flush residuals (mixed provenance). Splitting cumulative member
+  deltas by this flag yields a per-process evicted-bytes timeline (under
+  threshold batching the flag reflects the update that crossed the threshold).
+
+### New synthetic members (periodic mm snapshots, `utid` = sampled thread)
+- `-3` maj_flt: cumulative major fault count for the sampled thread — a page
+  the process needed came back from disk/swap. Count, not bytes.
+- `-4` thrashing_count / `-5` thrashing_delay_ns: delayacct's thrash metrics
+  (stalls on `PG_workingset` pages — pages that refaulted soon after reclaim).
+  Emitted (zero values included) whenever delayacct was readable for the
+  sampled task, so zero-valued rows mean "delayacct on, no thrash", and their
+  complete absence while -3 rows are present means delayacct is not enabled
+  on the host (`CONFIG_TASK_DELAY_ACCT` plus the `delayacct` boot parameter
+  or the `kernel.task_delayacct` sysctl — runtime-enableable, but only tasks
+  forked after enablement carry the counters).
+
+"RSS flat while maj_flt and thrashing_delay climb" is a direct per-process
+thrash signature; `external` tells you whose pages reclaim is taking. Pre-v14
+databases and traces have neither the column nor the members: merging a
+pre-v14 DuckDB into a v14 database (`systing-util convert`) NULL-fills
+`external` via the column-intersection import, and readers of raw pre-v14
+parquet must treat the column as absent.

--- a/skills/systing-analyze/SKILL.md
+++ b/skills/systing-analyze/SKILL.md
@@ -113,7 +113,7 @@ ORDER BY retransmits DESC;
 ### Memory
 From the `memory` / `memory-alloc` recorders. `stack_id` columns join to `stack.id` like sample stacks.
 
-- `memory_rss(ts, utid, member, size)` — RSS tracking. `member`: `0`=file, `1`=anon, `2`=swap, `3`=shmem, `-1`=hiwater_rss, `-2`=total_vm (the negatives are synthetic periodic `mm_struct` samples).
+- `memory_rss(ts, utid, member, size, external)` — RSS tracking. `member`: `0`=file, `1`=anon, `2`=swap, `3`=shmem, `-1`=hiwater_rss, `-2`=total_vm, `-3`=maj_flt, `-4`=thrashing_count, `-5`=thrashing_delay_ns (negatives are synthetic periodic samples). Units vary by member: `size` is bytes for `0..3`/`-1`/`-2`, a cumulative fault count for `-3`, a stall count for `-4`, and nanoseconds for `-5` — never aggregate across members. `external` is true when the update came from an external reclaimer (kswapd, direct reclaim by another process) rather than the process itself; `-4`/`-5` rows appear only on delayacct-enabled hosts (zero-valued rows there mean "no thrash").
 - `memory_map(ts, utid, event_type, addr, size, prot, flags, stack_id)` — mmap/munmap/brk.
 - `memory_fault(ts, utid, addr, error_code, stack_id)` — user page faults (sampled 1-in-N, default 97).
 - `memory_alloc(ts, utid, op, addr, size, old_addr, stack_id)` — malloc/calloc/realloc/free uprobes.

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -412,6 +412,7 @@ enum memory_event_type {
 	MEMORY_MM_SAMPLE,     // periodic mm_struct snapshot (from perf_event_clock)
 	MEMORY_ALLOC,         // uretprobe malloc/calloc/realloc/... - heap object allocated
 	MEMORY_FREE,          // uprobe free - heap object released
+	MEMORY_THRASH_SAMPLE, // periodic per-task thrash counters (from perf_event_clock)
 };
 
 /* RSS stat member indices (mirrors include/linux/mm_types_task.h) */
@@ -421,6 +422,22 @@ enum memory_rss_member {
 	MEMORY_MM_SWAPENTS,
 	MEMORY_MM_SHMEMPAGES,
 };
+
+/* memory_event_header.flags bits for MEMORY_RSS_STAT events. */
+/* The counter update was performed by a task outside the mm's thread
+ * group -- an external reclaimer (kswapd, khugepaged, another process in
+ * direct reclaim, a memory.reclaim / process_madvise writer) evicted or
+ * migrated this process's pages, rather than the process itself
+ * faulting, mapping, or unmapping. Never set on exit-flush residuals
+ * (those aggregate updates from both classes). */
+#define MEMORY_RSS_FLAG_EXTERNAL (1U << 0)
+
+/* memory_event_header.flags bit for MEMORY_THRASH_SAMPLE events: delayacct
+ * was enabled and task->delays was read, so zero-valued thrash counters mean
+ * "no thrash". Events without this bit mean the counters were unavailable
+ * (CONFIG_TASK_DELAY_ACCT off, delayacct not enabled, or delays not
+ * allocated for this task). */
+#define MEMORY_THRASH_FLAG_DELAYACCT (1U << 0)
 
 /* Allocator operation, stored in memory_event.member for MEMORY_ALLOC/FREE. */
 enum memory_alloc_op {
@@ -434,19 +451,19 @@ enum memory_alloc_op {
 
 /*
  * memory_event is split so the high-frequency stack-less types
- * (RSS_STAT, MM_SAMPLE, FREE) reserve only the ~80-byte header instead of the
- * full struct with stack arrays and pystacks buffer.
+ * (RSS_STAT, MM_SAMPLE, THRASH_SAMPLE, FREE) reserve only the ~80-byte header
+ * instead of the full struct with stack arrays and pystacks buffer.
  */
 struct memory_event_header {
 	enum memory_event_type type;
 	u64 ts;
 	u32 cpu;
 	struct task_info task;
-	u64 addr;          // mmap ret / munmap addr / fault addr / brk new / hiwater_rss / alloc ret
-	u64 size;          // mmap len / munmap len / rss size (bytes) / total_vm (bytes) / alloc bytes
+	u64 addr;          // mmap ret / munmap addr / fault addr / brk new / hiwater_rss / alloc ret / thrash maj_flt
+	u64 size;          // mmap len / munmap len / rss size (bytes) / total_vm (bytes) / alloc bytes / thrash stall count
 	u32 member;        // rss_stat: enum memory_rss_member; mmap: prot; alloc: enum memory_alloc_op
-	u32 flags;         // mmap: MAP_* flags; page_fault: error_code
-	u64 old_addr;      // realloc: previous pointer (else 0)
+	u32 flags;         // mmap: MAP_* flags; page_fault: error_code; rss_stat: MEMORY_RSS_FLAG_*
+	u64 old_addr;      // realloc: previous pointer / thrash stall delay ns (else 0)
 	u64 kernel_stack_length;
 	u64 user_stack_length;
 };
@@ -2329,6 +2346,32 @@ int systing_perf_event_clock(void *ctx)
 				mev->addr = BPF_CORE_READ(mm, hiwater_rss) * (u64)tool_config.page_size;
 				mev->size = BPF_CORE_READ(mm, total_vm) * (u64)tool_config.page_size;
 				bpf_ringbuf_submit(mev, mflags);
+			} else {
+				handle_missed_event(MISSED_MEMORY_EVENT);
+			}
+			/* Companion thrash sample: a separate event type so
+			 * the shared header doesn't grow for fields only this
+			 * low-rate path fills. task->delays is only present
+			 * with CONFIG_TASK_DELAY_ACCT and only allocated when
+			 * delayacct is enabled; absent or NULL leaves the
+			 * init-zeroed values. */
+			struct memory_event_header *tev = reserve_memory_event_header(&mflags);
+			if (tev) {
+				tev->type = MEMORY_THRASH_SAMPLE;
+				tev->ts = ts;
+				tev->cpu = bpf_get_smp_processor_id();
+				record_task_info(&tev->task, task);
+				tev->addr = BPF_CORE_READ(task, maj_flt);
+				if (bpf_core_field_exists(task->delays)) {
+					struct task_delay_info *d =
+						BPF_CORE_READ(task, delays);
+					if (d) {
+						tev->flags = MEMORY_THRASH_FLAG_DELAYACCT;
+						tev->size = BPF_CORE_READ(d, thrashing_count);
+						tev->old_addr = BPF_CORE_READ(d, thrashing_delay);
+					}
+				}
+				bpf_ringbuf_submit(tev, mflags);
 			} else {
 				handle_missed_event(MISSED_MEMORY_EVENT);
 			}
@@ -5041,7 +5084,8 @@ static __always_inline s64 read_mm_rss_pages(struct mm_struct *mm, u32 member)
 }
 
 static __always_inline int emit_rss_stat_event(struct task_struct *task,
-					       u32 member, s64 size_bytes)
+					       u32 member, s64 size_bytes,
+					       u32 rss_flags)
 {
 	long flags;
 	struct memory_event_header *event = reserve_memory_event_header(&flags);
@@ -5054,6 +5098,7 @@ static __always_inline int emit_rss_stat_event(struct task_struct *task,
 	record_task_info(&event->task, task);
 	event->member = member;
 	event->size = (u64)size_bytes;
+	event->flags = rss_flags;
 
 	bpf_ringbuf_submit(event, flags);
 	return 0;
@@ -5064,14 +5109,15 @@ static __always_inline int emit_rss_stat_event(struct task_struct *task,
  * (counter reads, size math) so untraced tasks pay as close to zero as
  * possible on this very hot tracepoint. */
 static __always_inline int handle_rss_stat(struct task_struct *task,
-					   u32 member, s64 size_bytes)
+					   u32 member, s64 size_bytes,
+					   u32 rss_flags)
 {
 	if (member >= NR_MM_COUNTERS)
 		return 0;
 
 	/* Threshold disabled (0): preserve pre-change behavior exactly. */
 	if (tool_config.memory_rss_threshold_bytes == 0)
-		return emit_rss_stat_event(task, member, size_bytes);
+		return emit_rss_stat_event(task, member, size_bytes, rss_flags);
 
 	u32 tgid = BPF_CORE_READ(task, tgid);
 	struct rss_stat_state *st = bpf_map_lookup_elem(&rss_stat_last, &tgid);
@@ -5083,10 +5129,10 @@ static __always_inline int handle_rss_stat(struct task_struct *task,
 		 * BPF_NOEXIST (not BPF_ANY) so the race-loser doesn't clobber
 		 * the winner's populated state. */
 		if (bpf_map_update_elem(&rss_stat_last, &tgid, &init, BPF_NOEXIST) != 0)
-			return emit_rss_stat_event(task, member, size_bytes);
+			return emit_rss_stat_event(task, member, size_bytes, rss_flags);
 		st = bpf_map_lookup_elem(&rss_stat_last, &tgid);
 		if (!st)
-			return emit_rss_stat_event(task, member, size_bytes);
+			return emit_rss_stat_event(task, member, size_bytes, rss_flags);
 	}
 
 	/* Unsynchronized per-member s64 stores — multiple threads of a tgid
@@ -5104,25 +5150,79 @@ static __always_inline int handle_rss_stat(struct task_struct *task,
 		return 0;
 
 	st->last_emitted[member] = size_bytes;
-	return emit_rss_stat_event(task, member, size_bytes);
+	return emit_rss_stat_event(task, member, size_bytes, rss_flags);
 }
 
 SEC("tp_btf/rss_stat")
 int BPF_PROG(systing_rss_stat_btf, struct mm_struct *mm, int member)
 {
-	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	struct task_struct *current = (struct task_struct *)bpf_get_current_task_btf();
+	struct task_struct *task = current;
+	u32 rss_flags = 0;
+
+	/* Attribute by the tracepoint's mm, not by current. Reclaim fires
+	 * this tracepoint from a context whose current is the RECLAIMER --
+	 * kswapd, khugepaged, another process in direct reclaim, a
+	 * memory.reclaim / process_madvise writer -- while the counters
+	 * that moved belong to the mm's owner. Attributing by current
+	 * dropped those events in cgroup-targeted mode (the reclaimer
+	 * fails the filter) and misattributed them to the reclaimer in
+	 * whole-system mode (with the threshold state batched under the
+	 * wrong tgid). The common self-update case (fault, mmap, munmap)
+	 * keeps current: it is a thread of the mm's own thread group, so
+	 * attribution is identical and no mm->owner walk is paid. */
+	if (current->mm != mm) {
+		struct task_struct *owner = NULL;
+
+		if (bpf_core_field_exists(mm->owner))
+			owner = mm->owner;
+		if (owner) {
+			task = owner;
+			/* Same-tgid updates with current->mm detached are
+			 * the task's own exit teardown (exit_mm() nulls
+			 * current->mm before exit_mmap() drops the
+			 * counters): the process releasing its own memory,
+			 * not external reclaim. */
+			if (current->tgid != owner->tgid)
+				rss_flags |= MEMORY_RSS_FLAG_EXTERNAL;
+		} else if (!(current->flags & PF_KTHREAD) &&
+			   current->active_mm == mm) {
+			/* Last-user exit teardown: mm_update_next_owner()
+			 * NULLs mm->owner before exit_mmap() drops the
+			 * counters (and CONFIG_MEMCG=n kernels have no
+			 * owner field at all), but the exiting task still
+			 * carries the mm as active_mm. Keep the final
+			 * RSS fall self-attributed so per-process RSS
+			 * reaches zero at exit. */
+			task = current;
+		} else {
+			/* Unattributable: a reclaimer hit an mm whose
+			 * owner is gone. */
+			return 0;
+		}
+	}
 	if (!trace_task(task))
 		return 0;
 	s64 pages = read_mm_rss_pages(mm, (u32)member);
 	if (pages < 0)
 		pages = 0;
-	return handle_rss_stat(task, (u32)member, pages * (s64)tool_config.page_size);
+	return handle_rss_stat(task, (u32)member,
+			       pages * (s64)tool_config.page_size, rss_flags);
 }
 
 SEC("tracepoint/kmem/rss_stat")
 int systing_rss_stat(struct trace_event_raw_rss_stat *ctx)
 {
 	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	/* The raw tracepoint carries a hashed mm id (ctx->mm_id) plus a
+	 * curr flag -- no mm pointer -- so on this fallback path the victim
+	 * of a remote update (reclaim) cannot be resolved. curr==0 events
+	 * would be attributed to the reclaimer; drop them instead. Bounded
+	 * loss: this path is only selected on kernels whose BTF lacks
+	 * btf_trace_rss_stat, and such events were never correctly
+	 * attributed here anyway. */
+	if (!ctx->curr)
+		return 0;
 	if (!trace_task(task))
 		return 0;
 	/* ctx->size is the kernel's exact percpu_counter_sum_positive() already
@@ -5133,7 +5233,7 @@ int systing_rss_stat(struct trace_event_raw_rss_stat *ctx)
 	s64 size = (s64)ctx->size;
 	if (size < 0)
 		size = 0;
-	return handle_rss_stat(task, (u32)ctx->member, size);
+	return handle_rss_stat(task, (u32)ctx->member, size, 0);
 }
 
 /* Flush sub-threshold residual rss_stat state at last-thread-exit so a
@@ -5167,13 +5267,14 @@ int BPF_PROG(systing_rss_stat_exit_flush, struct task_struct *task)
 
 	/* task->mm is NULL here (exit_mm() precedes this tracepoint), so
 	 * flush latest_seen[] captured on the rss_stat path rather than
-	 * re-reading mm. */
+	 * re-reading mm. Flushed residuals aggregate updates from both the
+	 * process itself and any external reclaimer, so no external flag. */
 	for (u32 m = 0; m < NR_MM_COUNTERS; m++) {
 		s64 latest = st->latest_seen[m];
 		if (latest < 0)
 			continue; /* never seen */
 		if (latest != st->last_emitted[m])
-			emit_rss_stat_event(task, m, latest);
+			emit_rss_stat_event(task, m, latest, 0);
 	}
 	bpf_map_delete_elem(&rss_stat_last, &tgid);
 	return 0;

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -133,7 +133,7 @@ pub struct TraceImportMapping {
 }
 
 /// Current schema version. See SCHEMA_CHANGES.md for history.
-pub const SCHEMA_VERSION: u32 = 13;
+pub const SCHEMA_VERSION: u32 = 14;
 
 /// All data tables in the DuckDB schema (excludes the `_traces` metadata table).
 pub const DATA_TABLES: &[&str] = &[
@@ -555,7 +555,8 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
             ts BIGINT,
             utid BIGINT,
             member TINYINT,
-            size BIGINT
+            size BIGINT,
+            external BOOLEAN
         );
         CREATE TABLE IF NOT EXISTS memory_map (
             trace_id VARCHAR,

--- a/src/memory_recorder.rs
+++ b/src/memory_recorder.rs
@@ -24,6 +24,27 @@ pub(crate) const MEMORY_STACK_ID_OFFSET: i64 = 1_000_000_000;
 /// the kernel rss_stat member indices 0..=3).
 pub const MEMORY_MEMBER_HIWATER_RSS: i8 = -1;
 pub const MEMORY_MEMBER_TOTAL_VM: i8 = -2;
+/// Synthetic `member` values for the passive per-task thrash counters sampled
+/// at the same periodic mm snapshot. maj_flt is a fault COUNT (not bytes);
+/// thrashing_count is delayacct's thrash stall count and thrashing_delay its
+/// cumulative stall time in NANOSECONDS — all cumulative per sampled thread.
+/// The thrashing pair is emitted whenever delayacct was readable on the host,
+/// zero values included — so zero-valued rows mean "delayacct on, no thrash",
+/// and their complete absence while -3 rows are present means delayacct is
+/// not enabled (kernel config or the `delayacct` boot / `kernel.task_delayacct`
+/// sysctl setting).
+pub const MEMORY_MEMBER_MAJ_FLT: i8 = -3;
+pub const MEMORY_MEMBER_THRASHING_COUNT: i8 = -4;
+pub const MEMORY_MEMBER_THRASHING_DELAY: i8 = -5;
+
+/// Mirror of `MEMORY_RSS_FLAG_EXTERNAL` in systing_system.bpf.c: the rss_stat
+/// counter update came from outside the process's thread group (external
+/// reclaim) rather than the process's own fault/map/unmap/exit path.
+const MEMORY_RSS_FLAG_EXTERNAL: u32 = 1 << 0;
+
+/// Mirror of `MEMORY_THRASH_FLAG_DELAYACCT` in systing_system.bpf.c: delayacct
+/// was enabled and the thrash counters were actually read for this sample.
+const MEMORY_THRASH_FLAG_DELAYACCT: u32 = 1 << 0;
 
 pub struct MemoryRecorder {
     pub(crate) ringbuf: RingBuffer<memory_event>,
@@ -181,6 +202,7 @@ impl SystingRecordEvent<memory_event> for MemoryRecorder {
                     utid,
                     member: hdr.member.min(i8::MAX as u32) as i8,
                     size: hdr.size as i64,
+                    external: hdr.flags & MEMORY_RSS_FLAG_EXTERNAL != 0,
                 });
                 self.report_write_error(r);
             }
@@ -238,6 +260,7 @@ impl SystingRecordEvent<memory_event> for MemoryRecorder {
                     utid,
                     member: MEMORY_MEMBER_HIWATER_RSS,
                     size: hdr.addr as i64,
+                    external: false,
                 });
                 self.report_write_error(r);
                 let r = collector.add_memory_rss(MemoryRssRecord {
@@ -245,8 +268,45 @@ impl SystingRecordEvent<memory_event> for MemoryRecorder {
                     utid,
                     member: MEMORY_MEMBER_TOTAL_VM,
                     size: hdr.size as i64,
+                    external: false,
                 });
                 self.report_write_error(r);
+            }
+            memory_event_type::MEMORY_THRASH_SAMPLE => {
+                // Per-type field reuse: addr = maj_flt, size = delayacct
+                // thrashing_count, old_addr = thrashing_delay ns.
+                let (maj_flt, thrash_count, thrash_delay_ns) = (hdr.addr, hdr.size, hdr.old_addr);
+                // maj_flt is emitted unconditionally (a 0 row distinguishes
+                // "no major faults yet" from "no data"); the delayacct pair
+                // only when the flag says the counters were readable, so
+                // zero-valued pair rows mean "no thrash" and pair absence
+                // means delayacct is off on the host.
+                let r = collector.add_memory_rss(MemoryRssRecord {
+                    ts: hdr.ts as i64,
+                    utid,
+                    member: MEMORY_MEMBER_MAJ_FLT,
+                    size: maj_flt as i64,
+                    external: false,
+                });
+                self.report_write_error(r);
+                if hdr.flags & MEMORY_THRASH_FLAG_DELAYACCT != 0 {
+                    let r = collector.add_memory_rss(MemoryRssRecord {
+                        ts: hdr.ts as i64,
+                        utid,
+                        member: MEMORY_MEMBER_THRASHING_COUNT,
+                        size: thrash_count as i64,
+                        external: false,
+                    });
+                    self.report_write_error(r);
+                    let r = collector.add_memory_rss(MemoryRssRecord {
+                        ts: hdr.ts as i64,
+                        utid,
+                        member: MEMORY_MEMBER_THRASHING_DELAY,
+                        size: thrash_delay_ns as i64,
+                        external: false,
+                    });
+                    self.report_write_error(r);
+                }
             }
             _ => {}
         }
@@ -260,6 +320,9 @@ pub fn memory_rss_member_name(member: i8) -> &'static str {
     match member {
         MEMORY_MEMBER_HIWATER_RSS => "hiwater_rss",
         MEMORY_MEMBER_TOTAL_VM => "total_vm",
+        MEMORY_MEMBER_MAJ_FLT => "maj_flt",
+        MEMORY_MEMBER_THRASHING_COUNT => "thrashing_count",
+        MEMORY_MEMBER_THRASHING_DELAY => "thrashing_delay_ns",
         m if m >= 0 => match memory_rss_member(m as u32) {
             memory_rss_member::MEMORY_MM_FILEPAGES => "file",
             memory_rss_member::MEMORY_MM_ANONPAGES => "anon",
@@ -280,6 +343,10 @@ mod tests {
         assert_eq!(memory_rss_member_name(1), "anon");
         assert_eq!(memory_rss_member_name(-1), "hiwater_rss");
         assert_eq!(memory_rss_member_name(-2), "total_vm");
+        assert_eq!(memory_rss_member_name(-3), "maj_flt");
+        assert_eq!(memory_rss_member_name(-4), "thrashing_count");
+        assert_eq!(memory_rss_member_name(-5), "thrashing_delay_ns");
+        assert_eq!(memory_rss_member_name(-6), "unknown");
         assert_eq!(memory_rss_member_name(99), "unknown");
     }
 }

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -2472,17 +2472,19 @@ fn build_memory_rss_batch(
     records: &[MemoryRssRecord],
     schema: &Arc<Schema>,
 ) -> Result<RecordBatch> {
-    use arrow::array::{Int64Builder, Int8Builder};
+    use arrow::array::{BooleanBuilder, Int64Builder, Int8Builder};
     let n = records.len();
     let mut ts = Int64Builder::with_capacity(n);
     let mut utid = Int64Builder::with_capacity(n);
     let mut member = Int8Builder::with_capacity(n);
     let mut size = Int64Builder::with_capacity(n);
+    let mut external = BooleanBuilder::with_capacity(n);
     for r in records {
         ts.append_value(r.ts);
         utid.append_value(r.utid);
         member.append_value(r.member);
         size.append_value(r.size);
+        external.append_value(r.external);
     }
     Ok(RecordBatch::try_new(
         schema.clone(),
@@ -2491,6 +2493,7 @@ fn build_memory_rss_batch(
             Arc::new(utid.finish()),
             Arc::new(member.finish()),
             Arc::new(size.finish()),
+            Arc::new(external.finish()),
         ],
     )?)
 }

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -539,7 +539,14 @@ pub struct CpuInfoRecord {
 /// Per-process RSS / VM counter sample.
 ///
 /// `member` indexes the kernel `rss_stat` counter (0=file, 1=anon, 2=swap, 3=shmem).
-/// Negative members are synthetic: -1 = hiwater_rss, -2 = total_vm (from periodic mm snapshots).
+/// Negative members are synthetic, from periodic mm snapshots: -1 = hiwater_rss
+/// bytes, -2 = total_vm bytes, -3 = maj_flt (major fault count for the sampled
+/// thread), -4 = delayacct thrashing stall count, -5 = delayacct thrashing
+/// stall delay in ns. -4/-5 rows are emitted (zero values included) whenever
+/// delayacct was readable on the host, so zero-valued rows mean "delayacct
+/// on, no thrash", and their complete absence while -3 rows are present means
+/// delayacct is not enabled (`CONFIG_TASK_DELAY_ACCT` plus the `delayacct`
+/// boot parameter or `kernel.task_delayacct` sysctl).
 ///
 /// Emission cadence: rss_stat samples are threshold-batched in BPF (one event
 /// per ≥ `memory_rss_threshold_bytes` of drift per (tgid, member), default
@@ -550,12 +557,24 @@ pub struct CpuInfoRecord {
 /// ±(percpu_counter_batch · nr_online_cpus) pages where the kernel sets
 /// batch = max(32, 2·nr_online_cpus). On the classic `tracepoint/kmem/rss_stat`
 /// fallback the kernel's own exact sum is used.
+///
+/// `external` is true when the sampled counter update was performed from
+/// outside the process's own thread group — an external reclaimer (kswapd,
+/// khugepaged, another process's direct reclaim, a memory.reclaim or
+/// process_madvise writer) evicted or migrated the process's pages. False for
+/// the process's own faults/maps/unmaps/exit teardown, for all synthetic
+/// members, for exit-flush residuals (mixed provenance), and always on the
+/// classic fallback attach path (which cannot resolve remote updates and
+/// drops them instead). Under threshold batching the flag carries the
+/// provenance of the update that crossed the threshold; the sub-threshold
+/// drift folded into that emission may mix self and external updates.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MemoryRssRecord {
     pub ts: i64,
     pub utid: i64,
     pub member: i8,
     pub size: i64,
+    pub external: bool,
 }
 
 /// Virtual address space change: mmap / munmap / brk.

--- a/src/trace/schema.rs
+++ b/src/trace/schema.rs
@@ -429,6 +429,7 @@ pub fn memory_rss_schema() -> Arc<Schema> {
         Field::new("utid", DataType::Int64, false),
         Field::new("member", DataType::Int8, false),
         Field::new("size", DataType::Int64, false),
+        Field::new("external", DataType::Boolean, false),
     ]))
 }
 


### PR DESCRIPTION
Reclaim-driven RSS changes were being dropped or misattributed: `kmem:rss_stat` fires from the *reclaimer's* context (kswapd, khugepaged, direct reclaim, a `memory.reclaim`/`process_madvise` writer), but both attach paths attributed the event to `current`. In cgroup-targeted mode the reclaimer fails the task filter and the victim's RSS drop is silently lost; in whole-system mode the drop is charged to the reclaimer, with the threshold-batching state keyed under the wrong tgid. This PR attributes by the tracepoint's mm instead, labels external-reclaim updates, and adds passive per-task thrash counters — so "process released memory" and "reclaim evicted its pages" become distinguishable, and steady-state thrash (evict + refault churn with flat RSS) becomes visible.

Three legs:

1. **Attribution by mm→owner** (`tp_btf/rss_stat`): when `current->mm != mm`, resolve `mm->owner` (CO-RE field-exists guard for `CONFIG_MEMCG`) and attribute the event, the trace-task filter, and the threshold batching to the owner. The common self-update case still uses `current` and pays one pointer compare. Exit teardown stays self-attributed on both of its shapes: same-tgid owner updates (`exit_mm()` nulls `current->mm` before `exit_mmap()` drops the counters), and the last-user case where `mm_update_next_owner()` has already cleared `mm->owner` — recognized by the exiting task still carrying the mm as `active_mm` — so per-process RSS falls to zero at exit. Ownerless updates from anyone else (a reclaimer hitting an mm whose owner is gone) are dropped as unattributable.

2. **`external` label**: a flag bit set when the updater is outside the mm's thread group, surfaced as a `memory_rss.external` BOOLEAN column. Splitting member deltas by it gives a per-process evicted-bytes timeline. Exit-flush residuals stay unflagged (mixed provenance), and under threshold batching the flag reflects the update that crossed the threshold — both documented in the schema notes.

3. **Passive thrash counters**: a companion `MEMORY_THRASH_SAMPLE` event at the existing periodic mm snapshot samples `task->maj_flt` and delayacct's `thrashing_count`/`thrashing_delay`, emitted as synthetic members -3/-4/-5. No new hooks, no per-page tracking. The event reuses the header's per-type scratch fields, so the shared event header does not grow. Whether delayacct was readable is recorded per sample (a flag bit), which makes the semantics definitive: zero-valued -4/-5 rows mean "delayacct on, no thrash", absent -4/-5 rows alongside -3 mean delayacct is off on the host (boot param or `kernel.task_delayacct` sysctl), and `maj_flt` works everywhere.

Classic fallback (`tracepoint/kmem/rss_stat`): the raw tracepoint carries a hashed `mm_id` plus a `curr` flag, no mm pointer, so remote updates cannot be resolved there — `curr==0` events are dropped (documented bounded loss; they were never correctly attributed on this path anyway, and the path is only selected on kernels whose BTF lacks `btf_trace_rss_stat`).

Out of scope, per the proposal: per-page tracking (rmap-side hooks are too hot), and munmap `size` stays caller-requested by design.

Schema: version 13→14 (`external` column + three synthetic members); SCHEMA_CHANGES.md carries the reader-facing semantics.

Testing: full suite green (522 passed, 0 failed), `cargo fmt --check` and `cargo clippy --all-targets` clean. On-kernel BPF load-verify under virtme-ng follows as a comment on this PR before any merge ask.
