### PR TITLE
[bump minor] memory_map: record the signed RSS delta of each mmap/munmap/brk

### DIFF
--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -344,3 +344,38 @@ databases and traces have neither the column nor the members: merging a
 pre-v14 DuckDB into a v14 database (`systing-util convert`) NULL-fills
 `external` via the column-intersection import, and readers of raw pre-v14
 parquet must treat the column as absent.
+
+## Schema Version 15 (unreleased) — 2026-08-13
+
+`memory_map` gains `rss_delta_bytes BIGINT` (nullable): the SIGNED change in
+the process's resident set across each mmap/munmap/brk call — pages actually
+committed or freed, where `size` only names the virtual-address range the
+arguments described.
+
+Why: the VA number misrepresents reality on both sides. mmap commits nothing
+(page faults do), so huge mmaps of sparse reservations recorded as if memory
+appeared; munmap frees only what was resident in the range, so sparse unmaps
+recorded far more than the machine gave back. `rss_delta_bytes` is measured
+from the mm's resident counters at syscall enter and success-gated exit:
+munmap rows are typically negative (the real release), mmap rows typically
+~0, brk either sign.
+
+Read rules, stated once here and in the record docs:
+- NULL means the resident read was unavailable on either side of the call —
+  and every pre-v15 row. Never treat NULL as zero.
+- Three approximations, all bounded and deliberate: concurrent faults or
+  reclaim on the process's other threads inside the syscall window land in
+  the delta (microsecond window); the resident reads carry the rss_stat
+  sampling's worst-case ±(percpu batch x nr_cpus pages) error (the kernel's
+  counter caching — the same slop rss_stat rows already document); and under
+  `--memory-map-sample-rate` 1:N sampling only sampled events carry a delta.
+- Sampling composition: a sampled-in row carries the FULL delta of its own
+  call — the rate scales aggregate event mass (multiply sums by N), never
+  divides a row's delta. At rates above 1 the scaled estimate is unbiased
+  but heavy-tail-noisy: one huge munmap missed by sampling is invisible,
+  the same property the VA sums always had. Zero-delta events are NOT
+  suppressed — every sampled successful call emits a row, so event-rate
+  reads on this stream stay valid.
+- Churn built from this column: freed = sum(-rss_delta_bytes) over negative
+  rows; committed-at-map = sum over positive rows. The old `size` sums remain
+  VA-range churn and keep their v13/v14 meaning for historical continuity.

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -439,6 +439,12 @@ enum memory_rss_member {
  * allocated for this task). */
 #define MEMORY_THRASH_FLAG_DELAYACCT (1U << 0)
 
