### PR TITLE
Emit no brk delta when the previous break read as 0

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -5561,6 +5561,16 @@ int systing_brk_exit(struct trace_event_raw_sys_exit *ctx)
 	s64 enter_rss = saved->enter_rss;
 	bpf_map_delete_elem(&memory_syscall_scratch, &tgidpid);
 
+	/* The enter-side mm->brk read can yield 0 (the same mm edge the munmap
+	 * total_vm bound skips on). There is then no previous break to diff
+	 * against, and ret - 0 would record the new break ADDRESS as the
+	 * "delta": a page-aligned value in the tens of TB on a 47-bit VA,
+	 * observed in production as a count=1 brk row of ~92 TB on a process
+	 * that exited during the capture. An unknown previous break is not a
+	 * delta of that size; emit nothing, as a failed or query brk does. */
+	if (!old_brk)
+		return 0;
+
 	/* brk(0) queries the current break and failed brk returns it unchanged. */
 	if ((u64)ctx->ret == old_brk)
 		return 0;


### PR DESCRIPTION
The memory recorder stops emitting an address-sized `brk` "delta" when the previous break is unknown. `sys_exit_brk` records `size = ret - old_brk` with `old_brk` = `mm->brk` read at `sys_enter_brk`; when that read yields 0 (the same `mm` edge the munmap `total_vm` bound already skips on), the recorded size is the new break address itself — a page-aligned value in the tens of TB. This PR returns early in that case, exactly as a failed or query `brk` (`ret == old_brk`) already does.

**Why now.** Seen in production: one `brk` row with `count=1` and `bytes = 101,550,571,069,440` (`0x5c5c15b72000`, page-aligned, inside the 47-bit user VA) on a process that exited during the capture, while the next-largest single `brk` event in the same 24 h was 82 MB and the largest legitimate single `mmap` event 1.48 TB. Downstream, the churn aggregate reads that one event as a 92 TB heap change for the pod. A consumer can drop it by a per-row bound today only because each row is still one process; once a consumer groups rows by pod, the garbage event would sum into a legitimate row and no consumer-side bound could separate it — so the recorder must not emit it.

**What the reviewer decides.** That "unknown previous break ⇒ emit nothing" is the right semantics (the alternative, recording 0 or the address, is wrong either way), and that the guard belongs beside the existing `ret == old_brk` early return.

**What does not change.** Map, ringbuf and schema are untouched (no `SCHEMA_VERSION` bump, no `Cargo.toml` version edit); the map-sampled (`memory_map_sample_rate > 1`) and unsampled paths take the same early return; mmap/munmap and the RSS legs are untouched. The recording hot path gains one branch in a tracepoint program that already returns early on two conditions.

**Precedent.** `0fe6165` ("Bound recorded munmap size by the process's mapped size") fixed the same class — a physically impossible size recorded from a syscall pair — at the recorder, and its own comment skips the bound when the `mm` read yields 0 ("kernel-thread edge"); this is the `brk` twin of that clause. No hot-path, map or NMI-context change: the sampler/map wedge class does not apply.

**Tests.** `cargo build` (BPF skeleton compiles), `cargo fmt --check`, `cargo clippy --all-targets` clean; no Rust change, so the existing `memory_recorder` tests are unchanged. The BPF branch is verified by the build and the review below.

**First contact (after this change is deployed).** In the downstream memory-events table: zero `brk` rows with `count = 1` and `abs(bytes) > 2^44` per day (baseline ~1/day); every other `brk` figure unchanged (the `p99.99` single-event size stays in the tens of MB).
