### PR TITLE
Start the CPU stack sampler after every other BPF link is attached

### DIFF
--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -2511,21 +2511,28 @@ fn cycles_sample_period(target_freq_hz: u64) -> u64 {
     (max_hz / target_freq_hz).max(1)
 }
 
-fn setup_perf_events(
+/// Open the per-CPU clock sampling events (hardware cpu-cycles, falling back
+/// to the software cpu-clock inside a VM) and attach `systing_perf_event_clock`
+/// to them.
+///
+/// This runs LAST in the attach sequence — after `skel.attach()`, the
+/// USDT/uprobe probes and the memory-alloc uprobes — so the stack sampler
+/// never observes the tracer's own attach phase. Enabling a tracepoint,
+/// raw_tp or fentry link goes through `text_poke_bp`, whose IPI batches stall
+/// every CPU on a many-core host; a sampler that is already live records that
+/// stall (kworkers spinning on `text_mutex`, the IPI handlers themselves) as
+/// if it were the workload. On a 224-CPU host mid IPI storm the attach phase
+/// ran ~9 s and read as ~6 cores of lock contention in a 10 s capture.
+/// The capture window is unchanged: `--duration` starts counting after the
+/// whole attach sequence either way.
+fn attach_clock_sampler(
     skel: &mut SystingSystemSkel,
     opts: &Config,
-    counters: &PerfCounters,
-    perf_counter_names: &[String],
     num_cpus: u32,
-) -> Result<(
-    Vec<libbpf_rs::Link>,
-    Vec<PerfOpenEvents>,
-    ClockSamplingConfig,
-)> {
+) -> Result<(Vec<libbpf_rs::Link>, ClockSamplingConfig)> {
     use crate::perf;
 
     let mut perf_links = Vec::new();
-    let mut event_files_vec = Vec::new();
 
     // Clamp to avoid divide-by-zero for library callers that bypass the
     // clap range(1..) validator on --sample-freq.
@@ -2605,6 +2612,22 @@ fn setup_perf_events(
         perf_links.push(link);
     }
 
+    Ok((perf_links, clock_sampling))
+}
+
+/// Open the `--perf-counter` events (plus the `slots` events topdown counters
+/// need) and populate the `perf_counters` map the BPF side reads on context
+/// switches. Runs before `skel.attach()` so the map is populated before the
+/// first event that reads it; the clock sampler is attached separately and
+/// last (see [`attach_clock_sampler`]).
+fn setup_perf_counter_events(
+    skel: &mut SystingSystemSkel,
+    counters: &PerfCounters,
+    perf_counter_names: &[String],
+    num_cpus: u32,
+) -> Result<Vec<PerfOpenEvents>> {
+    let mut event_files_vec = Vec::new();
+
     // Determine if we need slots for topdown counters
     let need_slots = perf_counter_names
         .iter()
@@ -2660,7 +2683,7 @@ fn setup_perf_events(
         event_files_vec.push(slots_files);
     }
 
-    Ok((perf_links, event_files_vec, clock_sampling))
+    Ok(event_files_vec)
 }
 
 /// Returns PIDs to attach probes to with their resolved library paths.
@@ -3731,15 +3754,10 @@ pub fn systing(
             &task_info_tx,
         )?;
 
-        // Set up perf events (clock events and counter events)
-        let (_perf_links, _events_files, clock_sampling) =
-            setup_perf_events(&mut skel, &opts, &counters, &perf_counter_names, num_cpus)?;
-
-        // Record which event/period drives stack sampling so the trace's
-        // sysinfo row documents what each stack sample represents. Perf
-        // events are opened once per recording session, so the set cannot
-        // race or repeat.
-        let _ = recorder.clock_sampling.set(clock_sampling);
+        // Set up the perf counter events and populate the perf_counters map
+        // before anything that reads it is attached.
+        let _events_files =
+            setup_perf_counter_events(&mut skel, &counters, &perf_counter_names, num_cpus)?;
 
         skel.attach().with_context(|| {
             "Failed to attach BPF programs to tracepoints. Check if tracepoints are enabled."
@@ -3760,6 +3778,17 @@ pub fn systing(
         } else {
             Vec::new()
         };
+
+        // Every tracepoint, raw_tp, fentry, USDT and uprobe link is in place:
+        // start the CPU stack sampler now, so the capture never contains the
+        // tracer's own attach phase (see attach_clock_sampler).
+        let (_perf_links, clock_sampling) = attach_clock_sampler(&mut skel, &opts, num_cpus)?;
+
+        // Record which event/period drives stack sampling so the trace's
+        // sysinfo row documents what each stack sample represents. Perf
+        // events are opened once per recording session, so the set cannot
+        // race or repeat.
+        let _ = recorder.clock_sampling.set(clock_sampling);
 
         // Signal the traced child to exec now that BPF is fully attached.
         // All tracing is active, so we capture everything from exec onwards.


### PR DESCRIPTION
The CPU stack sampler now attaches after every other BPF link, so a capture no longer records systing's own attach phase. Before this change the perf_event sampler was attached first, ahead of `skel.attach()`, and it sampled the tracepoint/raw_tp/fentry enables — which go through `text_poke_bp` and, on a many-core host, stall every CPU in IPI batches. Those samples look like real workload: kworkers and other tasks spinning on `text_mutex`, plus the IPI handlers themselves.

**What the reviewer decides:** that the sampler should start once the whole attach sequence is done (tracepoints, raw_tp/fentry, USDT/uprobe probes, memory-alloc uprobes), and still before a traced command is signalled to exec.

**Why it matters.** On a 224-CPU host in the middle of an IPI storm (job-start TLB flushes plus expedited RCU), the attach phase ran for about 9 s of a 10 s capture and read as about 6 cores of lock contention. Downstream analysis flagged that capture as node lock contention when nothing on the node was contending. Normally the attach phase costs about 0.01 core per capture and is invisible; under an IPI storm it balloons by two to three orders of magnitude, which is exactly when a false contention reading does the most damage.

**What changes.**
- `setup_perf_events` is split: `setup_perf_counter_events` keeps the `--perf-counter` events and the `perf_counters` map population where they were (before `skel.attach()`, so the map is populated before anything reads it); the new `attach_clock_sampler` opens the clock sampling events (hardware cpu-cycles, falling back to the software cpu-clock inside a VM — the same fallback as before) and attaches `systing_perf_event_clock` to them.
- `attach_clock_sampler` is called last in the attach sequence, after `skel.attach()`, the USDT/uprobe probes and the memory-alloc uprobes, and before the traced child is signalled to exec. `recorder.clock_sampling` is recorded right after it, as before; it is only read when the trace's sysinfo row is written.
- No BPF change, no schema change, no new flag.

**What does not change.** The capture window: `--duration` starts counting after the whole attach sequence either way, so a 10 s capture still samples for 10 s. The sampling event, period and VM fallback are the same code, moved. The sched/irq/network recorders attach exactly as before.

**Validation.** `cargo fmt -- --check` and `cargo clippy --all-targets` clean on the branch; the integration suite runs in CI (the attach sequence is exercised by every trace test). The in-repo `rust-bpf-code-reviewer` pass is posted as a comment below: no critical issues; its one improvement (name the counter-only function for what it does) is applied.