+/* Sentinel for "no RSS read" in the map legs' old_addr rss-delta encoding
+ * (see the header field comments): S64_MIN can never be a real signed
+ * byte delta, so it marks rows where the enter- or exit-side resident-set
+ * read was unavailable and the recorder should emit NULL. */
+#define MEMORY_RSS_DELTA_ABSENT ((s64)0x8000000000000000)
+
 /* Allocator operation, stored in memory_event.member for MEMORY_ALLOC/FREE. */
 enum memory_alloc_op {
 	MEMORY_OP_MALLOC,
@@ -463,7 +469,7 @@ struct memory_event_header {
 	u64 size;          // mmap len / munmap len / rss size (bytes) / total_vm (bytes) / alloc bytes / thrash stall count
 	u32 member;        // rss_stat: enum memory_rss_member; mmap: prot; alloc: enum memory_alloc_op
 	u32 flags;         // mmap: MAP_* flags; page_fault: error_code; rss_stat: MEMORY_RSS_FLAG_*
-	u64 old_addr;      // realloc: previous pointer / thrash stall delay ns (else 0)
+	u64 old_addr;      // realloc: previous pointer / thrash stall delay ns / map legs: signed rss-delta bytes as two's-complement (MEMORY_RSS_DELTA_ABSENT = no read); else 0
 	u64 kernel_stack_length;
 	u64 user_stack_length;
 };
@@ -1005,6 +1011,15 @@ struct memory_syscall_args {
 	 * in total; this is that upper bound (looser than the exact in-range
 	 * mapped bytes, but enough to drop the impossible values). */
 	u64 vm_limit;
+	/* All map legs: the mm's resident-set bytes at syscall enter
+	 * (file + anon + shmem, the same approximate percpu-counter read
+	 * the rss_stat handler uses), so the success-gated exit can emit
+	 * the signed RSS delta the call actually caused -- pages committed
+	 * or freed, not the VA range the arguments named. The VA number
+	 * misrepresents reality on both sides: mmap commits nothing (faults
+	 * do), and munmap frees only what was resident in range. -1 = read
+	 * unavailable at enter; the exit then emits the delta as absent. */
+	s64 enter_rss;
 };
 
 struct {
@@ -5303,6 +5318,40 @@ static __always_inline bool memory_map_sample_hit(u64 *cnt)
 	return (*cnt % tool_config.memory_map_sample_rate) == 0;
 }
 
+/* Resident-set bytes of the task's mm (file + anon + shmem pages), the
+ * same approximate percpu_counter read the rss_stat handler uses, so the
+ * two share one error model (worst case ±(percpu batch x nr_cpus) pages).
+ * Returns -1 when the mm is unreadable so callers can mark the read
+ * absent rather than emitting a fake zero. */
+static __always_inline s64 current_task_rss_bytes(struct task_struct *task)
+{
+	struct mm_struct *mm = BPF_CORE_READ(task, mm);
+	if (!mm)
+		return -1;
+	s64 pages = read_mm_rss_pages(mm, MEMORY_MM_FILEPAGES) +
+		    read_mm_rss_pages(mm, MEMORY_MM_ANONPAGES) +
+		    read_mm_rss_pages(mm, MEMORY_MM_SHMEMPAGES);
+	if (pages < 0)
+		pages = 0;
+	return pages * (s64)tool_config.page_size;
+}
+
+/* Compute the map legs' signed rss-delta encoding for old_addr: the exit-
+ * side resident read minus the stashed enter-side read, or ABSENT when
+ * either side was unavailable. Concurrent faults or reclaim on other
+ * threads inside the syscall window land in the delta -- the window is
+ * microseconds, the drift is small, and the schema doc says so. */
+static __always_inline u64 map_rss_delta_enc(struct task_struct *task,
+					     s64 enter_rss)
+{
+	if (enter_rss < 0)
+		return (u64)MEMORY_RSS_DELTA_ABSENT;
+	s64 exit_rss = current_task_rss_bytes(task);
+	if (exit_rss < 0)
+		return (u64)MEMORY_RSS_DELTA_ABSENT;
+	return (u64)(exit_rss - enter_rss);
+}
+
 SEC("tracepoint/syscalls/sys_enter_mmap")
 int systing_mmap_enter(struct trace_event_raw_sys_enter *ctx)
 {
@@ -5316,6 +5365,7 @@ int systing_mmap_enter(struct trace_event_raw_sys_enter *ctx)
 		.size = (u64)ctx->args[1],
 		.prot = (u32)ctx->args[2],
 		.flags = (u32)ctx->args[3],
+		.enter_rss = current_task_rss_bytes(task),
 	};
 	bpf_map_update_elem(&memory_syscall_scratch, &tgidpid, &args, BPF_ANY);
 	return 0;
@@ -5360,6 +5410,7 @@ int systing_mmap_exit(struct trace_event_raw_sys_exit *ctx)
 	event->hdr.size = args.size;
 	event->hdr.member = args.prot;
 	event->hdr.flags = args.flags;
+	event->hdr.old_addr = map_rss_delta_enc(task, args.enter_rss);
 	memory_capture_stack(ctx, event, task, true);
 
 	bpf_ringbuf_submit(event, flags);
@@ -5379,6 +5430,7 @@ int systing_munmap_enter(struct trace_event_raw_sys_enter *ctx)
 		.size = (u64)ctx->args[1],
 		.vm_limit = (u64)BPF_CORE_READ(task, mm, total_vm) *
 			    tool_config.page_size,
+		.enter_rss = current_task_rss_bytes(task),
 	};
 	bpf_map_update_elem(&memory_syscall_scratch, &tgidpid, &args, BPF_ANY);
 	return 0;
