### PR TITLE
stack_recorder: use as_chunks for the fixed-size Python frame decode

### DIFF
--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -651,7 +651,9 @@ fn read_spill_record(reader: &mut BufReader<File>) -> Result<Option<(Stack, i32,
         .read_exact(&mut py_bytes)
         .context("reading stack spill record body")?;
     let py_stack = py_bytes
-        .chunks_exact(PY_FRAME_BYTES)
+        .as_chunks::<PY_FRAME_BYTES>()
+        .0
+        .iter()
         .map(|c| PyAddr {
             addr: crate::pystacks::types::StackWalkerFrame {
                 symbol_id: u64::from_le_bytes(c[0..8].try_into().unwrap()),


### PR DESCRIPTION
**What changes.** One expression in `src/stack_recorder.rs` (`read_spill_record`): `py_bytes.chunks_exact(PY_FRAME_BYTES)` becomes `py_bytes.as_chunks::<PY_FRAME_BYTES>().0.iter()`. Behaviour is unchanged — the buffer is allocated as a multiple of the 12-byte frame size, so neither form has a remainder, and the two `from_le_bytes` reads index the chunk exactly as before.

**Why.** Rust 1.98's clippy added `chunks_exact_to_as_chunks`, and the CI workflow tracks the `stable` toolchain, so every pull request's Clippy job is red on this one line right now regardless of what the PR touches (first seen on #204). Merging this first lets the open PRs go green on a CI re-run without rebases. `as_chunks` is stable since Rust 1.88; the crate's MSRV is 1.89.

**What to decide.** Whether you would rather pin the CI toolchain than follow new lints as they land — this PR does not touch `ci.yml`; it only fixes the line.

**Tests.** No new tests; the spill round-trip tests in `stack_recorder.rs` carry Python frames through this decode path and pass (30/30 in the module; workspace `cargo test --lib` unaffected). Local: fmt clean, clippy `--all-targets -D warnings` clean on the local toolchain (1.95 — which does not yet carry the new lint, so the CI run on this PR is the real check), release build clean.

**Hazard precedent:** analysis/decode-side only — no BPF, no schema, no hot capture path; the recorder's spill format is unchanged.
