### PR TITLE
stack_recorder: count CPU samples that land in KVM guest execution as [guest]

### DIFF
--- a/docs/PROFILE_EXPORT_FORMAT.md
+++ b/docs/PROFILE_EXPORT_FORMAT.md
@@ -125,6 +125,12 @@ Frame strings are exactly systing's symbolized frame names:
   may be a label rather than a binary basename: `[kernel]`,
   `[gvisor:runtime]`, `[gvisor:guest]`, `[jit:<runtime>]`, `[exited]`,
   `[vdso]` and similar. Unresolvable frames use the function name `unknown`.
+- Guest execution: `unknown ([guest])` — a CPU sample that interrupted a
+  hypervisor vCPU thread while it was running its virtual machine. There is
+  no host address (the kernel does not walk callchains for guest-mode
+  samples), so there is never an `<0xaddr>` suffix; the frame exists so that
+  CPU time spent inside VMs is counted and attributed to the VMM process
+  rather than dropped. It is emitted regardless of `--no-frame-labels`.
 - Python (pystacks): `name (python) [file.py:line]` — no address suffix.
 - With `--no-frame-labels`: bare hex addresses (`0x7f95bfdb6e12`).
 

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -42,6 +42,13 @@
 
 #define TASK_COMM_LEN 16
 
+/* PF_VCPU: the task is a hypervisor vCPU thread currently accounted as
+ * running its guest (set from guest_timing_enter_irqoff() until
+ * guest_timing_exit_irqoff(), which KVM deliberately runs only after the
+ * host has serviced the interrupt that forced the VM-exit). A sampling
+ * interrupt that lands while a CPU is executing guest code is handled in
+ * exactly that window. */
+#define PF_VCPU 0x00000001
 #define PF_WQ_WORKER 0x00000020
 #define PF_KTHREAD 0x00200000
 
