### PR TITLE
analyze: bound stacktrace flamegraph memory — --top N as a SQL LIMIT, streamed output, --max-depth D

### DIFF
--- a/skills/systing-analyze/SKILL.md
+++ b/skills/systing-analyze/SKILL.md
@@ -180,12 +180,13 @@ Every table has a `trace_id` column. Always include it in joins, and filter on i
 
 ## Using `flamegraph`
 
-Returns `stacks` (array of `{frames, count}`), `metadata` (total_samples, unique_stacks, time_range, stack_type), and `folded` — folded-stack text (semicolon-separated frames root→leaf, space, count) for inferno / brendangregg's FlameGraph. Parameters:
+Returns `stacks` (array of `{frames, count}`), `metadata` (total_samples, matched_samples, unique_stacks, time_range, stack_type), and `folded` — folded-stack text (semicolon-separated frames root→leaf, space, count) for inferno / brendangregg's FlameGraph. `total_samples` is the whole trace; `matched_samples` and `unique_stacks` count what passed the filters BEFORE the `top_n` cut, so you can tell how much was cut. Parameters:
 - `stack_type` — `"cpu"` (default), `"interruptible-sleep"`, `"uninterruptible-sleep"`, `"all-sleep"`, `"all"`
 - `pid` / `tid` — restrict to a process or thread
 - `start_time` / `end_time` — seconds offset from trace start
 - `min_count` — minimum sample count per stack (default 1)
-- `top_n` — keep the top N stacks (default 500)
+- `top_n` — keep the top N stacks (default 500); the cut happens inside the database, so large traces stay cheap
+- `max_depth` — truncate every stack to its D root-most frames before merging (stacks that only differ deeper than D count as one); default full depth
 - `trace_id` — for multi-trace DBs
 
 ## Common investigation patterns

--- a/src/analyze/flamegraph.rs
+++ b/src/analyze/flamegraph.rs
@@ -64,7 +64,14 @@ pub struct FlamegraphParams {
     pub end_time: Option<f64>,
     pub trace_id: Option<String>,
     pub min_count: u64,
-    pub top_n: usize,
+    /// Keep only the `top_n` stacks with the most samples (`None` = every
+    /// stack). Applied as a `LIMIT` inside the fold query, so DuckDB keeps a
+    /// top-N heap and the caller never sees the long tail.
+    pub top_n: Option<usize>,
+    /// Cut every stack down to its `max_depth` frames nearest the root
+    /// (frames are stored root→leaf) before stacks are merged, so two stacks
+    /// that only differ below that depth count as one. `None` = full depth.
+    pub max_depth: Option<usize>,
 }
 
 impl Default for FlamegraphParams {
@@ -77,7 +84,8 @@ impl Default for FlamegraphParams {
             end_time: None,
             trace_id: None,
             min_count: 1,
-            top_n: 500,
+            top_n: Some(500),
+            max_depth: None,
         }
     }
 }
@@ -90,9 +98,16 @@ pub struct StackEntry {
 }
 
 /// Metadata about a flamegraph result.