@@ -5440,6 +5492,7 @@ int systing_munmap_exit(struct trace_event_raw_sys_exit *ctx)
 	event->hdr.size = (args.vm_limit && args.size > args.vm_limit)
 				  ? args.vm_limit
 				  : args.size;
+	event->hdr.old_addr = map_rss_delta_enc(task, args.enter_rss);
 	memory_capture_stack(ctx, event, task, true);
 
 	bpf_ringbuf_submit(event, flags);
@@ -5455,7 +5508,10 @@ int systing_brk_enter(struct trace_event_raw_sys_enter *ctx)
 
 	u64 tgidpid = bpf_get_current_pid_tgid();
 	/* Stash the current brk so exit can compute the delta. */
-	struct memory_syscall_args args = { .addr = BPF_CORE_READ(task, mm, brk) };
+	struct memory_syscall_args args = {
+		.addr = BPF_CORE_READ(task, mm, brk),
+		.enter_rss = current_task_rss_bytes(task),
+	};
 	bpf_map_update_elem(&memory_syscall_scratch, &tgidpid, &args, BPF_ANY);
 	return 0;
 }
@@ -5472,6 +5528,7 @@ int systing_brk_exit(struct trace_event_raw_sys_exit *ctx)
 	if (!saved)
 		return 0;
 	u64 old_brk = saved->addr;
+	s64 enter_rss = saved->enter_rss;
 	bpf_map_delete_elem(&memory_syscall_scratch, &tgidpid);
 
 	/* brk(0) queries the current break and failed brk returns it unchanged. */
@@ -5496,6 +5553,7 @@ int systing_brk_exit(struct trace_event_raw_sys_exit *ctx)
 	record_task_info(&event->hdr.task, task);
 	event->hdr.addr = (u64)ctx->ret;
 	event->hdr.size = (u64)((s64)ctx->ret - (s64)old_brk);
+	event->hdr.old_addr = map_rss_delta_enc(task, enter_rss);
 	memory_capture_stack(ctx, event, task, true);
 
 	bpf_ringbuf_submit(event, flags);

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -133,7 +133,7 @@ pub struct TraceImportMapping {
 }
 
 /// Current schema version. See SCHEMA_CHANGES.md for history.