@@ -239,8 +246,21 @@ struct marker_event {
 #define USER_STACK_FORMAT_IP 0
 #define USER_STACK_FORMAT_BUILD_ID 1
 
+/* stack_event.sample_flags bits. */
+/* The sample interrupted a vCPU thread while it was running its guest
+ * (task->flags & PF_VCPU — the same test the kernel's own cputime code uses
+ * to bill a tick as guest time). The kernel returns EMPTY callchains for
+ * such samples by design (perf_callchain_kernel()/perf_callchain_user()
+ * bail out under perf_guest_state(), on x86 and arm64 alike), so the event
+ * arrives with no frames; the flag lets userspace account the sample as
+ * guest execution instead of discarding it. */
+#define SAMPLE_FLAG_IN_GUEST (1U << 0)
+
 struct stack_event {
 	enum stack_event_type stack_event_type;
+	/* Occupies what was alignment padding before `ts`: no other field
+	 * moves and the record does not grow. */
+	u32 sample_flags;
 	u64 ts;
 	u32 cpu;
 	u32 user_stack_format;
@@ -1787,7 +1807,17 @@ static void emit_stack_event_with_ts(void *ctx, struct task_struct *task,
 
 	event->stack_event_type = type;
 
-	if (!(task->flags & PF_KTHREAD)) {
+	unsigned int task_flags = task->flags;
+	/*
+	 * A vCPU thread sampled while its guest was executing: the callchain
+	 * walks below come back empty for it (see SAMPLE_FLAG_IN_GUEST), and
+	 * without this mark userspace could not tell "CPU busy running guest
+	 * code" from an unwind failure — it would drop the sample and the
+	 * guest's CPU time would vanish from the profile entirely.
+	 */
+	event->sample_flags = (task_flags & PF_VCPU) ? SAMPLE_FLAG_IN_GUEST : 0;
+
+	if (!(task_flags & PF_KTHREAD)) {
 		/*
 		 * Both modes walk into the same user_stack region; the entry
 		 * format (and how much of the region was reserved) differs.

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -51,7 +51,23 @@ pub enum UserFrame {
     /// ELF build-id plus file offset; symbolized through the build-id store
     /// regardless of whether the process still exists.
     BuildId { id: [u8; 20], offset: u64 },
+    /// Synthetic: the sample interrupted a hypervisor vCPU thread while it
+    /// was executing guest code (`PF_VCPU`, the flag the kernel's cputime
+    /// accounting bills as guest time). There is no host address to
+    /// symbolize — the kernel returns empty callchains for guest-mode
+    /// samples by design, on x86 and arm64 alike — so the frame renders as
+    /// the `[guest]` label. It exists so that CPU time spent inside virtual
+    /// machines is *counted*, attributed to the VMM thread that ran it,
+    /// rather than silently dropped as an unwind failure.
+    Guest,
 }
+
+/// Rendered name of [`UserFrame::Guest`]: the standard `symbol (module)`
+/// frame shape with the label in the module slot, like `[exited]` and the
+/// `[gvisor:*]` family, so existing frame parsers classify it without
+/// changes. No `<0x…>` suffix — there is no address, and inventing one
+/// would be worse than its honest absence.
+const GUEST_FRAME_NAME: &str = "unknown ([guest])";
 
 // Stack structure representing kernel, user, and Python stacks.
 //
@@ -92,7 +108,7 @@ fn filter_and_reverse_user_frames(frames: Vec<UserFrame>) -> Vec<UserFrame> {
         .into_iter()
         .filter(|f| match f {
             UserFrame::Ip(addr) => *addr != 0 && *addr <= MAX_USER_ADDR,
-            UserFrame::BuildId { .. } => true,
+            UserFrame::BuildId { .. } | UserFrame::Guest => true,
         })
         .rev()
         .collect()
@@ -263,6 +279,10 @@ impl StackSpill {
                     self.buf.push(1);
                     self.buf.extend_from_slice(id);
                     self.buf.extend_from_slice(&offset.to_le_bytes());
+                }
+                UserFrame::Guest => {
+                    // Tag only: a guest frame carries no payload.
+                    self.buf.push(2);
                 }
             }
         }
@@ -591,7 +611,8 @@ fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32,
     }
 
     // User frames are self-describing (see `push`): tag 0 = raw IP (u64),
-    // tag 1 = build-id (20 id bytes + u64 file offset).
+    // tag 1 = build-id (20 id bytes + u64 file offset), tag 2 = guest
+    // (no payload).
     let mut user_stack = Vec::with_capacity(ulen);
     for _ in 0..ulen {
         let mut tag = [0u8; 1];
@@ -618,6 +639,7 @@ fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32,
                     offset: u64::from_le_bytes(buf8),
                 });
             }
+            2 => user_stack.push(UserFrame::Guest),
             t => anyhow::bail!("corrupt stack spill record: unknown user frame tag {t}"),
         }
     }
@@ -680,6 +702,13 @@ const BUILD_ID_STATUS_IP: i32 = 2;
 /// USER_STACK_FORMAT_* defines): which entry format the event's user_stack
 /// region carries.
 const USER_STACK_FORMAT_BUILD_ID: u32 = 1;
+
+/// `stack_event.sample_flags` bit (mirrors the BPF-side SAMPLE_FLAG_IN_GUEST
+/// define): the sampled task was a vCPU thread executing its guest
+/// (`PF_VCPU`). Such events carry no frames — the kernel does not walk
+/// callchains for guest-mode samples — and are accounted as one
+/// [`UserFrame::Guest`] frame instead of being dropped.
+const SAMPLE_FLAG_IN_GUEST: u32 = 1;
 
 /// Index one live process's executable mappings into the build-id store
 /// (the opportunistic fill source). Returns how many mappings were read.
@@ -951,6 +980,15 @@ pub struct StackRecorder {
     /// trace size. Shorter names are unchanged; longer names keep their
     /// path head and function segment. See [`crate::symbol_shorten`].
     elide_generics: bool,
+    /// Samples accounted as guest execution: a vCPU thread interrupted
+    /// while its guest was running (see [`UserFrame::Guest`]). Reported at
+    /// trace end — this is CPU time that used to be invisible.
+    guest_samples: u64,
+    /// Stack events that arrived with no kernel, user, or Python frames and
+    /// no guest mark, and were therefore dropped. Both unwinds failing for
+    /// an ordinary task is rare; counting it keeps the recorder from ever
+    /// discarding samples without a trace.
+    dropped_frameless: u64,
 }
 
 impl ThreadAwareRecorder for StackRecorder {
@@ -985,6 +1023,8 @@ impl StackRecorder {
             gopclntab: true,
             names_only: false,
             elide_generics: false,
+            guest_samples: 0,
+            dropped_frameless: 0,
         }
     }
 
@@ -1135,6 +1175,23 @@ impl StackRecorder {
         // it has been drained.
         let mut interners = vec![std::mem::replace(&mut self.interner, StackInterner::new(1))];
         interners.append(&mut self.external_interners);
+
+        // Sample-accounting notes. Guest samples are CPU time inside virtual
+        // machines that carries no host frames (rendered as [guest]); the
+        // frameless count is the residual class that still cannot be
+        // attributed to anything — surfaced so it is never silently zero.
+        if self.guest_samples > 0 {
+            eprintln!(
+                "Note: {} CPU samples landed in guest execution (vCPU threads) and were recorded as [guest]",
+                self.guest_samples
+            );
+        }
+        if self.dropped_frameless > 0 {
+            eprintln!(
+                "Note: dropped {} stack samples that carried no frames (kernel and user unwind both empty)",
+                self.dropped_frameless
+            );
+        }
 
         let total: u64 = interners.iter().map(|i| i.total()).sum();
         if total == 0 {
@@ -1661,6 +1718,9 @@ impl StackRecorder {
                                 }
                             }
                         }
+                        // Not an address: guest execution is opaque to the
+                        // host, live process or not.
+                        UserFrame::Guest => GUEST_FRAME_NAME.to_string(),
                     };
                     frame_names.push(frame_name);
                 }
@@ -1678,6 +1738,7 @@ impl StackRecorder {
                         UserFrame::BuildId { id, offset } => self.symbolize_build_id_frame(
                             symbolizer, bid_store, bid_cache, *id, *offset,
                         ),
+                        UserFrame::Guest => GUEST_FRAME_NAME.to_string(),
                     };
                     frame_names.push(frame_name);
                 }
@@ -1880,10 +1941,17 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
     fn handle_event(&mut self, event: stack_event) {
         let py_stack_len = event.py_msg_buffer.stack_len;
 
-        let has_stack =
+        // A vCPU thread sampled while its guest was executing arrives with
+        // no frames at all (the kernel does not walk callchains for
+        // guest-mode samples). That is CPU time all the same — a busy
+        // virtual machine — so it is accounted below as one synthetic
+        // [guest] frame under the VMM thread rather than dropped.
+        let in_guest = event.sample_flags & SAMPLE_FLAG_IN_GUEST != 0;
+
+        let has_frames =
             event.user_stack_length > 0 || event.kernel_stack_length > 0 || py_stack_len > 0;
 
-        if has_stack {
+        if has_frames || in_guest {
             let kstack_vec = Vec::from(&event.kernel_stack[..event.kernel_stack_length as usize]);
             // One user_stack region, two entry formats; the per-event
             // user_stack_format flag says which one this record carries
@@ -1893,7 +1961,7 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
             // but clamp anyway — a short (zero-extended) record must never
             // index past the region.
             let ulen = event.user_stack_length as usize;
-            let user_frames: Vec<UserFrame> =
+            let mut user_frames: Vec<UserFrame> =
                 if event.user_stack_format == USER_STACK_FORMAT_BUILD_ID {
                     event.user_stack[..ulen.min(event.user_stack.len())]
                         .iter()
@@ -1926,6 +1994,14 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
                         .map(|&addr| UserFrame::Ip(addr))
                         .collect()
                 };
+            // Guest-mode sample with (as expected) no host frames: the
+            // synthetic frame makes it a countable stack. If a guest-marked
+            // sample does carry frames — a sampling NMI landing in the
+            // host's VM-entry/exit glue — the real frames are kept as-is.
+            if in_guest && !has_frames {
+                user_frames.push(UserFrame::Guest);
+                self.guest_samples += 1;
+            }
             let stack_key = (event.task.tgidpid >> 32) as i32;
             let py_stack = self.psr.get_pystack_from_event(&event);
 
@@ -1958,6 +2034,10 @@ impl SystingRecordEvent<stack_event> for StackRecorder {
                     eprintln!("Warning: Failed to stream stack sample: {e}");
                 }
             }
+        } else {
+            // Neither unwind produced a frame and the task was not running a
+            // guest: nothing to attribute the sample to. Counted, not silent.
+            self.dropped_frameless += 1;
         }
     }
 }
@@ -2220,12 +2300,14 @@ mod tests {
             bid_frame(1, 0),                  // kept: offset 0 is valid
             UserFrame::Ip(MAX_USER_ADDR + 1), // filtered: garbage addr
             bid_frame(2, u64::MAX),           // kept: any offset
+            UserFrame::Guest,                 // kept: no address to judge
             UserFrame::Ip(0x1000),            // kept
         ];
         assert_eq!(
             filter_and_reverse_user_frames(frames),
             vec![
                 UserFrame::Ip(0x1000),
+                UserFrame::Guest,
                 bid_frame(2, u64::MAX),
                 bid_frame(1, 0)
             ]
@@ -2350,15 +2432,26 @@ mod tests {
                 7,
                 8,
             ),
+            // The payload-free guest tag must round-trip and must not
+            // desynchronize the frames that follow it in the record.
+            (
+                Stack {
+                    kernel_stack: vec![0xffffffff81000000],
+                    user_stack: vec![UserFrame::Guest],
+                    py_stack: vec![],
+                },
+                9,
+                10,
+            ),
         ];
         for (stack, tgid, id) in &stacks {
             spill.push(stack.clone(), *tgid, *id);
         }
-        assert_eq!(spill.total(), 4);
+        assert_eq!(spill.total(), 5);
         assert!(spill.fallback.is_empty());
 
         let (mut reader, durable) = spill.take_reader().expect("reader");
-        assert_eq!(durable, 4);
+        assert_eq!(durable, 5);
         for (stack, tgid, id) in &stacks {
             let (rstack, rtgid, rid) = read_spill_record(&mut reader).unwrap().unwrap();
             assert_eq!(&rstack, stack);
@@ -2613,6 +2706,82 @@ mod tests {
     #[inline(never)]
     fn marker_fn() -> u64 {
         42
+    }
+
+    /// A BPF-shaped stack event for `handle_event` tests: zeroed (as the
+    /// ring delivers short records), then given a task identity, a RUNNING
+    /// type, and the requested sample flags. No frames.
+    fn frameless_event(tgid: i32, tid: i32, sample_flags: u32) -> stack_event {
+        use crate::systing_core::types::{stack_event_type, task_info};
+        stack_event {
+            stack_event_type: stack_event_type::STACK_RUNNING,
+            sample_flags,
+            task: task_info {
+                tgidpid: ((tgid as u32 as u64) << 32) | (tid as u32 as u64),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// The fix for invisible virtual-machine CPU time, end to end through
+    /// the recorder: a frameless sample marked as guest execution must be
+    /// COUNTED — interned as a one-frame stack and streamed as a sample —
+    /// and must symbolize to the `[guest]` label whether or not the VMM
+    /// process is still alive at trace end. Before this, such events were
+    /// discarded in `handle_event` and a busy VM host profiled as idle.
+    #[test]
+    fn test_guest_sample_is_counted_and_labeled() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        rec.set_spill_dir(dir.path());
+        rec.set_streaming_collector(Box::new(crate::record::InMemoryCollector::new()));
+
+        // One guest sample from our own (live) process, one from a VMM that
+        // has since exited (tgid far above pid_max).
+        let self_tgid = std::process::id() as i32;
+        let dead_tgid = i32::MAX - 1;
+        rec.handle_event(frameless_event(self_tgid, self_tgid, SAMPLE_FLAG_IN_GUEST));
+        rec.handle_event(frameless_event(dead_tgid, dead_tgid, SAMPLE_FLAG_IN_GUEST));
+
+        assert_eq!(rec.guest_samples, 2);
+        assert_eq!(rec.dropped_frameless, 0);
+        // Same synthetic content, two tgids: two dedup keys.
+        assert_eq!(rec.interner.total(), 2);
+
+        let mut collector = crate::record::InMemoryCollector::new();
+        rec.finish_inner(&mut collector).unwrap();
+        let stacks = &collector.data().stacks;
+        assert_eq!(stacks.len(), 2);
+        for s in stacks {
+            assert_eq!(s.frame_names, vec![GUEST_FRAME_NAME.to_string()]);
+        }
+    }
+
+    /// The residual class — no frames and no guest mark (both unwinds
+    /// failed for an ordinary task) — is still dropped, but now counted;
+    /// and a guest mark never turns a sample that HAS frames into `[guest]`.
+    #[test]
+    fn test_frameless_unmarked_sample_is_dropped_and_counted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut rec = StackRecorder::new(false, Arc::new(UtidGenerator::new()));
+        rec.set_spill_dir(dir.path());
+        rec.set_streaming_collector(Box::new(crate::record::InMemoryCollector::new()));
+
+        rec.handle_event(frameless_event(1234, 1234, 0));
+        assert_eq!(rec.dropped_frameless, 1);
+        assert_eq!(rec.guest_samples, 0);
+        assert_eq!(rec.interner.total(), 0);
+
+        // Guest-marked but WITH a kernel frame (an NMI in the host's
+        // VM-entry/exit glue): kept as the real stack, no synthetic frame.
+        let mut ev = frameless_event(1234, 1234, SAMPLE_FLAG_IN_GUEST);
+        ev.kernel_stack[0] = 0xffffffff81000000;
+        ev.kernel_stack_length = 1;
+        rec.handle_event(ev);
+        assert_eq!(rec.guest_samples, 0);
+        assert_eq!(rec.dropped_frameless, 1);
+        assert_eq!(rec.interner.total(), 1);
     }
 
     /// End-to-end run of the finish()-time symbolization over the real


### PR DESCRIPTION
CPU time spent inside virtual machines currently vanishes from systing profiles. When a sampling interrupt lands while a vCPU thread (Firecracker, QEMU, cloud-hypervisor, gVisor's KVM platform) is executing guest code, the kernel deliberately returns empty callchains — `perf_callchain_kernel()` and `perf_callchain_user()` both bail out under `perf_guest_state()` ("We don't support guest os callchain now", on x86 and arm64 alike). The BPF side submits the stack event anyway, frameless, and `StackRecorder::handle_event` only acted on events carrying at least one frame, so every such sample was silently discarded. A host whose CPUs are mostly busy running guests profiled as mostly idle: no error, no counter, just missing samples.

This change counts those samples. BPF tags each stack event with whether the task was in guest context (`task->flags & PF_VCPU` — the same test the kernel's cputime accounting uses to bill a tick as guest time in `/proc/stat`), using four bytes of existing padding in `stack_event`. Userspace turns a frameless, guest-tagged event into a one-frame stack rendered `unknown ([guest])`, attributed to the vCPU thread like any other sample. Guest internals stay opaque — there is nothing on the host to symbolize — but the machine's utilization, and which VMM process and thread is burning it, become truthful. Frameless events that are *not* guest-tagged (both unwinds failed for an ordinary task) are still dropped, but are now counted and reported at trace end instead of disappearing.

**Observed on a real deployment** (Kubernetes nodes that are themselves cloud VMs, running Firecracker microVMs through nested virtualization, sampled with the software cpu-clock event): comparing systing's per-capture sample totals against node_exporter for the same nodes and hour, systing accounted for roughly a fifth of busy CPU; on Firecracker-heavy nodes its total tracked node_exporter's *system* time while *user* time — where guest execution is billed — produced nothing. Of ~2×10⁸ samples on `fc_vcpu` threads, 99.8% had `vcpu_run` on the stack and exactly zero had `vmx_vcpu_run`: no sample was ever recorded between VM-entry and VM-exit. What was recorded on those threads was host-side KVM work only (VMCS loads, TDP MMU faults, TLB-flush IPIs, halt polling).

<details><summary>What changes on the wire and on disk</summary>

- `stack_event` gains `u32 sample_flags` in what was alignment padding after the leading enum: no other field moves, the record does not grow, and the offsetof-based raw-IP reservation is unchanged.
- No new BPF work per sample beyond one flag test; `task->flags` is now loaded once and shared with the existing kthread check. Ring traffic is identical — these events were already being submitted and consumed; userspace simply stops discarding them — so sample volume on VM hosts rises to reflect actual utilization.
- Stack spill format: user-frame tag 2 = guest (no payload), alongside 0 = raw IP and 1 = build-id.
- Frame string `unknown ([guest])`: label in the module slot like `[exited]` / `[gvisor:*]`, no `<0xaddr>` suffix (there is no address); in-tree consumers (`parse_module_name`, profile export) already treat the suffix as optional. Documented in `docs/PROFILE_EXPORT_FORMAT.md`. Emitted regardless of `--no-frame-labels`, since it is not an address-derived label.
- No schema change (frame strings are values), so no `SCHEMA_VERSION` bump and no `[bump minor]`; `Cargo.toml` untouched.
- Precedent check: nothing in this tree's history handles guest/vCPU samples; the nearest cost-class precedent (b25c202, work moved off the BPF probe path) does not apply, since this adds no per-event BPF work beyond one flag test on an already-loaded value.
</details>

<details><summary>Why PF_VCPU is the right mark</summary>

KVM sets `PF_VCPU` in `guest_timing_enter_irqoff()` and clears it in `guest_timing_exit_irqoff()`, which it deliberately runs only *after* servicing the interrupt that forced the VM-exit ("so that any ticks that occurred while running the guest are properly accounted to the guest"). A sampling interrupt that hits guest execution is handled inside exactly that window, with `perf_guest_state()` set — hence frameless. A guest-tagged sample that does carry frames (for example an NMI landing in the host's entry/exit glue on bare metal) keeps its real frames; the synthetic frame is used only when there is nothing else. Exit handling proper (EPT faults, emulation, halt polling) runs after `guest_timing_exit_irqoff()` and profiles normally, as the `fc_vcpu` spectrum above shows.
</details>

<details><summary>Tests</summary>

- `test_guest_sample_is_counted_and_labeled`: BPF-shaped frameless events carrying the guest flag, for a live and an exited VMM tgid → counted, interned (one dedup key per tgid), streamed, and symbolized to `unknown ([guest])` through `finish_inner`.
- `test_frameless_unmarked_sample_is_dropped_and_counted`: unmarked frameless event → dropped and counted; guest-marked event *with* a kernel frame → real stack kept, no synthetic frame.
- Spill round-trip and user-frame filter tests extended with the guest tag / variant.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, full `cargo test --lib`.
</details>

A follow-up this enables but does not attempt: visibility *inside* the guest needs cooperation from within the VM (an in-guest agent, or PMU/LBR passthrough) and is a separate design.
