### PR TITLE
memory recorder: record page faults on non-x86 via the perf software page-fault event

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -432,7 +432,7 @@ enum memory_event_type {
 	MEMORY_MMAP,          // sys_exit_mmap - new VM area
 	MEMORY_MUNMAP,        // sys_exit_munmap (success-gated) - VM area removed
 	MEMORY_BRK,           // sys_exit_brk - heap boundary change
-	MEMORY_PAGE_FAULT,    // exceptions:page_fault_user - demand fault (sampled)
+	MEMORY_PAGE_FAULT,    // exceptions:page_fault_user (x86) / perf sw page-faults (other arches) - demand fault (sampled)
 	MEMORY_MM_SAMPLE,     // periodic mm_struct snapshot (from perf_event_clock)
 	MEMORY_ALLOC,         // uretprobe malloc/calloc/realloc/... - heap object allocated
 	MEMORY_FREE,          // uprobe free - heap object released
@@ -492,7 +492,7 @@ struct memory_event_header {
 	u64 addr;          // mmap ret / munmap addr / fault addr / brk new / hiwater_rss / alloc ret / thrash maj_flt
 	u64 size;          // mmap len / munmap len / rss size (bytes) / total_vm (bytes) / alloc bytes / thrash stall count
 	u32 member;        // rss_stat: enum memory_rss_member; mmap: prot; alloc: enum memory_alloc_op
-	u32 flags;         // mmap: MAP_* flags; page_fault: error_code; rss_stat: MEMORY_RSS_FLAG_*
+	u32 flags;         // mmap: MAP_* flags; page_fault: x86 error_code (0 on other arches); rss_stat: MEMORY_RSS_FLAG_*
 	u64 old_addr;      // realloc: previous pointer / thrash stall delay ns / map legs: signed rss-delta bytes as two's-complement (MEMORY_RSS_DELTA_ABSENT = no read); else 0
 	u64 kernel_stack_length;
 	u64 user_stack_length;
@@ -1053,7 +1053,8 @@ struct {
 	__type(value, struct memory_syscall_args);
 } memory_syscall_scratch SEC(".maps");
 
-/* Per-CPU counter for page-fault sampling. */
+/* Per-CPU counter for page-fault sampling (x86 tracepoint path only; on other
+ * arches the perf software event samples kernel-side via sample_period). */
 struct {
 	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
 	__uint(max_entries, 1);
@@ -5682,6 +5683,47 @@ int systing_page_fault_user(struct systing_pf_args *ctx)
 	record_task_info(&event->hdr.task, task);
 	event->hdr.addr = ctx->address;
 	event->hdr.flags = (u32)ctx->error_code;
+	memory_capture_stack(ctx, event, task, false);
+
+	bpf_ringbuf_submit(event, flags);
+	return 0;
+}
+#else
+/* Outside x86 there is no exceptions:page_fault_user tracepoint to attach to
+ * (trace_page_fault_user() is called from arch/x86/mm/fault.c and, from 6.18,
+ * arch/riscv/mm/fault.c; arch/arm64/mm/fault.c never fires it), so the fault
+ * leg rides the perf software event PERF_COUNT_SW_PAGE_FAULTS instead. The
+ * events are opened per CPU from userspace (attach_page_fault_sw_events in
+ * systing_core.rs) with exclude_kernel=1 — user-mode faults only, the same
+ * population the x86 tracepoint sees — and sample_period =
+ * memory_fault_sample_rate, so the kernel does the 1:N sampling and no BPF-side
+ * counter is needed. The program runs in the faulting task's own context (the
+ * software event fires synchronously from the fault path, not from an NMI or
+ * a timer), so it writes the memory ringbuf like every other memory program.
+ * ctx->addr is the faulting address (perf_sw_event(PERF_COUNT_SW_PAGE_FAULTS,
+ * 1, regs, address) in the arch fault handlers; the event is opened with
+ * PERF_SAMPLE_ADDR so the field reads 0, not stale stack, for a fault at
+ * address 0). The x86 error_code has no portable equivalent, so flags is 0 on
+ * this path; the user stack is walked from the sample's registers, i.e. from
+ * the faulting user frame. */
+SEC("perf_event")
+int systing_page_fault_sw(struct bpf_perf_event_data *ctx)
+{
+	struct task_struct *task = (struct task_struct *)bpf_get_current_task_btf();
+	if (!trace_task(task))
+		return 0;
+
+	long flags;
+	struct memory_event *event = reserve_memory_event(&flags);
+	if (!event)
+		return handle_missed_event(MISSED_MEMORY_EVENT);
+
+	event->hdr.type = MEMORY_PAGE_FAULT;
+	event->hdr.ts = bpf_ktime_get_boot_ns();
+	event->hdr.cpu = bpf_get_smp_processor_id();
+	record_task_info(&event->hdr.task, task);
+	event->hdr.addr = ctx->addr;
+	event->hdr.flags = 0;
 	memory_capture_stack(ctx, event, task, false);
 
 	bpf_ringbuf_submit(event, flags);

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -18,6 +18,19 @@ pub struct PerfHwEvent {
     pub event_config: u64,
     pub disabled: bool,
     pub need_slots: bool,
+    /// Count only user-mode occurrences (perf_event_attr.exclude_kernel).
+    /// Used by the page-fault software event so the fault leg sees the same
+    /// user-mode fault population on every arch that the x86
+    /// exceptions:page_fault_user tracepoint sees.
+    pub exclude_kernel: bool,
+    /// Request PERF_SAMPLE_ADDR in perf_event_attr.sample_type so the
+    /// sample's `addr` field is always defined when a BPF program attached to
+    /// the event reads it (`ctx->addr`): the kernel only stores the address a
+    /// software event was raised with when it is non-zero, and zeroes the
+    /// field for every other sample only if the event asked for it. The
+    /// page-fault software event sets this so a fault at address 0 reads as 0
+    /// rather than as whatever was on the stack.
+    pub sample_addr: bool,
     pub cpus: Vec<u32>,
 }
 
@@ -138,6 +151,17 @@ pub const PERF_COUNT_HW_STALLED_CYCLES_FRONTEND: u64 = 7;
 pub const PERF_COUNT_HW_STALLED_CYCLES_BACKEND: u64 = 8;
 
 pub const PERF_COUNT_SW_CPU_CLOCK: u64 = 0;
+/// Software page-fault counter: fires once per page fault in the faulting
+/// task's context, on every arch. Opened per CPU with `sample_period = N` it
+/// samples 1:N kernel-side; with `exclude_kernel` it counts user-mode faults
+/// only. The memory recorder's fault leg uses it where the x86-only
+/// exceptions:page_fault_user tracepoint does not exist.
+#[allow(dead_code)]
+pub const PERF_COUNT_SW_PAGE_FAULTS: u64 = 2;
+
+/// perf_event_attr.sample_type bit: include the sample address
+/// (enum perf_event_sample_format, PERF_SAMPLE_ADDR).
+pub const PERF_SAMPLE_ADDR: u64 = 1 << 3;
 
 extern "C" {
     fn syscall(number: libc::c_long, ...) -> libc::c_long;
@@ -255,6 +279,12 @@ impl PerfOpenEvents {
             }
             if hwevent.disabled {
                 attr.flags.set_disabled(1);
+            }
+            if hwevent.exclude_kernel {
+                attr.flags.set_exclude_kernel(1);
+            }
+            if hwevent.sample_addr {
+                attr.sample_type |= PERF_SAMPLE_ADDR;
             }
             for cpu in hwevent.cpus.iter() {
                 let group_fd = if hwevent.need_slots {

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -214,8 +214,15 @@ const MEMORY_BPF_PROGRAMS: &[&str] = &[
     "systing_munmap_exit",
     "systing_brk_enter",
     "systing_brk_exit",
+    // The fault leg has two attach paths, selected at build time: the
+    // exceptions:page_fault_user tracepoint on x86 (auto-attached by
+    // skel.attach), and the perf software page-fault event everywhere else
+    // (SEC("perf_event"), attached per CPU in attach_clock_sampler) — arm64
+    // never fires that tracepoint.
     #[cfg(target_arch = "x86_64")]
     "systing_page_fault_user",
+    #[cfg(not(target_arch = "x86_64"))]
+    "systing_page_fault_sw",
 ];
 
 /// Allocator uprobe programs. Listed here only so `enable_programs` loads them
@@ -2559,6 +2566,8 @@ fn attach_clock_sampler(
             },
             disabled: false,
             need_slots: false,
+            exclude_kernel: false,
+            sample_addr: false,
             cpus: (0..num_cpus).collect(),
         };
         let mut clock_sampling = if opts.sw_event {
@@ -2610,6 +2619,15 @@ fn attach_clock_sampler(
                 },
             )?;
         perf_links.push(link);
+    }
+
+    // Non-x86: the memory recorder's fault leg is a perf software event, not an
+    // auto-attached tracepoint (see attach_page_fault_sw_events). It rides this
+    // last attach slot — after every tracepoint, USDT and uprobe link, like the
+    // clock sampler — and its links live in the same `perf_links`.
+    #[cfg(not(target_arch = "x86_64"))]
+    if opts.memory {
+        attach_page_fault_sw_events(skel, opts, num_cpus, &mut perf_links)?;
     }
 
     Ok((perf_links, clock_sampling))
@@ -2684,6 +2702,56 @@ fn setup_perf_counter_events(
     }
 
     Ok(event_files_vec)
+}
+
+/// Memory recorder, fault leg, on arches without the x86-only
+/// exceptions:page_fault_user tracepoint: one PERF_COUNT_SW_PAGE_FAULTS event
+/// per CPU, user-mode faults only, sampled kernel-side 1:N, driving the
+/// systing_page_fault_sw program (the BPF side carries the context and
+/// semantics notes). Called from [`attach_clock_sampler`], so it attaches in
+/// the same last slot as the clock sampler; the links go into `perf_links`
+/// like the clock sampler's.
+#[cfg(not(target_arch = "x86_64"))]
+fn attach_page_fault_sw_events(
+    skel: &mut SystingSystemSkel,
+    opts: &Config,
+    num_cpus: u32,
+    perf_links: &mut Vec<libbpf_rs::Link>,
+) -> Result<()> {
+    use crate::perf;
+
+    let mut fault_files = PerfOpenEvents::default();
+    fault_files.add_hw_event(PerfHwEvent {
+        name: "page-faults".to_string(),
+        event_type: perf::PERF_TYPE_SOFTWARE,
+        event_config: perf::PERF_COUNT_SW_PAGE_FAULTS,
+        disabled: false,
+        need_slots: false,
+        exclude_kernel: true,
+        sample_addr: true,
+        cpus: (0..num_cpus).collect(),
+    })?;
+    // 0 or 1 means every fault (the x86 path's convention for
+    // memory_fault_sample_rate); a software event needs a non-zero period, so
+    // clamp.
+    let period = u64::from(opts.memory_fault_sample_rate).max(1);
+    fault_files.open_events(None, period).with_context(|| {
+        "Failed to open the software page-fault perf events for the memory recorder"
+    })?;
+    for (_, file) in fault_files {
+        let link = skel
+            .progs
+            .systing_page_fault_sw
+            .attach_perf_event_with_opts(
+                file.as_raw_fd(),
+                libbpf_rs::PerfEventOpts {
+                    cookie: 0,
+                    ..Default::default()
+                },
+            )?;
+        perf_links.push(link);
+    }
+    Ok(())
 }
 
 /// Returns PIDs to attach probes to with their resolved library paths.

--- a/tests/memory_recorder.rs
+++ b/tests/memory_recorder.rs
@@ -236,25 +236,37 @@ fn test_memory_recorder_e2e() {
     );
     eprintln!("    {} memory_map rows join to stack table", joined);
 
-    // --- Check: memory_fault has rows (x86_64 only) ---
-    #[cfg(target_arch = "x86_64")]
-    {
-        eprintln!("  memory_fault events (x86_64)...");
-        let fault_rows: i64 = conn
-            .query_row(
-                &format!("SELECT COUNT(*) FROM memory_fault WHERE utid IN {UTIDS_FOR_PID}"),
-                [child_pid],
-                |row| row.get(0),
-            )
-            .expect("Failed to query memory_fault");
-        assert!(
-            fault_rows > 0,
-            "[memory_fault] no page-fault rows for workload pid {child_pid}"
-        );
-        eprintln!("    {} page-fault events", fault_rows);
-    }
-    #[cfg(not(target_arch = "x86_64"))]
-    eprintln!("  memory_fault: skipped (non-x86_64)");
+    // --- Check: memory_fault has rows (every arch: the x86 tracepoint path or
+    // the perf software page-fault event elsewhere) ---
+    eprintln!("  memory_fault events...");
+    let fault_rows: i64 = conn
+        .query_row(
+            &format!("SELECT COUNT(*) FROM memory_fault WHERE utid IN {UTIDS_FOR_PID}"),
+            [child_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to query memory_fault");
+    assert!(
+        fault_rows > 0,
+        "[memory_fault] no page-fault rows for workload pid {child_pid}"
+    );
+    eprintln!("    {} page-fault events", fault_rows);
+    // The fault address is the one field both attach paths fill the same way;
+    // error_code is the x86 tracepoint's error_code and 0 on the software-event
+    // path, so only its presence is pinned here.
+    let fault_rows_with_addr: i64 = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*) FROM memory_fault WHERE utid IN {UTIDS_FOR_PID} AND addr != 0"
+            ),
+            [child_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to query memory_fault addr");
+    assert!(
+        fault_rows_with_addr > 0,
+        "[memory_fault] page-fault rows carry no fault address for workload pid {child_pid}"
+    );
 
     // --- Check: every memory_* utid joins to thread.utid ---
     eprintln!("  memory_*.utid -> thread.utid FK integrity...");


### PR DESCRIPTION
## Memory recorder: record page faults on aarch64 via the perf software page-fault event

The memory recorder's page-fault leg only worked on x86 because it attaches to the `exceptions:page_fault_user` tracepoint, and only x86 fires that tracepoint (arm64's `arch/arm64/mm/fault.c` never calls `trace_page_fault_user()`; riscv gained it in 6.18). On arm64 the program was compiled out and `memory_fault` stayed empty, with no error anywhere. This PR gives the fault leg a second attach path on non-x86 builds: one `PERF_COUNT_SW_PAGE_FAULTS` software perf event per CPU, user-mode faults only (`exclude_kernel`), sampled kernel-side with `sample_period = memory_fault_sample_rate`, driving a new `SEC("perf_event")` program that emits the same `MEMORY_PAGE_FAULT` event (fault address + user stack) as the x86 tracepoint program. The x86 path is unchanged.

**What you decide:**
1. `error_code` on the software-event path is **0**. The x86 tracepoint's `error_code` (present/write/user/instruction-fetch bits) has no portable equivalent in the software event. The alternative is two events per CPU (`PERF_COUNT_SW_PAGE_FAULTS_MIN` / `_MAJ`) with minor-vs-major encoded into `error_code`. I chose 0 because nothing reads `error_code` today (it is a column in `memory_fault` that no query or consumer uses) and the two-event form doubles the per-CPU event count for a field nobody uses. Say the word and I add the MIN/MAJ split.
2. Every non-x86 arch takes the software-event path, including riscv (which has the tracepoint from 6.18): one portable path for everything that is not x86, rather than a third variant.
3. Where the non-x86 fault sampler attaches: from `attach_clock_sampler`, i.e. in the LAST attach slot that #207 introduced for the CPU stack sampler (after `skel.attach()`, the USDT/uprobe probes and the memory-alloc uprobes). The x86 tracepoint leg keeps attaching inside `skel.attach()`. Both legs are live before `--duration` starts counting, so the capture window is the same either way; the difference is only that the arm64 fault sampler, like the clock sampler, never observes the tracer's own attach phase. The alternative — attaching it right after `skel.attach()` to mirror the x86 timing exactly — is a two-line move if you prefer it.

**Validation — x86 host; the real-arm64 run is still pending (last bullet):**
- BPF object compiled for both targets with clang 18 `-target bpf`: `__TARGET_ARCH_arm64` + `vmlinux_aarch64.h` → the object carries `systing_page_fault_sw` and no `systing_page_fault_user`; `__TARGET_ARCH_x86` → the inverse.
- x86, this tree (rebased onto v1.13.10): `cargo clippy --all-targets -D warnings` exit 0, `cargo fmt --check` clean, `cargo test --lib --bins` 516 + 11 + 0 + 28 passed, 0 failed.
- VM integration test `tests/memory_recorder.rs::test_memory_recorder_e2e` (qemu, 6.12 kernel, x86 tracepoint path as shipped): PASS, 7 passed / 0 failed / 1 filtered out, 830 s — run on this diff at base v1.13.5 before the rebase; the x86 path is untouched by the diff and by the rebase (v1.13.5→v1.13.10 touches the attach order, not the fault leg).
- The new software-event path itself, force-enabled on x86 by a scratch build that flips the arch `#if`/`cfg` (scratch only, not in this PR): it **compiles clean** — the full `cargo test` build of the flipped tree, including the BPF object, finished with no error twice today — but the VM run of that build **did not execute**: the VM test rig on my build host lost guest access to the checkout today (a host environment regression, tracked and being fixed separately), so the new program has not yet been through a kernel's verifier + `perf_event_open`/attach path + ringbuf → `memory_fault` on a running kernel. I run that leg as soon as the rig is back and post the result here as a comment; it does not depend on arm64 hardware.
- `tests/memory_recorder.rs`: the `memory_fault` assertion is no longer x86-gated (every arch must now produce fault rows), and it additionally pins that rows carry a non-zero fault address — the one field both attach paths fill the same way.
- **Not yet run: an actual arm64 kernel.** If you have one (a GB200/Grace node or an arm64 VM), `sudo cargo test --test memory_recorder -- --ignored test_memory_recorder_e2e` is the whole validation; otherwise the first continuous capture on an arm64 node with the memory recorder on will show `page_fault` rows where there were none. I will run it on any arm64 host you point me at.

### Mechanism notes (for the reviewer)
- `perf_sw_event(PERF_COUNT_SW_PAGE_FAULTS, 1, regs, addr)` fires synchronously in the faulting task's context from every arch's fault handler (arm64 `do_page_fault`, x86 `do_user_addr_fault`, riscv `handle_page_fault`) — not NMI, not a timer — and it fires once per fault exception, at the handler's entry before the per-VMA-lock / mmap-lock retry loop, so a fault that drops `mmap_lock` and retries inside the handler is counted once (the double-count concern with hooking `handle_mm_fault` does not arise; the `_MIN`/`_MAJ` pair in `mm_account_fault()` likewise accounts a retried fault once, at completion). The program's written-map set is a strict subset of the x86 tracepoint program's: the memory ringbuf (`reserve_memory_event`, `BPF_MAP_TYPE_RINGBUF` behind an array-of-maps lookup) and the missed-events `PERCPU_ARRAY` counter on ringbuf exhaustion; `trace_task()` runs first (the pids/cgroups scope filter, so a cgroup-scoped launch records only its own tasks' faults); no hash-map writes; no `LRU_HASH` map anywhere in the object. The CPU sampler program and its attach are untouched.
- The event is opened with `PERF_TYPE_SOFTWARE` / `PERF_COUNT_SW_PAGE_FAULTS` as constants, per CPU (`pid = -1`), `exclude_kernel = 1` (only faults taken in user mode — the same population `exceptions:page_fault_user` sees; `perf_exclude_event` drops kernel-mode samples for software events), and `PERF_SAMPLE_ADDR` in `sample_type` so `ctx->addr` is defined on every sample: the kernel stores the address a software event was raised with only when it is non-zero (`perf_sample_data_init`) and zeroes the field otherwise only if the event asked for it (`perf_prepare_sample`); without the bit a fault at address 0 would read stale stack through `ctx->addr`.
- Sampling: the kernel's `sample_period` does the 1:N (`perf_swevent_event` decrements `period_left` per fault and runs the program on overflow), replacing the BPF-side per-CPU counter on this path. `memory_fault_sample_rate` 0 or 1 means every fault on both paths (a software event needs a non-zero period, so the Rust side clamps to ≥1). One semantic difference, stated so it is not a surprise: here the 1:N denominator is all user-mode faults on that CPU, while x86 counts only traced tasks' faults (its counter sits after `trace_task()`). Same in expectation; per-workload sample counts can differ on a host where untraced tasks fault heavily.
- `ctx->addr` is the faulting address (`perf_sample_data_init(&data, addr, 0)` in `___perf_sw_event`; `pe_prog_convert_ctx_access` maps the field to `perf_sample_data.addr`), readable from `struct bpf_perf_event_data` on both vmlinux headers. The user stack is walked from the sample's registers (`bpf_get_stack` on a perf_event program without `PERF_SAMPLE_CALLCHAIN` falls back to `__bpf_get_stack(ctx->regs, …)`), i.e. from the faulting user frame — same as the tracepoint path; no kernel stack (`with_kernel=false`, as on x86 since `6fa35ed`). When the program returns 0, `__perf_event_overflow` returns early — no perf ring-buffer output, no signal, no wakeup.
- Hazard-precedent search (this repo's history): the only prior changes to the fault leg are `c08f3f6` (add), `6db1bc8` (review follow-ups) and `6fa35ed` (drop the kernel-stack unwind — preserved here); #207 (`090620ce`, v1.13.10) reordered the attach sequence without touching the fault leg and is what this path now rides. The NMI-context-sampler + LRU-hash hazard this repo's history records (#126, #171) does not apply: task-context program, ringbuf + per-CPU-array writes only, no LRU map in the object, sampler untouched. Per-fault cost on arm64 is the software-event hook plus the kernel's period decrement; the BPF program runs only on the sampled fault, as on x86.
- Files: `src/bpf/systing_system.bpf.c` (the `#else` program + comment lines), `src/perf.rs` (`PERF_COUNT_SW_PAGE_FAULTS`, `PERF_SAMPLE_ADDR`, `PerfHwEvent.exclude_kernel` / `.sample_addr` honoured in `open_events`), `src/systing_core.rs` (program list + per-CPU open/attach from `attach_clock_sampler`, non-x86 only), `tests/memory_recorder.rs`. No schema change (no new field, `SCHEMA_VERSION` untouched); no `Cargo.toml` version touch.