-pub const SCHEMA_VERSION: u32 = 14;
+pub const SCHEMA_VERSION: u32 = 15;
 
 /// All data tables in the DuckDB schema (excludes the `_traces` metadata table).
 pub const DATA_TABLES: &[&str] = &[
@@ -566,6 +566,7 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
             event_type VARCHAR,
             addr BIGINT,
             size BIGINT,
+            rss_delta_bytes BIGINT,
             prot INTEGER,
             flags INTEGER,
             stack_id BIGINT

--- a/src/memory_recorder.rs
+++ b/src/memory_recorder.rs
@@ -165,6 +165,13 @@ impl MemoryRecorder {
         let stack_id = self.intern_stack(event, task.tgid);
         let id = self.next_map_id;
         self.next_map_id += 1;
+        // Per-type field reuse: map legs carry the signed RSS delta in
+        // old_addr (see the BPF header comment); the sentinel marks rows
+        // where either resident read was unavailable.
+        let rss_delta_bytes = match event.hdr.old_addr as i64 {
+            i64::MIN => None,
+            d => Some(d),
+        };
         let r = collector.add_memory_map(MemoryMapRecord {
             id,
             ts: event.hdr.ts as i64,
@@ -172,6 +179,7 @@ impl MemoryRecorder {
             event_type: event_type.to_string(),
             addr: event.hdr.addr as i64,
             size: event.hdr.size as i64,
+            rss_delta_bytes,
             prot,
             flags,
             stack_id,

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -2549,6 +2549,7 @@ fn build_memory_map_batch(
     let mut event_type = StringBuilder::with_capacity(n, n * 8);
     let mut addr = Int64Builder::with_capacity(n);
     let mut size = Int64Builder::with_capacity(n);
+    let mut rss_delta_bytes = Int64Builder::with_capacity(n);
     let mut prot = Int32Builder::with_capacity(n);
     let mut flags = Int32Builder::with_capacity(n);
     let mut stack_id = Int64Builder::with_capacity(n);
@@ -2559,6 +2560,7 @@ fn build_memory_map_batch(
         event_type.append_value(&r.event_type);
         addr.append_value(r.addr);
         size.append_value(r.size);
+        rss_delta_bytes.append_option(r.rss_delta_bytes);
         prot.append_option(r.prot);
         flags.append_option(r.flags);
         stack_id.append_option(r.stack_id);
@@ -2572,6 +2574,7 @@ fn build_memory_map_batch(
             Arc::new(event_type.finish()),
             Arc::new(addr.finish()),
             Arc::new(size.finish()),
+            Arc::new(rss_delta_bytes.finish()),
             Arc::new(prot.finish()),
             Arc::new(flags.finish()),
             Arc::new(stack_id.finish()),

--- a/src/trace/models.rs
+++ b/src/trace/models.rs
@@ -584,6 +584,19 @@ pub struct MemoryRssRecord {
 /// munmap, `size` is the requested length bounded by the process's total
 /// mapped size at call time -- an upper bound on what the call could free,
 /// not necessarily a region of that size at `addr`.
+///
+/// `rss_delta_bytes` is the SIGNED change in the process's resident set across the
+/// syscall, in bytes -- pages actually committed or freed, where `size` is
+/// only the virtual-address range the arguments named. munmap is typically
+/// negative (what the call really freed), mmap typically ~0 (mapping commits
+/// nothing; faults do), brk either sign. `None` when either resident read was
+/// unavailable, and on all pre-v15 rows. Three documented approximations:
+/// concurrent faults/reclaim on other threads inside the syscall window land
+/// in the delta (microsecond window, small drift); the resident reads carry
+/// the same worst-case ±(percpu batch x nr_cpus pages) error as rss_stat
+/// samples; and under `--memory-map-sample-rate` 1:N sampling, per-event
+/// deltas exist only for sampled events -- aggregates scale by the stamped
+/// rate like the byte sums.
 /// `stack_id` joins to the `stack` table for allocation-site attribution.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct MemoryMapRecord {
@@ -593,6 +606,7 @@ pub struct MemoryMapRecord {
     pub event_type: String,
     pub addr: i64,
     pub size: i64,
+    pub rss_delta_bytes: Option<i64>,
     pub prot: Option<i32>,
     pub flags: Option<i32>,
     pub stack_id: Option<i64>,

--- a/src/trace/schema.rs
+++ b/src/trace/schema.rs
@@ -442,6 +442,7 @@ pub fn memory_map_schema() -> Arc<Schema> {
         Field::new("event_type", DataType::Utf8, false),
         Field::new("addr", DataType::Int64, false),
         Field::new("size", DataType::Int64, false),
+        Field::new("rss_delta_bytes", DataType::Int64, true),
         Field::new("prot", DataType::Int32, true),
         Field::new("flags", DataType::Int32, true),
         Field::new("stack_id", DataType::Int64, true),

--- a/tests/memory_recorder.rs
+++ b/tests/memory_recorder.rs
@@ -168,6 +168,48 @@ fn test_memory_recorder_e2e() {
     );
     eprintln!("    {} munmap events", munmap_rows);
 
+    // --- Check: memory_map.rss_delta_bytes captures the munmap RSS drop ---
+    // The workload's bytearray(size) memsets the full buffer, so each large
+    // munmap releases ~ALLOC_SIZE_BYTES of resident anon. First make sure the
+    // column is populated at all (if the BPF-side mm read failed, every row
+    // would carry the absent sentinel and decode to NULL — a vacuous pass),
+    // then require the signed drop on at least half the large frees. The
+    // negative bound also catches an enter/exit sign inversion, which would
+    // render frees as +2 MiB gains.
+    eprintln!("  memory_map.rss_delta_bytes munmap drop...");
+    let (delta_rows, drop_rows): (i64, i64) = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*) FILTER (WHERE rss_delta_bytes IS NOT NULL),
+                        COUNT(*) FILTER (WHERE rss_delta_bytes <= -?)
+                 FROM memory_map WHERE event_type = 'munmap' AND utid IN {UTIDS_FOR_PID}"
+            ),
+            [ALLOC_SIZE_BYTES / 2, child_pid as i64],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("Failed to query memory_map rss_delta_bytes");
+    assert!(
+        delta_rows > 0,
+        "[memory_map] rss_delta_bytes is NULL on all {munmap_rows} munmap rows \
+         (BPF mm read never succeeded?)"
+    );
+    assert!(
+        drop_rows >= ALLOC_COUNT / 2,
+        "[memory_map] expected >= {} munmap events with rss_delta_bytes <= -{} bytes, \
+         got {} ({} non-NULL of {} munmaps)",
+        ALLOC_COUNT / 2,
+        ALLOC_SIZE_BYTES / 2,
+        drop_rows,
+        delta_rows,
+        munmap_rows
+    );
+    eprintln!(
+        "    {} munmap drops <= -{} MiB ({} non-NULL)",
+        drop_rows,
+        (ALLOC_SIZE_BYTES / 2) >> 20,
+        delta_rows
+    );
+
     // --- Check: memory_map.stack_id joins to stack.id ---
     eprintln!("  memory_map.stack_id -> stack.id join...");
     let (with_stack, joined): (i64, i64) = conn


### PR DESCRIPTION
## What

`memory_map` rows gain `rss_delta_bytes`: the signed change in the process's resident set across each recorded mmap/munmap/brk call, measured in the BPF handlers from the mm's resident counters at syscall enter and success-gated exit. Schema v15.

## Why

The `size` column names the virtual-address range the arguments described, and for churn accounting that number misrepresents reality on both sides: mmap commits nothing (page faults do), so mapping a large sparse reservation records as if that memory appeared; munmap frees only what was resident in the range, so unmapping one records far more than the machine got back. The resident-counter delta is the number that tracks pages actually committed or freed.

## How

- The map legs' existing enter-stash (`memory_syscall_args`) gains `enter_rss`: file+anon+shmem pages via the same `read_mm_rss_pages` read the rss_stat handler uses, so the two share one error model (worst case ±(percpu batch × nr_cpus) pages of counter-caching slop).
- The delta rides the event header's per-type `old_addr` field (previously always 0 on map legs), so the event size is unchanged and no new maps or map operations are added. `S64_MIN` is the "no read" sentinel; the recorder decodes it to NULL.
- All three enter-side reads sit behind the existing `trace_task` gates, so untraced tasks pay nothing. History check on these paths: the recorded hazard was per-event cost, cured by the trace_task gating in a11016f and batching in 5638255 — this change stays behind those gates. The 2026-07 reverts (#171) concerned per-tick whole-population scanning, a different mechanism; nothing here runs per-tick.
- `rss_delta_bytes BIGINT` nullable in parquet and DuckDB. NULL means the read was unavailable (or a pre-v15 row) — never zero. SCHEMA_CHANGES.md documents the read rules: NULL semantics, the three bounded approximations (concurrent faults in the syscall window, percpu counter slop, sampling composition — a sampled row carries its own call's full delta; the rate scales aggregate mass).

## Validation

- Full suite green on the final tree; rustfmt and clippy clean.
- VM e2e on a real kernel (v6.12): the map-touch-free workload now also asserts the new column — a non-NULL control first (a failed BPF-side read would NULL every row and pass vacuously), then at least 25 of the 50 fully-touched 2 MiB frees showing drops of 1 MiB or more. The negative bound also catches an enter/exit sign inversion. Result posted in a comment below.