+///
+/// `total_samples` counts every stack sample in the trace (or the selected
+/// trace); `matched_samples` and `unique_stacks` count what passed the
+/// filters (stack type, pid/tid, time window, `min_count`, and `max_depth`
+/// merging) BEFORE any `top_n` cut, so a truncated result can still say
+/// what it was cut from.
 #[derive(Debug, Serialize)]
 pub struct FlamegraphMetadata {
     pub total_samples: u64,
+    pub matched_samples: u64,
     pub unique_stacks: u64,
     pub time_range_seconds: (f64, f64),
     pub stack_type: String,
@@ -118,12 +133,65 @@ impl AnalyzeDb {
     /// per trace (frame ids are scoped per `trace_id`), so the same call chain
     /// in two traces appears as two output rows rather than one merged count.
     /// Filter to a single trace if a merged view is needed.
+    ///
+    /// This collects every emitted stack twice (`stacks` and `folded`), which
+    /// is fine for the bounded `top_n` the MCP tool asks for; a caller that
+    /// wants the whole fold of a large trace should stream it through
+    /// [`AnalyzeDb::flamegraph_stream`] instead.
     pub fn flamegraph(&self, params: &FlamegraphParams) -> Result<FlamegraphResult> {
+        let mut stacks = Vec::new();
+        let mut folded = String::new();
+        let metadata = self.flamegraph_stream(params, |line, count| {
+            if !folded.is_empty() {
+                folded.push('\n');
+            }
+            folded.push_str(line);
+            let _ = write!(folded, " {count}");
+            stacks.push(StackEntry {
+                frames: line.split(';').map(str::to_string).collect(),
+                count,
+            });
+            Ok(())
+        })?;
+
+        Ok(FlamegraphResult {
+            stacks,
+            metadata,
+            folded,
+        })
+    }
+
+    /// Run the fold query and hand each folded stack (`root;...;leaf`) and
+    /// its sample count to `emit`, heaviest first, without keeping any of
+    /// them: the only per-stack state is the one line being formatted. The
+    /// stack set is bounded by `params.top_n` and `params.max_depth` inside
+    /// DuckDB (a `LIMIT` over the grouped rows, and the group key itself), so
+    /// this path's memory is set by the frame-name table — one entry per
+    /// unique frame in the trace — not by the number of unique stacks.
+    ///
+    /// The returned metadata's `unique_stacks` and `matched_samples` count
+    /// what passed the filters (after `max_depth` merging and `min_count`),
+    /// not what was emitted, so a truncated output can still say how much it
+    /// left out.
+    pub fn flamegraph_stream<F>(
+        &self,
+        params: &FlamegraphParams,
+        mut emit: F,
+    ) -> Result<FlamegraphMetadata>
+    where
+        F: FnMut(&str, u64) -> Result<()>,
+    {
         if !self.table_exists("stack_sample")? || !self.table_exists("stack")? {
             bail!(
                 "Database missing required tables (stack_sample, stack). \
                  Is this a systing trace database?"
             );
+        }
+        if params.top_n == Some(0) {
+            bail!("top_n must be at least 1");
+        }
+        if params.max_depth == Some(0) {
+            bail!("max_depth must be at least 1");
         }
 
         let (min_ts, max_ts, total_samples) =
@@ -138,54 +206,52 @@ impl AnalyzeDb {
         // store stacks ~5x smaller.
         let frame_names = self.load_frame_names(params.trace_id.as_deref())?;
 
-        let sql = build_flamegraph_query(
-            params.stack_type,
-            params.pid,
-            params.tid,
+        let sql = build_flamegraph_query(&FlamegraphQuery {
+            stack_type: params.stack_type,
+            pid: params.pid,
+            tid: params.tid,
             abs_start,
             abs_end,
-            params.trace_id.as_deref(),
-            params.min_count,
-        );
+            trace_id: params.trace_id.as_deref(),
+            min_count: params.min_count,
+            top_n: params.top_n,
+            max_depth: params.max_depth,
+        });
 
         let mut stmt = self.conn.prepare(&sql)?;
         let mut rows = stmt.query([])?;
 
-        let mut stacks = Vec::new();
-        let mut folded_lines = Vec::new();
         let mut unique_stacks: u64 = 0;
+        let mut matched_samples: u64 = 0;
+        let mut folded = String::new();
 
         while let Some(row) = rows.next()? {
             let trace_id: String = row.get(0)?;
             let frames_str: String = row.get(1)?;
             let count: i64 = row.get(2)?;
-            let count = count as u64;
+            // Every row carries the same pre-cut totals; a query with no rows
+            // leaves them at zero, which is also the truth.
+            let total_stacks: i64 = row.get(3)?;
+            let total_samples_matched: i64 = row.get(4)?;
+            unique_stacks = total_stacks as u64;
+            matched_samples = total_samples_matched as u64;
 
-            let folded = format_folded_stack(&trace_id, &frames_str, &frame_names);
+            folded.clear();
+            format_folded_stack_into(&mut folded, &trace_id, &frames_str, &frame_names);
             if folded.is_empty() {
                 continue;
             }
-
-            unique_stacks += 1;
-
-            if stacks.len() < params.top_n {
-                let frames: Vec<String> = folded.split(';').map(|s| s.to_string()).collect();
-                folded_lines.push(format!("{folded} {count}"));
-                stacks.push(StackEntry { frames, count });
-            }
+            emit(&folded, count as u64)?;
         }
 
         let duration_secs = (max_ts - min_ts) as f64 / 1e9;
 
-        Ok(FlamegraphResult {
-            stacks,
-            metadata: FlamegraphMetadata {
-                total_samples,
-                unique_stacks,
-                time_range_seconds: (0.0, duration_secs),
-                stack_type: params.stack_type.to_string(),
-            },
-            folded: folded_lines.join("\n"),
+        Ok(FlamegraphMetadata {
+            total_samples,
+            matched_samples,
+            unique_stacks,
+            time_range_seconds: (0.0, duration_secs),
+            stack_type: params.stack_type.to_string(),
         })
     }
 
@@ -216,15 +282,64 @@ impl AnalyzeDb {
     }
 }
 
-fn build_flamegraph_query(
+/// The resolved inputs of the fold query (absolute timestamps, not offsets).
+#[derive(Debug)]
+struct FlamegraphQuery<'a> {
     stack_type: StackTypeFilter,
     pid: Option<u32>,
     tid: Option<u32>,
     abs_start: Option<i64>,
     abs_end: Option<i64>,
-    trace_id: Option<&str>,
+    trace_id: Option<&'a str>,
     min_count: u64,
-) -> String {
+    top_n: Option<usize>,
+    max_depth: Option<usize>,
+}
+
+impl Default for FlamegraphQuery<'_> {
+    fn default() -> Self {
+        Self {
+            stack_type: StackTypeFilter::Cpu,
+            pid: None,
+            tid: None,
+            abs_start: None,
+            abs_end: None,
+            trace_id: None,
+            min_count: 1,
+            top_n: None,
+            max_depth: None,
+        }
+    }
+}
+
+/// Build the fold query. It returns one row per unique stack, heaviest
+/// first, as `(trace_id, frames, count, unique_stacks, matched_samples)`:
+///
+/// * `frames` is the stack's frame ids joined with chr(31) (duckdb-rs has no
+///   FromSql for `Vec<i64>`); the caller resolves names.
+/// * `unique_stacks` and `matched_samples` are the same numbers on every
+///   row: how many unique stacks passed the filters before `LIMIT`, and how
+///   many samples those stacks hold, so a `top_n` caller can still report the
+///   size of what it cut.
+///
+/// Grouping happens on the raw `BIGINT[]` (`max_depth` slices it first, so
+/// stacks that only differ deeper than that merge in DuckDB and the top-N
+/// over the merged stacks is exact). The id→string conversion runs only on
+/// the rows that survive the `LIMIT`, and the sort has a total order
+/// (`count DESC, trace_id, frame_ids`) so equal-count stacks come out in a
+/// fixed order and `top_n` picks the same set every run.
+fn build_flamegraph_query(q: &FlamegraphQuery<'_>) -> String {
+    let FlamegraphQuery {
+        stack_type,
+        pid,
+        tid,
+        abs_start,
+        abs_end,
+        trace_id,
+        min_count,
+        top_n,
+        max_depth,
+    } = *q;
     let mut joins = String::new();
     let mut conditions = Vec::new();
 
@@ -286,48 +401,81 @@ fn build_flamegraph_query(
         String::new()
     };
 
-    // duckdb-rs has no FromSql for Vec<i64>, so flatten frame_ids to a
-    // chr(31)-separated string and parse it Rust-side. Grouping happens on the
-    // raw BIGINT[] so the string conversion only runs once per output row.
-    // trace_id is carried through because frame ids are scoped per trace.
+    // frame_ids are stored root→leaf, so the first `max_depth` elements are
+    // the root-most frames (list_slice bounds are 1-based and inclusive; a
+    // shorter list comes back whole).
+    let frame_ids_expr = match max_depth {
+        Some(d) => format!("list_slice(s.frame_ids, 1, {d})"),
+        None => "s.frame_ids".to_string(),
+    };
+
+    let limit_clause = match top_n {
+        Some(n) => format!(" LIMIT {n}"),
+        None => String::new(),
+    };
+
+    // Three pieces: (1) `folded` — the samples grouped by stack, keyed on the
+    // raw BIGINT[] because that is what DuckDB hashes and compares cheapest,
+    // materialized once so it can be both counted and cut; (2) the ordered
+    // LIMIT over it, so DuckDB keeps a top-N heap and the total is counted
+    // before the cut (a window `COUNT(*) OVER ()` gives the same number but
+    // costs a full extra pass over the folded rows); (3) the id→string
+    // conversion (duckdb-rs has no FromSql for Vec<i64>) on the surviving
+    // rows only — inside the same SELECT as the LIMIT it would run for every
+    // folded row. trace_id is carried through because frame ids are scoped
+    // per trace.
     format!(
-        "SELECT s.trace_id, \
-                array_to_string([x::VARCHAR for x in s.frame_ids], chr(31)) as frames, \
-                COUNT(*) as count \
-         FROM stack_sample ss \
-         JOIN stack s ON ss.stack_id = s.id AND ss.trace_id = s.trace_id\
-         {joins}{where_clause} \
-         GROUP BY s.trace_id, s.frame_ids{having_clause} \
-         ORDER BY count DESC"
+        "WITH folded AS MATERIALIZED ( \
+            SELECT s.trace_id AS trace_id, \
+                   {frame_ids_expr} AS frame_ids, \
+                   COUNT(*) AS count \
+            FROM stack_sample ss \
+            JOIN stack s ON ss.stack_id = s.id AND ss.trace_id = s.trace_id\
+            {joins}{where_clause} \
+            GROUP BY s.trace_id, {frame_ids_expr}{having_clause}) \
+         SELECT trace_id, \
+                array_to_string([x::VARCHAR for x in frame_ids], chr(31)) AS frames, \
+                count, \
+                (SELECT COUNT(*) FROM folded) AS unique_stacks, \
+                (SELECT COALESCE(SUM(count), 0)::BIGINT FROM folded) AS matched_samples \
+         FROM (SELECT trace_id, frame_ids, count \
+               FROM folded \
+               ORDER BY count DESC, trace_id, frame_ids{limit_clause}) \
+         ORDER BY count DESC, trace_id, frame_ids"
     )
 }
 
-/// Format a chr(31)-separated string of frame ids into folded stack format.
+/// Format a chr(31)-separated string of frame ids into folded stack format,
+/// appended to a caller-owned buffer so a streaming caller formats every
+/// stack through the same allocation.
 ///
 /// Frame ids are stored root-to-leaf in the database (see `Stack` in
 /// stack_recorder.rs), which is already the flamegraph folded convention
 /// (root;child;...;leaf) — emit in storage order.
-fn format_folded_stack(trace_id: &str, frames_str: &str, frames: &FrameTable) -> String {
+fn format_folded_stack_into(
+    out: &mut String,
+    trace_id: &str,
+    frames_str: &str,
+    frames: &FrameTable,
+) {
     if frames_str.is_empty() {
-        return String::new();
+        return;
     }
 
     let trace_frames = frames.get(trace_id);
 
-    let formatted: Vec<String> = frames_str
-        .split('\x1F')
-        .map(|id_str| {
-            let name = id_str
-                .parse::<usize>()
-                .ok()
-                .and_then(|id| trace_frames.and_then(|v| v.get(id)))
-                .map(String::as_str)
-                .unwrap_or(id_str);
-            format_frame(name)
-        })
-        .collect();
-
-    formatted.join(";")
+    for (i, id_str) in frames_str.split('\x1F').enumerate() {
+        if i > 0 {
+            out.push(';');
+        }
+        let name = id_str
+            .parse::<usize>()
+            .ok()
+            .and_then(|id| trace_frames.and_then(|v| v.get(id)))
+            .map(String::as_str)
+            .unwrap_or(id_str);
+        format_frame_into(out, name);
+    }
 }
 
 /// The recorder writes frame names in one of three shapes, in order of
@@ -393,7 +541,8 @@ fn parse_frame(raw: &str) -> Frame<'_> {
     }
 }
 
-/// Render one recorder frame for folded output as `file:function:line`.
+/// Render one recorder frame for folded output as `file:function:line`,
+/// appended to a caller-owned buffer.
 ///
 /// This is the same grammar systing's continuous-profiling frames use, so a
 /// frame reads identically whichever mode produced it: `file` falls back to
@@ -407,10 +556,9 @@ fn parse_frame(raw: &str) -> Frame<'_> {
 /// unknown ([guest])                                                  →  [guest]:unknown
 /// 0x5dbfa1                                                           →  :0x5dbfa1
 /// ```
-fn format_frame(frame: &str) -> String {
+fn format_frame_into(out: &mut String, frame: &str) {
     let f = parse_frame(frame);
     let file = if f.file.is_empty() { f.mapping } else { f.file };
-    let mut out = String::with_capacity(frame.len());
     out.push_str(file);
     out.push(':');
     if f.func.is_empty() {
@@ -421,12 +569,23 @@ fn format_frame(frame: &str) -> String {
     if f.line > 0 {
         let _ = write!(out, ":{}", f.line);
     }
-    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn format_frame(frame: &str) -> String {
+        let mut out = String::new();
+        format_frame_into(&mut out, frame);
+        out
+    }
+
+    fn format_folded_stack(trace_id: &str, frames_str: &str, frames: &FrameTable) -> String {
+        let mut out = String::new();
+        format_folded_stack_into(&mut out, trace_id, frames_str, frames);
+        out
+    }
 
     // --- parse_frame: the recorder's three frame shapes ---
 
@@ -654,24 +813,23 @@ mod tests {
         assert_eq!(format_folded_stack("t", "0\x1F7", &frames), "myapp:main;:7");
     }
 
+    fn query(stack_type: StackTypeFilter) -> FlamegraphQuery<'static> {
+        FlamegraphQuery {
+            stack_type,
+            ..FlamegraphQuery::default()
+        }
+    }
+
     #[test]
     fn test_build_flamegraph_query_cpu() {
-        let sql = build_flamegraph_query(StackTypeFilter::Cpu, None, None, None, None, None, 1);
+        let sql = build_flamegraph_query(&query(StackTypeFilter::Cpu));
         assert!(sql.contains("stack_event_type = 1"));
         assert!(!sql.contains("sched_slice"));
     }
 
     #[test]
     fn test_build_flamegraph_query_interruptible_sleep() {
-        let sql = build_flamegraph_query(
-            StackTypeFilter::InterruptibleSleep,
-            None,
-            None,
-            None,
-            None,
-            None,
-            1,
-        );
+        let sql = build_flamegraph_query(&query(StackTypeFilter::InterruptibleSleep));
         assert!(sql.contains("stack_event_type = 2"));
         assert!(!sql.contains("sched_slice"));
         assert!(!sql.contains("end_state"));
@@ -679,15 +837,7 @@ mod tests {
 
     #[test]
     fn test_build_flamegraph_query_uninterruptible_sleep() {
-        let sql = build_flamegraph_query(
-            StackTypeFilter::UninterruptibleSleep,
-            None,
-            None,
-            None,
-            None,
-            None,
-            1,
-        );
+        let sql = build_flamegraph_query(&query(StackTypeFilter::UninterruptibleSleep));
         assert!(sql.contains("stack_event_type = 0"));
         assert!(!sql.contains("sched_slice"));
         assert!(!sql.contains("end_state"));
@@ -695,8 +845,7 @@ mod tests {
 
     #[test]
     fn test_build_flamegraph_query_all_sleep() {
-        let sql =
-            build_flamegraph_query(StackTypeFilter::AllSleep, None, None, None, None, None, 1);
+        let sql = build_flamegraph_query(&query(StackTypeFilter::AllSleep));
         assert!(sql.contains("stack_event_type IN (0, 2)"));
         assert!(!sql.contains("sched_slice"));
         assert!(!sql.contains("end_state"));
@@ -704,8 +853,10 @@ mod tests {
 
     #[test]
     fn test_build_flamegraph_query_with_pid() {
-        let sql =
-            build_flamegraph_query(StackTypeFilter::Cpu, Some(1234), None, None, None, None, 1);
+        let sql = build_flamegraph_query(&FlamegraphQuery {
+            pid: Some(1234),
+            ..query(StackTypeFilter::Cpu)
+        });
         assert!(sql.contains("JOIN thread t"));
         assert!(sql.contains("JOIN process p"));
         assert!(sql.contains("p.pid = 1234"));
@@ -713,14 +864,280 @@ mod tests {
 
     #[test]
     fn test_build_flamegraph_query_with_min_count() {
-        let sql = build_flamegraph_query(StackTypeFilter::All, None, None, None, None, None, 10);
+        let sql = build_flamegraph_query(&FlamegraphQuery {
+            min_count: 10,
+            ..query(StackTypeFilter::All)
+        });
         assert!(sql.contains("HAVING COUNT(*) >= 10"));
     }
 
     #[test]
     fn test_build_flamegraph_query_no_having_for_min_count_1() {
-        let sql = build_flamegraph_query(StackTypeFilter::All, None, None, None, None, None, 1);
+        let sql = build_flamegraph_query(&query(StackTypeFilter::All));
         assert!(!sql.contains("HAVING"));
+    }
+
+    #[test]
+    fn test_build_flamegraph_query_unbounded_has_no_limit_and_full_depth() {
+        let sql = build_flamegraph_query(&query(StackTypeFilter::Cpu));
+        assert!(!sql.contains("LIMIT"));
+        assert!(!sql.contains("list_slice"));
+        assert!(sql.contains("GROUP BY s.trace_id, s.frame_ids"));
+        // The total is counted over the materialized fold, before any cut.
+        assert!(sql.contains("WITH folded AS MATERIALIZED"));
+        assert!(sql.contains("(SELECT COUNT(*) FROM folded) AS unique_stacks"));
+        assert!(
+            sql.contains("(SELECT COALESCE(SUM(count), 0)::BIGINT FROM folded) AS matched_samples")
+        );
+        // A total order, so equal counts come out the same way every run.
+        assert!(sql.contains("ORDER BY count DESC, trace_id, frame_ids"));
+    }
+
+    #[test]
+    fn test_build_flamegraph_query_top_n_is_a_sql_limit() {
+        let sql = build_flamegraph_query(&FlamegraphQuery {
+            top_n: Some(4096),
+            ..query(StackTypeFilter::Cpu)
+        });
+        // The LIMIT closes the inner ordered subquery; the id→string
+        // conversion is in the SELECT list outside it, so it only runs on
+        // the rows that survive the cut.
+        let inner_at = sql
+            .find("FROM (SELECT trace_id, frame_ids, count FROM folded")
+            .unwrap();
+        let limit_at = sql.find(" LIMIT 4096)").unwrap();
+        let strings_at = sql.find("array_to_string").unwrap();
+        assert!(strings_at < inner_at);
+        assert!(inner_at < limit_at);
+        assert_eq!(sql.matches("LIMIT").count(), 1);
+    }
+
+    #[test]
+    fn test_build_flamegraph_query_max_depth_slices_the_group_key() {
+        let sql = build_flamegraph_query(&FlamegraphQuery {
+            max_depth: Some(64),
+            ..query(StackTypeFilter::Cpu)
+        });
+        assert!(sql.contains("list_slice(s.frame_ids, 1, 64) AS frame_ids"));
+        assert!(sql.contains("GROUP BY s.trace_id, list_slice(s.frame_ids, 1, 64)"));
+    }
+
+    // --- the fold itself, on an in-memory trace DB ---
+
+    /// Four stacks over four frames, sampled 5/3/3/1 times:
+    ///   stack 0 = main;work;spin   ×5
+    ///   stack 1 = main;work;sleep  ×3
+    ///   stack 2 = main;sleep       ×3
+    ///   stack 3 = main;work        ×1
+    fn fold_db() -> AnalyzeDb {
+        let conn = duckdb::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE frame (trace_id VARCHAR, id BIGINT, name VARCHAR); \
+             CREATE TABLE stack (trace_id VARCHAR, id BIGINT, frame_ids BIGINT[], depth INTEGER, leaf_name VARCHAR); \
+             CREATE TABLE stack_sample (trace_id VARCHAR, ts BIGINT, utid BIGINT, cpu INTEGER, stack_id BIGINT, stack_event_type TINYINT); \
+             INSERT INTO frame VALUES \
+               ('t', 0, 'main (app) <0x1>'), ('t', 1, 'work (app) <0x2>'), \
+               ('t', 2, 'spin (app) <0x3>'), ('t', 3, 'sleep (app) <0x4>'); \
+             INSERT INTO stack VALUES \
+               ('t', 0, [0, 1, 2], 3, 'spin'), ('t', 1, [0, 1, 3], 3, 'sleep'), \
+               ('t', 2, [0, 3], 2, 'sleep'), ('t', 3, [0, 1], 2, 'work'); \
+             INSERT INTO stack_sample \
+               SELECT 't', 1000 + i * 1000, 1, 0, \
+                      CASE WHEN i < 5 THEN 0 WHEN i < 8 THEN 1 WHEN i < 11 THEN 2 ELSE 3 END, 1 \
+               FROM range(12) r(i);",
+        )
+        .unwrap();
+        AnalyzeDb {
+            conn,
+            path: std::path::PathBuf::new(),
+        }
+    }
+
+    fn streamed(
+        db: &AnalyzeDb,
+        params: &FlamegraphParams,
+    ) -> (Vec<(String, u64)>, FlamegraphMetadata) {
+        let mut lines = Vec::new();
+        let meta = db
+            .flamegraph_stream(params, |folded, count| {
+                lines.push((folded.to_string(), count));
+                Ok(())
+            })
+            .unwrap();
+        (lines, meta)
+    }
+
+    fn all() -> FlamegraphParams {
+        FlamegraphParams {
+            top_n: None,
+            ..FlamegraphParams::default()
+        }
+    }
+
+    #[test]
+    fn fold_orders_heaviest_first_with_a_fixed_tie_order() {
+        let db = fold_db();
+        let (lines, meta) = streamed(&db, &all());
+        assert_eq!(
+            lines,
+            vec![
+                ("app:main;app:work;app:spin".to_string(), 5),
+                // Equal counts tie-break on the frame-id list: [0,1,3] < [0,3].
+                ("app:main;app:work;app:sleep".to_string(), 3),
+                ("app:main;app:sleep".to_string(), 3),
+                ("app:main;app:work".to_string(), 1),
+            ]
+        );
+        assert_eq!(meta.total_samples, 12);
+        assert_eq!(meta.matched_samples, 12);
+        assert_eq!(meta.unique_stacks, 4);
+        assert_eq!(meta.stack_type, "cpu");
+    }
+
+    #[test]
+    fn fold_top_n_cuts_the_output_but_not_the_total() {
+        let db = fold_db();
+        let (lines, meta) = streamed(
+            &db,
+            &FlamegraphParams {
+                top_n: Some(2),
+                ..all()
+            },
+        );
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0], ("app:main;app:work;app:spin".to_string(), 5));
+        assert_eq!(lines[1], ("app:main;app:work;app:sleep".to_string(), 3));
+        assert_eq!(
+            meta.unique_stacks, 4,
+            "the total is counted before the LIMIT"
+        );
+        assert_eq!(
+            meta.matched_samples, 12,
+            "so is the matched-sample total, not the emitted 5 + 3"
+        );
+        assert_eq!(meta.total_samples, 12);
+    }
+
+    #[test]
+    fn fold_max_depth_merges_in_the_database() {
+        let db = fold_db();
+        let (lines, meta) = streamed(
+            &db,
+            &FlamegraphParams {
+                max_depth: Some(2),
+                ..all()
+            },
+        );
+        // Root-most two frames: stacks 0, 1 and 3 all become main;work.
+        assert_eq!(
+            lines,
+            vec![
+                ("app:main;app:work".to_string(), 9),
+                ("app:main;app:sleep".to_string(), 3),
+            ]
+        );
+        assert_eq!(
+            meta.unique_stacks, 2,
+            "unique stacks are counted after merging"
+        );
+        assert_eq!(meta.matched_samples, 12, "merging keeps every sample");
+        assert_eq!(meta.total_samples, 12);
+    }
+
+    #[test]
+    fn fold_top_n_over_merged_stacks_is_exact() {
+        let db = fold_db();
+        let (lines, meta) = streamed(
+            &db,
+            &FlamegraphParams {
+                max_depth: Some(2),
+                top_n: Some(1),
+                ..all()
+            },
+        );
+        // Without merging first, the single heaviest stack would be
+        // main;work;spin at 5; merged, main;work carries 9.
+        assert_eq!(lines, vec![("app:main;app:work".to_string(), 9)]);
+        assert_eq!(meta.unique_stacks, 2);
+    }
+
+    #[test]
+    fn fold_min_count_is_applied_before_the_total() {
+        let db = fold_db();
+        let (lines, meta) = streamed(
+            &db,
+            &FlamegraphParams {
+                min_count: 3,
+                ..all()
+            },
+        );
+        assert_eq!(lines.len(), 3);
+        assert!(lines.iter().all(|(_, c)| *c >= 3));
+        assert_eq!(meta.unique_stacks, 3);
+        assert_eq!(
+            meta.matched_samples, 11,
+            "the one-sample stack is out of the matched total too"
+        );
+        assert_eq!(meta.total_samples, 12);
+    }
+
+    #[test]
+    fn fold_with_nothing_in_the_window_reports_zero() {
+        let db = fold_db();
+        let (lines, meta) = streamed(
+            &db,
+            &FlamegraphParams {
+                start_time: Some(100.0),
+                ..all()
+            },
+        );
+        assert!(lines.is_empty());
+        assert_eq!(meta.unique_stacks, 0);
+        assert_eq!(meta.matched_samples, 0);
+        assert_eq!(meta.total_samples, 12, "the trace total is not windowed");
+    }
+
+    #[test]
+    fn fold_structured_result_matches_the_stream() {
+        let db = fold_db();
+        let params = FlamegraphParams {
+            top_n: Some(3),
+            ..all()
+        };
+        let (lines, _) = streamed(&db, &params);
+        let result = db.flamegraph(&params).unwrap();
+        assert_eq!(result.stacks.len(), 3);
+        assert_eq!(result.metadata.unique_stacks, 4);
+        let expected_folded: Vec<String> = lines.iter().map(|(f, c)| format!("{f} {c}")).collect();
+        assert_eq!(result.folded, expected_folded.join("\n"));
+        assert_eq!(
+            result.stacks[0].frames,
+            vec!["app:main", "app:work", "app:spin"]
+        );
+        assert_eq!(result.stacks[0].count, 5);
+    }
+
+    #[test]
+    fn fold_rejects_zero_bounds() {
+        let db = fold_db();
+        assert!(db
+            .flamegraph_stream(
+                &FlamegraphParams {
+                    top_n: Some(0),
+                    ..all()
+                },
+                |_, _| Ok(())
+            )
+            .is_err());
+        assert!(db
+            .flamegraph_stream(
+                &FlamegraphParams {
+                    max_depth: Some(0),
+                    ..all()
+                },
+                |_, _| Ok(())
+            )
+            .is_err());
     }
 
     #[test]

--- a/src/bin/systing_analyze.rs
+++ b/src/bin/systing_analyze.rs
@@ -107,6 +107,18 @@ struct FlamegraphArgs {
     /// Minimum sample count to include a stack
     #[arg(long, default_value = "1")]
     min_count: u64,
+
+    /// Emit only the N stacks with the most samples (the `# Unique stacks`
+    /// footer still counts every stack). Bounds memory on large traces: the
+    /// cut happens inside the database, not after everything was built.
+    #[arg(long, value_name = "N", value_parser = clap::value_parser!(u64).range(1..))]
+    top: Option<u64>,
+
+    /// Truncate every stack to its D root-most frames before merging, so
+    /// stacks that only differ deeper than D count as one (the top-N is
+    /// then exact for that depth). Default: full depth.
+    #[arg(long, value_name = "D", value_parser = clap::value_parser!(u64).range(1..))]
+    max_depth: Option<u64>,
 }
 
 #[derive(Clone, clap::ValueEnum)]
@@ -478,6 +490,8 @@ fn run_interactive(db: &AnalyzeDb, format: &str) -> Result<()> {
 
 /// Run the flamegraph subcommand
 fn run_flamegraph(args: FlamegraphArgs) -> Result<()> {
+    use std::io::Write as _;
+
     let db = AnalyzeDb::open(&args.database, true)?;
 
     let params = analyze::FlamegraphParams {
@@ -488,24 +502,14 @@ fn run_flamegraph(args: FlamegraphArgs) -> Result<()> {
         end_time: args.end_time,
         trace_id: args.trace_id.clone(),
         min_count: args.min_count,
-        top_n: usize::MAX, // No limit for CLI output
+        top_n: args.top.map(|n| n as usize), // None = every stack
+        max_depth: args.max_depth.map(|d| d as usize),
     };
 
-    let result = db.flamegraph(&params)?;
-
-    // Print metadata to stderr
+    // The lines that only describe the request go first; the counts come
+    // after the stream, once they are known. Consumers that parse the
+    // footer key on the `# ...:` prefixes, not on position.
     eprintln!("# Flamegraph: {}", args.database.display());
-    eprintln!("# Stack type: {}", result.metadata.stack_type);
-    eprintln!("# Total trace samples: {}", result.metadata.total_samples);
-    eprintln!(
-        "# Output samples: {}",
-        result.stacks.iter().map(|s| s.count).sum::<u64>()
-    );
-    eprintln!("# Unique stacks: {}", result.metadata.unique_stacks);
-    eprintln!(
-        "# Time range: {:.3}s - {:.3}s",
-        result.metadata.time_range_seconds.0, result.metadata.time_range_seconds.1
-    );
 
     let mut filters = Vec::new();
     if let Some(p) = &args.pid {
@@ -527,11 +531,36 @@ fn run_flamegraph(args: FlamegraphArgs) -> Result<()> {
         eprintln!("# Filters: {}", filters.join(", "));
     }
 
-    // Print folded stacks to stdout
-    for stack in &result.stacks {
-        let folded = stack.frames.join(";");
-        println!("{folded} {}", stack.count);
+    // Stream folded stacks to stdout as the database hands them over: one
+    // line in flight at a time, never the whole fold in memory.
+    let stdout = std::io::stdout();
+    let mut out = std::io::BufWriter::with_capacity(256 * 1024, stdout.lock());
+    let mut output_stacks: u64 = 0;
+    let mut output_samples: u64 = 0;
+    let metadata = db.flamegraph_stream(&params, |folded, count| {
+        writeln!(out, "{folded} {count}")?;
+        output_stacks += 1;
+        output_samples += count;
+        Ok(())
+    })?;
+    out.flush()?;
+
+    // `Matched samples` / `Unique stacks` describe everything that passed the
+    // filters; `Output samples` / `Output stacks` describe what was printed.
+    // The two pairs differ only under --top.
+    eprintln!("# Stack type: {}", metadata.stack_type);
+    eprintln!("# Total trace samples: {}", metadata.total_samples);
+    eprintln!("# Matched samples: {}", metadata.matched_samples);
+    eprintln!("# Output samples: {output_samples}");
+    eprintln!("# Unique stacks: {}", metadata.unique_stacks);
+    eprintln!("# Output stacks: {output_stacks}");
+    if let Some(d) = args.max_depth {
+        eprintln!("# Max depth: {d}");
     }
+    eprintln!(
+        "# Time range: {:.3}s - {:.3}s",
+        metadata.time_range_seconds.0, metadata.time_range_seconds.1
+    );
 
     Ok(())
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -391,6 +391,11 @@ struct FlamegraphToolParams {
     /// Limit to top N stacks by sample count. Default: 500.
     #[serde(default, deserialize_with = "string_or_number::option::deserialize")]
     top_n: Option<usize>,
+
+    /// Truncate every stack to its D root-most frames before merging, so
+    /// stacks that only differ deeper than D count as one. Default: full depth.
+    #[serde(default, deserialize_with = "string_or_number::option::deserialize")]
+    max_depth: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -579,7 +584,7 @@ impl SystingMcpServer {
 
     #[tool(
         name = "flamegraph",
-        description = "Query stack traces and return structured results for flame graph analysis. Returns 'stacks' (array of {frames, count}), 'metadata' (total_samples, unique_stacks, time_range, stack_type), and 'folded' (folded-stack text compatible with flamegraph tools like inferno or brendangregg/FlameGraph)."
+        description = "Query stack traces and return structured results for flame graph analysis. Returns 'stacks' (array of {frames, count}), 'metadata' (total_samples, matched_samples, unique_stacks, time_range, stack_type — matched_samples and unique_stacks count everything that passed the filters before the top_n cut), and 'folded' (folded-stack text compatible with flamegraph tools like inferno or brendangregg/FlameGraph)."
     )]
     async fn flamegraph(
         &self,
@@ -600,7 +605,8 @@ impl SystingMcpServer {
             end_time: params.end_time,
             trace_id: params.trace_id,
             min_count: params.min_count.unwrap_or(1),
-            top_n: params.top_n.unwrap_or(500),
+            top_n: Some(params.top_n.unwrap_or(500)),
+            max_depth: params.max_depth,
         };
 
         match self

--- a/tests/analyze_commands.rs
+++ b/tests/analyze_commands.rs
@@ -256,12 +256,20 @@ fn assert_flamegraph_metadata(stderr: &str, stack_type: &str) {
         "missing total samples in stderr"
     );
     assert!(
+        stderr.contains("# Matched samples:"),
+        "missing matched samples in stderr"
+    );
+    assert!(
         stderr.contains("# Output samples:"),
         "missing output samples in stderr"
     );
     assert!(
         stderr.contains("# Unique stacks:"),
         "missing unique stacks in stderr"
+    );
+    assert!(
+        stderr.contains("# Output stacks:"),
+        "missing output stacks in stderr"
     );
     assert!(
         stderr.contains("# Time range:"),
@@ -399,6 +407,126 @@ fn test_flamegraph_with_min_count(db: &Path) {
     assert!(
         filtered_lines <= baseline_lines,
         "min-count=5 ({filtered_lines} stacks) should be <= unfiltered ({baseline_lines} stacks)"
+    );
+}
+
+/// Pull the integer after a `# <key>:` footer line.
+fn footer_count(stderr: &str, key: &str) -> u64 {
+    let prefix = format!("# {key}:");
+    stderr
+        .lines()
+        .find_map(|l| l.strip_prefix(&prefix))
+        .unwrap_or_else(|| panic!("missing `{prefix}` in stderr: {stderr}"))
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("`{prefix}` is not a number ({e}): {stderr}"))
+}
+
+fn test_flamegraph_top_and_max_depth(db: &Path) {
+    let baseline = run_analyze(&[
+        "stacktrace",
+        "flamegraph",
+        "-d",
+        db.to_str().unwrap(),
+        "-t",
+        "all",
+    ]);
+    assert!(baseline.status.success(), "{}", lossy(&baseline.stderr));
+    let baseline_stdout = lossy(&baseline.stdout);
+    let baseline_stderr = lossy(&baseline.stderr);
+    let baseline_lines: Vec<&str> = baseline_stdout.lines().collect();
+    let baseline_unique = footer_count(&baseline_stderr, "Unique stacks");
+    let baseline_matched = footer_count(&baseline_stderr, "Matched samples");
+    assert_eq!(
+        footer_count(&baseline_stderr, "Output stacks"),
+        baseline_lines.len() as u64,
+        "without --top every unique stack is emitted"
+    );
+    assert_eq!(baseline_unique, baseline_lines.len() as u64);
+    assert_eq!(
+        footer_count(&baseline_stderr, "Output samples"),
+        baseline_matched,
+        "without --top every matched sample is printed"
+    );
+    assert!(baseline_matched <= footer_count(&baseline_stderr, "Total trace samples"));
+
+    // --top 1: exactly one line (the heaviest stack), and the footer still
+    // reports the full unique-stack and matched-sample counts.
+    let output = run_analyze(&[
+        "stacktrace",
+        "flamegraph",
+        "-d",
+        db.to_str().unwrap(),
+        "-t",
+        "all",
+        "--top",
+        "1",
+    ]);
+    assert!(
+        output.status.success(),
+        "flamegraph (--top 1) failed: {}",
+        lossy(&output.stderr)
+    );
+    let stdout = lossy(&output.stdout);
+    let stderr = lossy(&output.stderr);
+    assert_valid_folded_output(&stdout);
+    assert_flamegraph_metadata(&stderr, "all");
+    assert_eq!(
+        stdout.lines().count(),
+        1,
+        "--top 1 emits one stack: {stdout}"
+    );
+    assert_eq!(stdout.lines().next(), baseline_lines.first().copied());
+    assert_eq!(footer_count(&stderr, "Output stacks"), 1);
+    assert_eq!(
+        footer_count(&stderr, "Unique stacks"),
+        baseline_unique,
+        "--top does not change the unique-stack total"
+    );
+    assert_eq!(
+        footer_count(&stderr, "Matched samples"),
+        baseline_matched,
+        "--top does not change the matched-sample total"
+    );
+    assert!(footer_count(&stderr, "Output samples") <= baseline_matched);
+
+    // --max-depth 1: every stack collapses to its root frame, so no line has
+    // a ';' and the merged stacks cover the same samples as the full fold.
+    let output = run_analyze(&[
+        "stacktrace",
+        "flamegraph",
+        "-d",
+        db.to_str().unwrap(),
+        "-t",
+        "all",
+        "--max-depth",
+        "1",
+    ]);
+    assert!(
+        output.status.success(),
+        "flamegraph (--max-depth 1) failed: {}",
+        lossy(&output.stderr)
+    );
+    let stdout = lossy(&output.stdout);
+    let stderr = lossy(&output.stderr);
+    assert_valid_folded_output(&stdout);
+    for line in stdout.lines() {
+        let frames = line.rsplit_once(' ').map(|(f, _)| f).unwrap_or(line);
+        assert!(
+            !frames.contains(';'),
+            "--max-depth 1 left a multi-frame stack: {line}"
+        );
+    }
+    assert!(stderr.contains("# Max depth: 1"), "{stderr}");
+    assert_eq!(
+        footer_count(&stderr, "Output samples"),
+        footer_count(&baseline_stderr, "Output samples"),
+        "merging by depth keeps every sample"
+    );
+    assert_eq!(footer_count(&stderr, "Matched samples"), baseline_matched);
+    assert!(
+        footer_count(&stderr, "Unique stacks") <= baseline_unique,
+        "merged stacks cannot outnumber the full fold"
     );
 }
 
@@ -1745,6 +1873,9 @@ fn test_analyze_commands() {
 
     eprintln!("  min-count...");
     test_flamegraph_with_min_count(&duckdb_path);
+
+    eprintln!("  top + max-depth...");
+    test_flamegraph_top_and_max_depth(&duckdb_path);
 
     eprintln!("  nonexistent database...");
     test_flamegraph_nonexistent_db(&duckdb_path);


### PR DESCRIPTION
**What changes.** `systing-analyze stacktrace flamegraph` gets `--top N` (a `LIMIT` inside the fold query) and `--max-depth D` (the depth cut inside the `GROUP BY` key), and it streams folded lines to stdout as DuckDB produces them instead of building every unique stack in memory three times before printing the first line. The stderr footer keeps `# Unique stacks:` as the exact total (counted before the cut) and adds `# Matched samples:` (the sample total of everything that passed the filters), `# Output stacks:` (how many were emitted) and `# Max depth:` when set; `# Output samples:` stays the sum over the printed rows. The MCP `flamegraph` tool keeps its shape, gains `max_depth`, and its metadata gains `matched_samples`.

**Why.** Without a bound, the process's memory grows with the trace's unique-stack count with no ceiling: each unique stack was held as a `Vec<String>` of frames, as a folded line, and again in the joined folded text. On whole-system traces from large hosts that is gigabytes on top of what DuckDB uses for the fold, and a consumer that only wants the top few thousand stacks pays for all of them. 6e55afe and 12c99e3 bounded DuckDB's side of the fold (memory limit, spill); this bounds the Rust side. Measured on synthetic traces (table below): the Rust-side excess is about 1 GiB per 300K unique stacks and about 2.7 GiB per 1M; with `--top 4096` it is gone and the fold returns in about a second instead of tens of seconds.

**What to decide.** (1) Footer semantics: `# Unique stacks:` stays the exact total, and `# Matched samples:` / `# Output stacks:` are new, so under `--top` a consumer can keep trace-wide denominators (matched samples, unique stacks) while cross-checking the printed rows against `# Output samples:`. The alternative is to make `# Unique stacks:` the emitted count; I kept the total so a truncated output still says how much it left out. (2) `--max-depth` keeps the ROOT-most D frames (frames are stored root→leaf; the prefix is what an icicle view aggregates on). Say so if you want the leaf side instead. (3) The CLI default stays unbounded (no change for existing users); the structured/MCP path keeps its default of 500, now applied as a `LIMIT` as well.

<details>
<summary>Evidence — synthetic traces, release build, peak RSS = ru_maxrss of the child</summary>

Synthetic DBs (only the tables the fold reads): 100K distinct frames; stacks of depth 20–60 (mean 40) with 5 shared root frames drawn from 100 root shapes and pseudo-random deeper frames; samples half uniform over all stacks (the long tail) and half over the first 1,000 (the head). Times are wall clock from spawn to exit with stdout drained by the measurement script; "first line" is when the first folded line arrived.

| trace | binary | flags | wall | first line | peak RSS | stdout lines |
|---|---|---|---|---|---|---|
| 300K unique stacks / 3M samples | v1.13.5 | — | 10.2 s | 8.9 s | 1918 MiB | 297,906 |
| 300K / 3M | this PR | — | 8.2 s | 1.3 s | 992 MiB | 297,906 |
| 300K / 3M | this PR | `--top 4096` | 0.52 s | 0.38 s | 997 MiB | 4,096 |
| 1M unique stacks / 10M samples | v1.13.5 | — | 35.0 s | 30.7 s | 6198 MiB | 993,238 |
| 1M / 10M | this PR | — | 26.2 s | 3.8 s | 3971 MiB | 993,238 |
| 1M / 10M | this PR | `--top 4096` | 1.11 s | 0.70 s | 3806 MiB | 4,096 |
| 1M / 10M | this PR | `--top 4096 --max-depth 64` | 1.09 s | 0.72 s | 3929 MiB | 4,096 |

The "this PR" peak is DuckDB's own working set for the fold: the test host has no cgroup limit, so DuckDB ran with `memory_limit=51200MiB` and used what it liked; under a cgroup limit it stays inside the fraction 6e55afe gives it and spills. The Rust side's share is now flat in the number of unique stacks.

Equivalence checks on the 300K trace: the set of folded lines is identical between v1.13.5 and this PR (sorted diff empty); `--top 4096` equals the first 4,096 lines of the unbounded stream; counts are non-increasing down the output.
</details>

<details>
<summary>Design notes</summary>

- The fold is a `WITH folded AS MATERIALIZED (...)` CTE so it can be both counted (`(SELECT COUNT(*) FROM folded)` = unique stacks, `(SELECT SUM(count) FROM folded)` = matched samples) and cut (`ORDER BY ... LIMIT N` = a top-N heap) from one aggregation. `COUNT(*) OVER ()` gives the same number but measured 3.4× the query time on the 1M trace (2.7 s vs 0.8 s); a separate count query would re-run the aggregation. The two scalar subqueries over the materialized CTE cost nothing measurable.
- The id→string conversion (`array_to_string` over `frame_ids`) sits in the SELECT outside the limited subquery, so it runs only for surviving rows. In the same SELECT as the LIMIT it runs for every folded row (measured 2.4 s vs 0.8 s).
- `--max-depth D` is `list_slice(frame_ids, 1, D)` as the GROUP BY key, so stacks that only differ deeper than D merge in the database and a top-N over the merged stacks is exact. A read-side truncation after a top-N is not: the heaviest merged stack can be made of many light full-depth stacks (`fold_top_n_over_merged_stacks_is_exact` pins the case).
- The sort is `count DESC, trace_id, frame_ids` (a total order), so equal-count stacks come out in the same order every run and `--top` picks the same set. The old query ordered by count only.
- The CLI prints the request-describing footer lines before the stream and the count lines after it; consumers key on the `# ...:` prefixes. `# Matched samples:` / `# Unique stacks:` describe everything that passed the filters; `# Output samples:` / `# Output stacks:` describe what was printed; the pairs differ only under `--top`.
- Still loaded in full: the frame-name table (one entry per unique frame in the trace, not per unique stack). Resolving names inside DuckDB for the surviving rows would remove it too; left as a follow-up unless it shows up as the next growth term.
</details>

**Tests.** Eight fold tests on an in-memory trace DB (order and tie-break, top-N keeps both totals, max-depth merges in the database and makes top-N exact, min-count applies before the totals, empty window, structured result equals the stream, zero bounds rejected), three query-shape tests, and one CLI case in the analyze e2e suite (`--top 1` and `--max-depth 1` against a recorded trace, footer pairs checked). Local: fmt clean, clippy `-D warnings` clean, `cargo test --lib` 508/0.

**Hazard precedent (repo history):** d913a2f introduced the frame-id interning the fold reads and the Rust-side name resolution this keeps; 6e55afe / 12c99e3 bounded DuckDB's memory and spill for the analyze path. None of them bounded the per-stack materialization in Rust; this change does. No BPF, no schema, no recorder, no hot capture path — analysis-side only.
