### PR TITLE
Match --cgroup targets by ancestry, not a start-time snapshot of leaf ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,11 @@ the process going off the CPU or going on the CPU in addition to the process
 being traced, so you will miss events for the unwanted process leaving the CPU.
 Perfetto handles this appropriately, but it looks odd.
 
+`--cgroup <path>` traces every task whose cgroup is that cgroup or any cgroup
+below it, including cgroups created after the trace started (membership is
+decided by the kernel's `bpf_task_under_cgroup()`); it requires **Linux kernel
+6.5 or newer** and fails with a clear error on older kernels.
+
 `--trace-event` - This will add an `instant` track event for each event that
 this tool captures.  The format is "<trace type>:<optional
 info>:<class>:<name>".  This is most easily obtained by running

--- a/README.md
+++ b/README.md
@@ -254,9 +254,13 @@ being traced, so you will miss events for the unwanted process leaving the CPU.
 Perfetto handles this appropriately, but it looks odd.
 
 `--cgroup <path>` traces every task whose cgroup is that cgroup or any cgroup
-below it, including cgroups created after the trace started (membership is
-decided by the kernel's `bpf_task_under_cgroup()`); it requires **Linux kernel
-6.5 or newer** and fails with a clear error on older kernels.
+below it, including cgroups created after the trace started — membership is
+decided by the kernel's `bpf_task_under_cgroup()`, which needs **Linux kernel
+6.5 or newer**. On older kernels (no `bpf_task_under_cgroup` in the kernel's
+BTF) systing falls back to matching a snapshot of the target's cgroups taken
+when the trace starts, so cgroups created under the target afterwards are not
+traced; the mode in use is printed at start. Setting
+`SYSTING_CGROUP_FILTER_LEGACY=1` forces the fallback on any kernel.
 
 `--trace-event` - This will add an `instant` track event for each event that
 this tool captures.  The format is "<trace type>:<optional

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -103,6 +103,12 @@ const volatile struct {
 				 * cgroup_targets / cgroup_target_refs maps;
 				 * rodata so the filter loops are
 				 * verifier-bounded. */
+	u32 cgroup_match_kernel; /* 1: the kernel decides --cgroup membership
+				  * (cgroup_targets / cgroup_target_refs);
+				  * 0: legacy exact match of the task's own
+				  * cgroup id against the cgroups map (see the
+				  * map comments). Rodata, so the branch not
+				  * taken is dead code to the verifier. */
 	u32 no_stack_traces;
 	u32 no_cpu_stack_traces;
 	u32 no_sleep_stack_traces;
@@ -642,6 +648,23 @@ struct {
 	__type(value, struct cgroup_target_ref);
 	__uint(max_entries, 1);
 } cgroup_target_refs SEC(".maps");
+
+/*
+ * Legacy --cgroup matching, used when the running kernel's BTF does not
+ * export bpf_task_under_cgroup (before 6.5) or when SYSTING_CGROUP_FILTER_LEGACY
+ * forces it: userspace loads the cgroup ids of each target and of every
+ * descendant that exists when the trace starts, sized to that count, and the
+ * tracing programs match the task's own cgroup id against the set exactly.
+ * Cgroups created under a target after the trace started are not in the set
+ * and their tasks are not traced - the limitation the kernel-side matching
+ * above removes. Written by userspace only, lookup-only from BPF.
+ */
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__type(key, u64);
+	__type(value, u8);
+	__uint(max_entries, 1);
+} cgroups SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -1716,6 +1739,18 @@ static bool should_filter_systing(struct task_struct *task)
 	return false;
 }
 
+/*
+ * Legacy --cgroup matching (cgroup_match_kernel == 0): the task's own cgroup
+ * id looked up in the start-time set userspace loaded into the cgroups map.
+ * Any program type, any kernel; misses cgroups created after the trace
+ * started (see the cgroups map comment).
+ */
+static bool task_in_legacy_cgroup_set(struct task_struct *task)
+{
+	u64 cgid = task_cg_id(task);
+	return bpf_map_lookup_elem(&cgroups, &cgid) != NULL;
+}
+
 /* Every filter except --cgroup; see trace_task() and trace_task_btf(). */
 static bool trace_task_common(struct task_struct *task)
 {
@@ -1743,8 +1778,11 @@ static bool trace_task(struct task_struct *task)
 {
 	if (!trace_task_common(task))
 		return false;
-	if (tool_config.filter_cgroup && !current_in_cgroup_filter())
-		return false;
+	if (tool_config.filter_cgroup) {
+		if (tool_config.cgroup_match_kernel)
+			return current_in_cgroup_filter();
+		return task_in_legacy_cgroup_set(task);
+	}
 	return true;
 }
 
@@ -1760,8 +1798,11 @@ static bool trace_task_btf(struct task_struct *task)
 {
 	if (!trace_task_common(task))
 		return false;
-	if (tool_config.filter_cgroup && !task_in_cgroup_filter(task))
-		return false;
+	if (tool_config.filter_cgroup) {
+		if (tool_config.cgroup_match_kernel)
+			return task_in_cgroup_filter(task);
+		return task_in_legacy_cgroup_set(task);
+	}
 	return true;
 }
 

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -580,6 +580,16 @@ struct {
 	__uint(max_entries, 10240);
 } perf_counters SEC(".maps");
 
+/*
+ * The --cgroup filter set: cgroup v2 ids (dfl_cgrp->kn->id, the directory
+ * inode) of each --cgroup target. Written by userspace before tracing starts,
+ * read-only from BPF (lookups only, from both the perf_event sampler and the
+ * tp_btf/fentry programs, so it must stay a plain preallocated HASH — never
+ * LRU). A task matches when its own cgroup OR any ancestor is in the set (see
+ * task_in_cgroup_filter()); userspace only enumerates descendants into this
+ * map under kernel lockdown, where the ancestor walk's probe reads are
+ * unavailable. Sized by userspace to the ids it loads.
+ */
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__type(key, u64);
@@ -1454,6 +1464,98 @@ static u64 task_cg_id(struct task_struct *task)
 }
 
 /*
+ * CO-RE flavor type for kernels < 6.1, where struct cgroup carried its
+ * ancestors' cgroup ids directly (u64 ancestor_ids[], indexed by level) instead
+ * of the struct cgroup *ancestors[] pointer array that replaced it in 6.1. The
+ * ___pre61 suffix is ignored by CO-RE type matching, so this matches the
+ * kernel's actual struct cgroup at runtime.
+ */
+struct cgroup___pre61 {
+	u64 ancestor_ids[0];
+};
+
+/*
+ * Deepest cgroup v2 nesting level the --cgroup ancestry walk inspects. Real
+ * hierarchies are shallow (a Kubernetes container leaf sits at level 4-6; a
+ * nested runtime inside it adds a few more); the bound keeps the walk a
+ * verifier-bounded loop. A task deeper than this is still matched on its own
+ * cgroup id and on its first CGROUP_FILTER_MAX_DEPTH ancestors.
+ */
+#define CGROUP_FILTER_MAX_DEPTH 16
+
+/*
+ * --cgroup filter: is the task's own cgroup, or any ancestor of it, one of the
+ * --cgroup targets?
+ *
+ * Matching by ancestry rather than by exact id keeps the filter correct for
+ * cgroups created AFTER the trace started - a nested container runtime making
+ * cgroups inside a pod, a systemd unit spawning transient scopes. The task's
+ * leaf cgroup may be brand new, but its ancestor chain still reaches the
+ * target. Userspace therefore loads only the targets' own ids into the
+ * `cgroups` map, not a start-time snapshot of their descendants (which by
+ * construction could never contain a cgroup that did not exist yet).
+ *
+ * The walk probe-reads cgrp->ancestors[i] (cgrp->ancestor_ids[i] before 6.1)
+ * from a CO-RE-relocated array base: ancestors[] is a flexible array member,
+ * and the verifier does not accept a direct BTF load of its pointer elements
+ * past the struct's declared size, so each element is read with
+ * bpf_probe_read_kernel at an explicit offset. Probe reads are restricted under
+ * kernel lockdown confidentiality mode; there the walk is skipped and
+ * userspace enumerates each target's descendants at start instead (the
+ * pre-ancestry behaviour, with its known start-time-snapshot limitation).
+ *
+ * Cost, paid only when --cgroup is set: one hash lookup, plus at most
+ * level x (up to 3 probe reads + 1 hash lookup) when the task is not directly
+ * in a target. Lookups only - this map is never written from BPF, so it is
+ * safe from both the perf_event (NMI) sampler and the tp_btf/fentry programs.
+ */
+static bool task_in_cgroup_filter(struct task_struct *task)
+{
+	struct cgroup *cgrp = task->cgroups->dfl_cgrp;
+	u64 cgid = cgrp->kn->id;
+
+	/* The task sits directly in a target (or, under lockdown, in one of the
+	 * pre-enumerated descendants). */
+	if (bpf_map_lookup_elem(&cgroups, &cgid))
+		return true;
+	if (tool_config.confidentiality_mode)
+		return false;
+
+	/* ancestors[level] is the cgroup itself, checked above; walk the proper
+	 * ancestors, root first. */
+	int level = cgrp->level;
+	if (level > CGROUP_FILTER_MAX_DEPTH)
+		level = CGROUP_FILTER_MAX_DEPTH;
+
+	if (bpf_core_field_exists(cgrp->ancestors)) {
+		/* >= 6.1: struct cgroup *ancestors[], one pointer per level. */
+		struct cgroup **ancestors =
+			(void *)cgrp + bpf_core_field_offset(cgrp->ancestors);
+		for (int i = 0; i < CGROUP_FILTER_MAX_DEPTH && i < level; i++) {
+			struct cgroup *anc;
+			if (bpf_probe_read_kernel(&anc, sizeof(anc), &ancestors[i]))
+				break;
+			u64 id = BPF_CORE_READ(anc, kn, id);
+			if (id && bpf_map_lookup_elem(&cgroups, &id))
+				return true;
+		}
+	} else {
+		/* < 6.1: u64 ancestor_ids[], the cgroup id itself per level. */
+		struct cgroup___pre61 *old = (void *)cgrp;
+		u64 *ancestor_ids =
+			(void *)cgrp + bpf_core_field_offset(old->ancestor_ids);
+		for (int i = 0; i < CGROUP_FILTER_MAX_DEPTH && i < level; i++) {
+			u64 id;
+			if (bpf_probe_read_kernel(&id, sizeof(id), &ancestor_ids[i]))
+				break;
+			if (id && bpf_map_lookup_elem(&cgroups, &id))
+				return true;
+		}
+	}
+	return false;
+}
+
+/*
  * CO-RE flavor type for kernels < 6.18 that have icsk_timeout as a separate field.
  * The ___pre618 suffix is ignored by CO-RE type matching, so this matches the
  * kernel's actual struct inet_connection_sock at runtime.
@@ -1562,11 +1664,8 @@ static bool trace_task(struct task_struct *task)
 		if (bpf_map_lookup_elem(&pids, &pid) == NULL)
 			return false;
 	}
-	if (tool_config.filter_cgroup) {
-		u64 cgid = task_cg_id(task);
-		if (bpf_map_lookup_elem(&cgroups, &cgid) == NULL)
-			return false;
-	}
+	if (tool_config.filter_cgroup && !task_in_cgroup_filter(task))
+		return false;
 	return true;
 }
 

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -99,6 +99,10 @@ _Static_assert(sizeof(struct systing_stack_build_id) ==
 const volatile struct {
 	u32 filter_pid;
 	u32 filter_cgroup;
+	u32 num_cgroup_targets; /* --cgroup arguments = filled slots of the
+				 * cgroup_targets / cgroup_target_refs maps;
+				 * rodata so the filter loops are
+				 * verifier-bounded. */
 	u32 no_stack_traces;
 	u32 no_cpu_stack_traces;
 	u32 no_sleep_stack_traces;
@@ -581,21 +585,63 @@ struct {
 } perf_counters SEC(".maps");
 
 /*
- * The --cgroup filter set: cgroup v2 ids (dfl_cgrp->kn->id, the directory
- * inode) of each --cgroup target. Written by userspace before tracing starts,
- * read-only from BPF (lookups only, from both the perf_event sampler and the
- * tp_btf/fentry programs, so it must stay a plain preallocated HASH — never
- * LRU). A task matches when its own cgroup OR any ancestor is in the set (see
- * task_in_cgroup_filter()); userspace only enumerates descendants into this
- * map under kernel lockdown, where the ancestor walk's probe reads are
- * unavailable. Sized by userspace to the ids it loads.
+ * --cgroup filter targets: one slot per --cgroup argument in each of the two
+ * maps below, both filled by userspace before tracing starts and only ever
+ * READ from the tracing programs (no BPF-side writer in any program that runs
+ * in NMI or IRQ context, nothing LRU). Sized by userspace to the number of
+ * --cgroup arguments, at most MAX_CGROUP_TARGETS.
+ *
+ * The matching is the kernel's own: task_under_cgroup_hierarchy(), "is the
+ * task's cgroup the target or somewhere below it", which is what makes
+ * cgroups created AFTER the trace started (a nested container runtime making
+ * cgroups inside a pod, a transient systemd scope) match too. Two entry
+ * points into it exist and we need both:
+ *
+ *   cgroup_targets      BPF_MAP_TYPE_CGROUP_ARRAY of the target directory fds
+ *                       (the kernel holds a cgroup reference per slot).
+ *                       bpf_current_task_under_cgroup(map, idx) tests CURRENT
+ *                       against a slot: a READ_ONCE of the slot plus an
+ *                       ancestors[] compare, lock-free and NMI-safe, available
+ *                       to every tracing program type since 4.8. trace_task()
+ *                       uses it - all of its callers outside the sched
+ *                       tracepoints pass current.
+ *
+ *   cgroup_target_refs  the same targets as referenced struct cgroup kptrs,
+ *                       for bpf_task_under_cgroup(task, cgrp) on a task that
+ *                       is NOT current: the switched-in task, a woken task, a
+ *                       migrating one. Only TRACING programs (tp_btf) may call
+ *                       that kfunc on 6.6 and 6.12 kernels - 6.6 registers the
+ *                       generic kfuncs for TRACING alone, 6.12 adds tracepoint
+ *                       and perf_event but never kprobe or raw_tracepoint - so
+ *                       it cannot replace the helper above, and the kfunc
+ *                       needs a trusted cgroup pointer, which
+ *                       bpf_cgroup_from_id() must not produce from IRQ or NMI
+ *                       context (it takes kernfs_idr_lock on 6.6). The
+ *                       references are therefore taken once, in process
+ *                       context, by systing_cgroup_target_add below and read
+ *                       under bpf_rcu_read_lock() by task_in_cgroup_filter().
  */
+#define MAX_CGROUP_TARGETS 64
+
+struct cgroup_target_ref {
+	struct cgroup __kptr *cgrp;
+	u64 id; /* the target's cgroup id (kn->id), set with the reference so
+		 * userspace can confirm the slot was filled */
+};
+
 struct {
-	__uint(type, BPF_MAP_TYPE_HASH);
-	__type(key, u64);
-	__type(value, u8);
-	__uint(max_entries, 10240);
-} cgroups SEC(".maps");
+	__uint(type, BPF_MAP_TYPE_CGROUP_ARRAY);
+	__type(key, u32);
+	__type(value, u32);
+	__uint(max_entries, 1);
+} cgroup_targets SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__type(key, u32);
+	__type(value, struct cgroup_target_ref);
+	__uint(max_entries, 1);
+} cgroup_target_refs SEC(".maps");
 
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -1464,95 +1510,114 @@ static u64 task_cg_id(struct task_struct *task)
 }
 
 /*
- * CO-RE flavor type for kernels < 6.1, where struct cgroup carried its
- * ancestors' cgroup ids directly (u64 ancestor_ids[], indexed by level) instead
- * of the struct cgroup *ancestors[] pointer array that replaced it in 6.1. The
- * ___pre61 suffix is ignored by CO-RE type matching, so this matches the
- * kernel's actual struct cgroup at runtime.
+ * --cgroup filter for the CURRENT task, from any program type. The helper runs
+ * the kernel's task_under_cgroup_hierarchy() on current against each target
+ * slot of cgroup_targets (see the map comment): 1 when current's cgroup is the
+ * target or below it, 0 when not, negative for an unfilled slot. Lock-free and
+ * NMI-safe, so the perf_event sampler may call it like everything else.
  */
-struct cgroup___pre61 {
-	u64 ancestor_ids[0];
-};
+static bool current_in_cgroup_filter(void)
+{
+	for (u32 i = 0; i < MAX_CGROUP_TARGETS; i++) {
+		if (i >= tool_config.num_cgroup_targets)
+			break;
+		if (bpf_current_task_under_cgroup(&cgroup_targets, i) == 1)
+			return true;
+	}
+	return false;
+}
 
 /*
- * Deepest cgroup v2 nesting level the --cgroup ancestry walk inspects. Real
- * hierarchies are shallow (a Kubernetes container leaf sits at level 4-6; a
- * nested runtime inside it adds a few more); the bound keeps the walk a
- * verifier-bounded loop. A task deeper than this is still matched on its own
- * cgroup id and on its first CGROUP_FILTER_MAX_DEPTH ancestors.
- */
-#define CGROUP_FILTER_MAX_DEPTH 16
-
-/*
- * --cgroup filter: is the task's own cgroup, or any ancestor of it, one of the
- * --cgroup targets?
+ * --cgroup filter for ANY task, from tp_btf programs only: the sched
+ * tracepoints test tasks other than current (the switched-in task, a woken
+ * task, a migrating one). bpf_task_under_cgroup() is the same kernel predicate
+ * as the helper above, taking the task and a trusted cgroup pointer; the
+ * pointer is the reference systing_cgroup_target_add parked in
+ * cgroup_target_refs, loaded under bpf_rcu_read_lock() (struct cgroup is an
+ * RCU-protected kptr type, so the verifier accepts the load as trusted for
+ * this KF_RCU kfunc). The rcu section holds no lock and takes no reference:
+ * one map lookup and one ancestors[] compare per target.
  *
- * Matching by ancestry rather than by exact id keeps the filter correct for
- * cgroups created AFTER the trace started - a nested container runtime making
- * cgroups inside a pod, a systemd unit spawning transient scopes. The task's
- * leaf cgroup may be brand new, but its ancestor chain still reaches the
- * target. Userspace therefore loads only the targets' own ids into the
- * `cgroups` map, not a start-time snapshot of their descendants (which by
- * construction could never contain a cgroup that did not exist yet).
- *
- * The walk probe-reads cgrp->ancestors[i] (cgrp->ancestor_ids[i] before 6.1)
- * from a CO-RE-relocated array base: ancestors[] is a flexible array member,
- * and the verifier does not accept a direct BTF load of its pointer elements
- * past the struct's declared size, so each element is read with
- * bpf_probe_read_kernel at an explicit offset. Probe reads are restricted under
- * kernel lockdown confidentiality mode; there the walk is skipped and
- * userspace enumerates each target's descendants at start instead (the
- * pre-ancestry behaviour, with its known start-time-snapshot limitation).
- *
- * Cost, paid only when --cgroup is set: one hash lookup, plus at most
- * level x (up to 3 probe reads + 1 hash lookup) when the task is not directly
- * in a target. Lookups only - this map is never written from BPF, so it is
- * safe from both the perf_event (NMI) sampler and the tp_btf/fentry programs.
+ * Kernels without the kfunc (< 6.5) never get here - userspace refuses
+ * --cgroup on them - and bpf_ksym_exists() keeps every program that inlines
+ * this loadable there for traces without --cgroup.
  */
 static bool task_in_cgroup_filter(struct task_struct *task)
 {
-	struct cgroup *cgrp = task->cgroups->dfl_cgrp;
-	u64 cgid = cgrp->kn->id;
+	bool hit = false;
 
-	/* The task sits directly in a target (or, under lockdown, in one of the
-	 * pre-enumerated descendants). */
-	if (bpf_map_lookup_elem(&cgroups, &cgid))
-		return true;
-	if (tool_config.confidentiality_mode)
+	if (!bpf_ksym_exists(bpf_task_under_cgroup))
 		return false;
 
-	/* ancestors[level] is the cgroup itself, checked above; walk the proper
-	 * ancestors, root first. */
-	int level = cgrp->level;
-	if (level > CGROUP_FILTER_MAX_DEPTH)
-		level = CGROUP_FILTER_MAX_DEPTH;
+	bpf_rcu_read_lock();
+	for (u32 i = 0; i < MAX_CGROUP_TARGETS && !hit; i++) {
+		struct cgroup_target_ref *ref;
+		struct cgroup *cgrp;
+		/* A separate key keeps the loop counter in a register; passing &i
+		 * to the lookup spills it and the verifier loses its bound. */
+		u32 key = i;
 
-	if (bpf_core_field_exists(cgrp->ancestors)) {
-		/* >= 6.1: struct cgroup *ancestors[], one pointer per level. */
-		struct cgroup **ancestors =
-			(void *)cgrp + bpf_core_field_offset(cgrp->ancestors);
-		for (int i = 0; i < CGROUP_FILTER_MAX_DEPTH && i < level; i++) {
-			struct cgroup *anc;
-			if (bpf_probe_read_kernel(&anc, sizeof(anc), &ancestors[i]))
-				break;
-			u64 id = BPF_CORE_READ(anc, kn, id);
-			if (id && bpf_map_lookup_elem(&cgroups, &id))
-				return true;
-		}
-	} else {
-		/* < 6.1: u64 ancestor_ids[], the cgroup id itself per level. */
-		struct cgroup___pre61 *old = (void *)cgrp;
-		u64 *ancestor_ids =
-			(void *)cgrp + bpf_core_field_offset(old->ancestor_ids);
-		for (int i = 0; i < CGROUP_FILTER_MAX_DEPTH && i < level; i++) {
-			u64 id;
-			if (bpf_probe_read_kernel(&id, sizeof(id), &ancestor_ids[i]))
-				break;
-			if (id && bpf_map_lookup_elem(&cgroups, &id))
-				return true;
-		}
+		if (i >= tool_config.num_cgroup_targets)
+			break;
+		ref = bpf_map_lookup_elem(&cgroup_target_refs, &key);
+		if (!ref)
+			break;
+		cgrp = ref->cgrp;
+		if (cgrp && bpf_task_under_cgroup(task, cgrp) == 1)
+			hit = true;
 	}
-	return false;
+	bpf_rcu_read_unlock();
+	return hit;
+}
+
+/*
+ * Hands a --cgroup target to BPF as a referenced struct cgroup pointer.
+ *
+ * Userspace runs this once per target, before tracing starts, through a cgroup
+ * iterator pinned to the target with BPF_CGROUP_ITER_SELF_ONLY, so the program
+ * is called exactly once with ctx->cgroup = the target (and once more with
+ * NULL, the iterator's end). It runs in the context of the read(2) on the
+ * iterator fd: process context, where bpf_cgroup_from_id() may take
+ * kernfs_idr_lock. The reference goes into the first free slot of
+ * cgroup_target_refs together with the cgroup id, which is what userspace
+ * checks afterwards. Taking the reference by id rather than by acquiring
+ * ctx->cgroup keeps this loadable on 6.6, where the iterator's cgroup argument
+ * is not yet a trusted pointer. The references are dropped with the map when
+ * systing exits. Autoloaded only with --cgroup.
+ */
+SEC("iter/cgroup")
+int systing_cgroup_target_add(struct bpf_iter__cgroup *ctx)
+{
+	struct cgroup *cgrp = ctx->cgroup;
+	u64 id;
+
+	if (!cgrp)
+		return 0;
+	id = cgrp->kn->id;
+	if (!id)
+		return 0;
+
+	for (u32 i = 0; i < MAX_CGROUP_TARGETS; i++) {
+		struct cgroup_target_ref *slot;
+		struct cgroup *ref;
+		u32 key = i; /* see task_in_cgroup_filter() */
+
+		slot = bpf_map_lookup_elem(&cgroup_target_refs, &key);
+		if (!slot)
+			break;
+		if (slot->id)
+			continue;
+
+		ref = bpf_cgroup_from_id(id);
+		if (!ref)
+			break;
+		ref = bpf_kptr_xchg(&slot->cgrp, ref);
+		if (ref)
+			bpf_cgroup_release(ref);
+		slot->id = id;
+		break;
+	}
+	return 0;
 }
 
 /*
@@ -1651,7 +1716,8 @@ static bool should_filter_systing(struct task_struct *task)
 	return false;
 }
 
-static bool trace_task(struct task_struct *task)
+/* Every filter except --cgroup; see trace_task() and trace_task_btf(). */
+static bool trace_task_common(struct task_struct *task)
 {
 	if (!tracing_enabled)
 		return false;
@@ -1664,6 +1730,36 @@ static bool trace_task(struct task_struct *task)
 		if (bpf_map_lookup_elem(&pids, &pid) == NULL)
 			return false;
 	}
+	return true;
+}
+
+/*
+ * Is this task traced? For callers that pass current (every program outside
+ * the sched tracepoints: the --cgroup test here is on current, through the
+ * helper every program type may call). A caller in a tp_btf program that
+ * tests a task other than current uses trace_task_btf() instead.
+ */
+static bool trace_task(struct task_struct *task)
+{
+	if (!trace_task_common(task))
+		return false;
+	if (tool_config.filter_cgroup && !current_in_cgroup_filter())
+		return false;
+	return true;
+}
+
+/*
+ * trace_task() for tp_btf programs, where the task need not be current (the
+ * switched-in task, a wakee, a migrating task, a forked child's parent): the
+ * --cgroup test is bpf_task_under_cgroup() on the task itself. tp_btf only -
+ * the kfunc does not verify in kprobe or raw_tracepoint programs on any
+ * kernel, nor in tracepoint or perf_event programs before 6.12 (see the
+ * cgroup_targets comment).
+ */
+static bool trace_task_btf(struct task_struct *task)
+{
+	if (!trace_task_common(task))
+		return false;
 	if (tool_config.filter_cgroup && !task_in_cgroup_filter(task))
 		return false;
 	return true;
@@ -1960,7 +2056,7 @@ static int handle_sched_wakeup_new(struct task_struct *task)
 {
 	struct task_struct *cur = (struct task_struct *)bpf_get_current_task_btf();
 
-	if (!trace_task(cur) && !trace_task(task))
+	if (!trace_task_btf(cur) && !trace_task_btf(task))
 		return 0;
 	return handle_wakeup(cur, task, SCHED_WAKEUP_NEW);
 }
@@ -1989,7 +2085,7 @@ static int handle_sched_switch(void *ctx, bool preempt, struct task_struct *prev
 
 	u64 ts = bpf_ktime_get_boot_ns();
 
-	if (!trace_task(prev) && !trace_task(next))
+	if (!trace_task_btf(prev) && !trace_task_btf(next))
 		return 0;
 
 	/*
@@ -2074,7 +2170,7 @@ static int handle_sched_waking(struct task_struct *task)
 {
 	struct task_struct *cur = (struct task_struct *)bpf_get_current_task_btf();
 
-	if (!trace_task(cur) && !trace_task(task))
+	if (!trace_task_btf(cur) && !trace_task_btf(task))
 		return 0;
 	return handle_wakeup(cur, task, SCHED_WAKING);
 }
@@ -2103,7 +2199,7 @@ static int handle_sched_migrate(struct task_struct *task, int dest_cpu)
 	long flags;
 	u64 ts = bpf_ktime_get_boot_ns();
 
-	if (!trace_task(task))
+	if (!trace_task_btf(task))
 		return 0;
 	event = reserve_task_event(&flags);
 	if (!event)
@@ -2130,7 +2226,7 @@ static int handle_sched_process_exit(struct task_struct *task)
 	long flags;
 	u64 ts = bpf_ktime_get_boot_ns();
 
-	if (!trace_task(task))
+	if (!trace_task_btf(task))
 		return 0;
 
 #ifdef SYSTING_PYSTACKS
@@ -2174,7 +2270,7 @@ static int handle_sched_process_fork(struct task_struct *parent,
 				     struct task_struct *child)
 {
 	// Check if parent is being traced
-	if (!trace_task(parent))
+	if (!trace_task_btf(parent))
 		return 0;
 
 	// Add child to the pids map so we trace it too
@@ -2229,7 +2325,7 @@ int BPF_PROG(systing_sched_process_exec, struct task_struct *task,
 {
 	if (!tool_config.collect_pystacks)
 		return 0;
-	if (!trace_task(task))
+	if (!trace_task_btf(task))
 		return 0;
 
 	/*

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -111,13 +111,13 @@ pub fn build_cgroup_id_map() -> HashMap<u64, String> {
     map
 }
 
-/// The cgroup id (directory inode, matching the BPF `dfl_cgrp->kn->id`) of the
-/// cgroup at `path`.
+/// The cgroup id (directory inode, matching the kernel's `cgroup->kn->id`) of
+/// the cgroup at `path`.
 ///
-/// This is what the `--cgroup` filter loads per target: the BPF side matches a
-/// task whose cgroup is the target or has the target among its ancestors, so
-/// the target's own id is all it needs — its subtree is never enumerated, and
-/// cgroups created under the target after the trace starts are matched too.
+/// The `--cgroup` filter keys each target by it: the kernel decides membership
+/// (a task's cgroup is the target or somewhere below it, cgroups created after
+/// the trace started included), so the target's own id is all userspace ever
+/// resolves — its subtree is never enumerated.
 ///
 /// Failure to stat `path`, or `path` not being a directory, is reported to the
 /// caller so an invalid `--cgroup` argument is a clear error rather than a
@@ -133,38 +133,12 @@ pub fn cgroup_id(path: &Path) -> io::Result<u64> {
     Ok(meta.ino())
 }
 
-/// Collect the cgroup id (directory inode) of `path` and of every cgroup nested
-/// beneath it in the cgroup2 hierarchy.
-///
-/// This is the `--cgroup` filter's fallback under kernel lockdown confidentiality
-/// mode, where the BPF side cannot walk a task's cgroup ancestors (the walk needs
-/// probe reads, which lockdown restricts) and matches a task's *leaf* cgroup id
-/// exactly instead. A target is frequently an interior node rather than a leaf:
-/// a Kubernetes pod cgroup, for instance, contains per-container child cgroups
-/// and the tasks live in those children (cgroup v2 forbids processes in interior
-/// cgroups once they have controllers enabled), so filtering on only the
-/// interior id would miss every task. Descending and adding every descendant id
-/// makes `--cgroup <pod>` capture the subtree as it exists at the time of the
-/// walk — a cgroup created afterwards is not matched, which is the limitation
-/// the ancestry match removes everywhere else.
-///
-/// The returned vector lists `path`'s own id first, followed by its descendants
-/// in an unspecified order, deduplicated. Failure to stat `path` (or `path` not
-/// being a directory) is returned to the caller so an invalid `--cgroup` argument
-/// is reported; errors reading individual descendants are ignored (best-effort:
-/// cgroups can come and go mid-walk).
-pub fn collect_descendant_cgroup_ids(path: &Path) -> io::Result<Vec<u64>> {
-    let mut ids = Vec::new();
-    for_each_cgroup_dir(path, &mut |_, meta| ids.push(meta.ino()))?;
-    Ok(ids)
-}
-
 /// Collect the pids listed in `cgroup.procs` of `start` and of every cgroup
 /// nested beneath it, inserting them into `pids`.
 ///
-/// Like [`collect_descendant_cgroup_ids`], this descends because a `--cgroup`
-/// target is often an interior node whose own `cgroup.procs` is empty (the tasks
-/// live in child container/slice cgroups). Best-effort: an unreadable or
+/// This descends because a `--cgroup` target is often an interior node whose
+/// own `cgroup.procs` is empty (the tasks live in child container/slice
+/// cgroups). Best-effort: an unreadable or
 /// non-existent `start` simply contributes nothing.
 pub fn collect_cgroup_procs(start: &Path, pids: &mut HashSet<u32>) {
     let _ = for_each_cgroup_dir(start, &mut |path, _| {
@@ -310,80 +284,6 @@ mod tests {
         fs::write(&file, b"").unwrap();
         let err = cgroup_id(&file).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-    }
-
-    #[test]
-    fn test_collect_descendant_cgroup_ids() {
-        // Build a tree mimicking a pod cgroup with nested container cgroups:
-        //   pod/                      <- the --cgroup target (interior node)
-        //   pod/container-a/
-        //   pod/container-a/leaf/
-        //   pod/container-b/
-        let tmp = tempfile::TempDir::new().unwrap();
-        let pod = tmp.path().join("pod");
-        let a = pod.join("container-a");
-        let a_leaf = a.join("leaf");
-        let b = pod.join("container-b");
-        for d in [&pod, &a, &a_leaf, &b] {
-            fs::create_dir_all(d).unwrap();
-        }
-        // A regular file inside a cgroup (like cgroup.procs) must not be treated as
-        // a child cgroup.
-        fs::write(pod.join("cgroup.procs"), b"").unwrap();
-
-        let ids = collect_descendant_cgroup_ids(&pod).unwrap();
-
-        let mut expected = HashSet::new();
-        for d in [&pod, &a, &a_leaf, &b] {
-            expected.insert(fs::metadata(d).unwrap().ino());
-        }
-        let got: HashSet<u64> = ids.iter().copied().collect();
-        assert_eq!(got, expected);
-        // The target's own id is reported first.
-        assert_eq!(ids[0], fs::metadata(&pod).unwrap().ino());
-        // No duplicates.
-        assert_eq!(ids.len(), got.len());
-    }
-
-    #[test]
-    fn test_collect_descendant_cgroup_ids_missing_path_errors() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let missing = tmp.path().join("does-not-exist");
-        assert!(collect_descendant_cgroup_ids(&missing).is_err());
-    }
-
-    #[test]
-    fn test_collect_descendant_cgroup_ids_non_dir_errors() {
-        // A typo'd --cgroup pointing at a file must be a clear error, not a
-        // silently-empty filter.
-        let tmp = tempfile::TempDir::new().unwrap();
-        let file = tmp.path().join("a-file");
-        fs::write(&file, b"").unwrap();
-        assert!(collect_descendant_cgroup_ids(&file).is_err());
-    }
-
-    #[test]
-    fn test_collect_descendant_cgroup_ids_skips_symlinks() {
-        // A symlink to a sibling directory must neither be collected (it is not a
-        // directory per file_type) nor descended into.
-        let tmp = tempfile::TempDir::new().unwrap();
-        let root = tmp.path().join("root");
-        let real = root.join("real");
-        let outside = tmp.path().join("outside");
-        fs::create_dir_all(&real).unwrap();
-        fs::create_dir_all(&outside).unwrap();
-        std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
-
-        let ids = collect_descendant_cgroup_ids(&root).unwrap();
-        let got: HashSet<u64> = ids.iter().copied().collect();
-
-        let expected: HashSet<u64> = [&root, &real]
-            .iter()
-            .map(|d| fs::metadata(d).unwrap().ino())
-            .collect();
-        assert_eq!(got, expected);
-        // The symlink target lives outside the tree and must not be pulled in.
-        assert!(!got.contains(&fs::metadata(&outside).unwrap().ino()));
     }
 
     #[test]

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -133,12 +133,38 @@ pub fn cgroup_id(path: &Path) -> io::Result<u64> {
     Ok(meta.ino())
 }
 
+/// Collect the cgroup id (directory inode) of `path` and of every cgroup nested
+/// beneath it in the cgroup2 hierarchy.
+///
+/// This is the `--cgroup` filter's legacy mode, used when the running kernel's
+/// BTF does not export `bpf_task_under_cgroup` (before 6.5) or when
+/// `SYSTING_CGROUP_FILTER_LEGACY` forces it: the BPF side then matches a task's
+/// *leaf* cgroup id exactly against a start-time set. A target is frequently an
+/// interior node rather than a leaf: a Kubernetes pod cgroup, for instance,
+/// contains per-container child cgroups and the tasks live in those children
+/// (cgroup v2 forbids processes in interior cgroups once they have controllers
+/// enabled), so filtering on only the interior id would miss every task.
+/// Descending and adding every descendant id makes `--cgroup <pod>` capture the
+/// subtree as it exists at the time of the walk — a cgroup created afterwards is
+/// not matched, which is the limitation the kernel-side matching removes.
+///
+/// The returned vector lists `path`'s own id first, followed by its descendants
+/// in an unspecified order, deduplicated. Failure to stat `path` (or `path` not
+/// being a directory) is returned to the caller so an invalid `--cgroup` argument
+/// is reported; errors reading individual descendants are ignored (best-effort:
+/// cgroups can come and go mid-walk).
+pub fn collect_descendant_cgroup_ids(path: &Path) -> io::Result<Vec<u64>> {
+    let mut ids = Vec::new();
+    for_each_cgroup_dir(path, &mut |_, meta| ids.push(meta.ino()))?;
+    Ok(ids)
+}
+
 /// Collect the pids listed in `cgroup.procs` of `start` and of every cgroup
 /// nested beneath it, inserting them into `pids`.
 ///
-/// This descends because a `--cgroup` target is often an interior node whose
-/// own `cgroup.procs` is empty (the tasks live in child container/slice
-/// cgroups). Best-effort: an unreadable or
+/// Like [`collect_descendant_cgroup_ids`], this descends because a `--cgroup`
+/// target is often an interior node whose own `cgroup.procs` is empty (the tasks
+/// live in child container/slice cgroups). Best-effort: an unreadable or
 /// non-existent `start` simply contributes nothing.
 pub fn collect_cgroup_procs(start: &Path, pids: &mut HashSet<u32>) {
     let _ = for_each_cgroup_dir(start, &mut |path, _| {
@@ -284,6 +310,80 @@ mod tests {
         fs::write(&file, b"").unwrap();
         let err = cgroup_id(&file).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn test_collect_descendant_cgroup_ids() {
+        // Build a tree mimicking a pod cgroup with nested container cgroups:
+        //   pod/                      <- the --cgroup target (interior node)
+        //   pod/container-a/
+        //   pod/container-a/leaf/
+        //   pod/container-b/
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pod = tmp.path().join("pod");
+        let a = pod.join("container-a");
+        let a_leaf = a.join("leaf");
+        let b = pod.join("container-b");
+        for d in [&pod, &a, &a_leaf, &b] {
+            fs::create_dir_all(d).unwrap();
+        }
+        // A regular file inside a cgroup (like cgroup.procs) must not be treated as
+        // a child cgroup.
+        fs::write(pod.join("cgroup.procs"), b"").unwrap();
+
+        let ids = collect_descendant_cgroup_ids(&pod).unwrap();
+
+        let mut expected = HashSet::new();
+        for d in [&pod, &a, &a_leaf, &b] {
+            expected.insert(fs::metadata(d).unwrap().ino());
+        }
+        let got: HashSet<u64> = ids.iter().copied().collect();
+        assert_eq!(got, expected);
+        // The target's own id is reported first.
+        assert_eq!(ids[0], fs::metadata(&pod).unwrap().ino());
+        // No duplicates.
+        assert_eq!(ids.len(), got.len());
+    }
+
+    #[test]
+    fn test_collect_descendant_cgroup_ids_missing_path_errors() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        assert!(collect_descendant_cgroup_ids(&missing).is_err());
+    }
+
+    #[test]
+    fn test_collect_descendant_cgroup_ids_non_dir_errors() {
+        // A typo'd --cgroup pointing at a file must be a clear error, not a
+        // silently-empty filter.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let file = tmp.path().join("a-file");
+        fs::write(&file, b"").unwrap();
+        assert!(collect_descendant_cgroup_ids(&file).is_err());
+    }
+
+    #[test]
+    fn test_collect_descendant_cgroup_ids_skips_symlinks() {
+        // A symlink to a sibling directory must neither be collected (it is not a
+        // directory per file_type) nor descended into.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join("root");
+        let real = root.join("real");
+        let outside = tmp.path().join("outside");
+        fs::create_dir_all(&real).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        std::os::unix::fs::symlink(&outside, root.join("link")).unwrap();
+
+        let ids = collect_descendant_cgroup_ids(&root).unwrap();
+        let got: HashSet<u64> = ids.iter().copied().collect();
+
+        let expected: HashSet<u64> = [&root, &real]
+            .iter()
+            .map(|d| fs::metadata(d).unwrap().ino())
+            .collect();
+        assert_eq!(got, expected);
+        // The symlink target lives outside the tree and must not be pulled in.
+        assert!(!got.contains(&fs::metadata(&outside).unwrap().ino()));
     }
 
     #[test]

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -111,16 +111,42 @@ pub fn build_cgroup_id_map() -> HashMap<u64, String> {
     map
 }
 
+/// The cgroup id (directory inode, matching the BPF `dfl_cgrp->kn->id`) of the
+/// cgroup at `path`.
+///
+/// This is what the `--cgroup` filter loads per target: the BPF side matches a
+/// task whose cgroup is the target or has the target among its ancestors, so
+/// the target's own id is all it needs — its subtree is never enumerated, and
+/// cgroups created under the target after the trace starts are matched too.
+///
+/// Failure to stat `path`, or `path` not being a directory, is reported to the
+/// caller so an invalid `--cgroup` argument is a clear error rather than a
+/// silently-empty filter.
+pub fn cgroup_id(path: &Path) -> io::Result<u64> {
+    let meta = fs::metadata(path)?;
+    if !meta.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{} is not a cgroup directory", path.display()),
+        ));
+    }
+    Ok(meta.ino())
+}
+
 /// Collect the cgroup id (directory inode) of `path` and of every cgroup nested
 /// beneath it in the cgroup2 hierarchy.
 ///
-/// A `--cgroup` target is frequently an interior node rather than a leaf: a
-/// Kubernetes pod cgroup, for instance, contains per-container child cgroups and
-/// the tasks live in those children (cgroup v2 forbids processes in interior
-/// cgroups once they have controllers enabled). The BPF cgroup filter matches a
-/// task's *leaf* cgroup id (`dfl_cgrp->kn->id`) exactly, so filtering on only the
+/// This is the `--cgroup` filter's fallback under kernel lockdown confidentiality
+/// mode, where the BPF side cannot walk a task's cgroup ancestors (the walk needs
+/// probe reads, which lockdown restricts) and matches a task's *leaf* cgroup id
+/// exactly instead. A target is frequently an interior node rather than a leaf:
+/// a Kubernetes pod cgroup, for instance, contains per-container child cgroups
+/// and the tasks live in those children (cgroup v2 forbids processes in interior
+/// cgroups once they have controllers enabled), so filtering on only the
 /// interior id would miss every task. Descending and adding every descendant id
-/// makes `--cgroup <pod>` capture the whole subtree.
+/// makes `--cgroup <pod>` capture the subtree as it exists at the time of the
+/// walk — a cgroup created afterwards is not matched, which is the limitation
+/// the ancestry match removes everywhere else.
 ///
 /// The returned vector lists `path`'s own id first, followed by its descendants
 /// in an unspecified order, deduplicated. Failure to stat `path` (or `path` not
@@ -251,6 +277,39 @@ mod tests {
             relative_cgroup_path(root, Path::new("/sys/fs/cgroup/a/b/c")),
             "/a/b/c"
         );
+    }
+
+    #[test]
+    fn test_cgroup_id_is_the_target_inode_only() {
+        // The ancestry-matching filter loads just the target's own id: an
+        // interior pod cgroup with children must yield exactly its inode, never
+        // the children's (those are matched in-kernel through their ancestors).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pod = tmp.path().join("pod");
+        let child = pod.join("container-a");
+        fs::create_dir_all(&child).unwrap();
+        fs::write(pod.join("cgroup.procs"), b"").unwrap();
+
+        let id = cgroup_id(&pod).unwrap();
+        assert_eq!(id, fs::metadata(&pod).unwrap().ino());
+        assert_ne!(id, fs::metadata(&child).unwrap().ino());
+    }
+
+    #[test]
+    fn test_cgroup_id_missing_path_errors() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(cgroup_id(&tmp.path().join("does-not-exist")).is_err());
+    }
+
+    #[test]
+    fn test_cgroup_id_non_dir_errors() {
+        // A typo'd --cgroup pointing at a file must be a clear error, not a
+        // silently-empty filter.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let file = tmp.path().join("a-file");
+        fs::write(&file, b"").unwrap();
+        let err = cgroup_id(&file).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -2968,23 +2968,37 @@ fn collect_memory_alloc_target_pids(opts: &Config) -> Vec<u32> {
     pids.into_iter().collect()
 }
 
-/// Resolve every cgroup id the BPF filter must match for the configured
-/// `--cgroup` targets: each target plus all of its descendant cgroups,
-/// deduplicated across targets.
+/// Resolve the cgroup ids the BPF filter must hold for the configured
+/// `--cgroup` targets, deduplicated across targets.
 ///
-/// A target is frequently an interior node (e.g. a k8s pod cgroup) whose tasks
-/// live in descendant container/slice cgroups, and the BPF filter matches a
-/// task's leaf cgroup id exactly — so the whole subtree must be included. The
-/// result drives both the size of the `cgroups` BPF map and its contents, which
-/// is why it is resolved before the skeleton is loaded.
-fn collect_cgroup_filter_ids(opts: &Config) -> Result<Vec<u64>> {
+/// Normally that is each target's own id and nothing else: the BPF side
+/// (`task_in_cgroup_filter()`) matches a task whose cgroup is a target OR has a
+/// target among its ancestors, so a target that is an interior node (a k8s pod
+/// cgroup whose tasks live in per-container children, say) is covered without
+/// enumerating its subtree — including children that did not exist yet when
+/// the trace started. A start-time snapshot of the descendants could never
+/// contain those, which is how a nested container runtime creating cgroups
+/// under a pod used to yield an empty `--cgroup` trace.
+///
+/// Under kernel lockdown confidentiality mode the ancestry walk is unavailable
+/// (it needs probe reads, which lockdown restricts) and the BPF side falls back
+/// to exact-id matching, so the pre-ancestry behaviour is kept there: enumerate
+/// each target's descendants at start, accepting that limitation.
+///
+/// The result drives both the size of the `cgroups` BPF map and its contents,
+/// which is why it is resolved before the skeleton is loaded.
+fn collect_cgroup_filter_ids(opts: &Config, confidentiality_mode: bool) -> Result<Vec<u64>> {
     let mut ids = Vec::new();
     let mut seen = HashSet::new();
     for cgroup in opts.cgroup.iter() {
-        let descendants =
-            crate::cgroup::collect_descendant_cgroup_ids(std::path::Path::new(cgroup))
-                .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;
-        for id in descendants {
+        let path = std::path::Path::new(cgroup);
+        let target_ids = if confidentiality_mode {
+            crate::cgroup::collect_descendant_cgroup_ids(path)
+        } else {
+            crate::cgroup::cgroup_id(path).map(|id| vec![id])
+        }
+        .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;
+        for id in target_ids {
             if seen.insert(id) {
                 ids.push(id);
             }
@@ -3853,12 +3867,20 @@ pub fn systing(
                 format!("Failed to set missed_events map size to {num_cpus} entries")
             })?;
 
-        // Resolve the full cgroup filter set (each --cgroup target plus its whole
-        // subtree) before load so the cgroups map can be sized to fit. Pointing
-        // --cgroup at a high-level node (a systemd slice, kubepods.slice, the root)
-        // can enumerate far more than the static default, so size the map to the
-        // actual count rather than risk an E2BIG failure when populating it.
-        let cgroup_filter_ids = collect_cgroup_filter_ids(&opts)?;
+        // Resolve the cgroup filter set before load so the cgroups map can be
+        // sized to fit. Normally that is one id per --cgroup target (the BPF side
+        // matches by ancestry); under lockdown confidentiality mode it is each
+        // target's whole subtree, and pointing --cgroup at a high-level node (a
+        // systemd slice, kubepods.slice, the root) can then enumerate far more
+        // than the static default — so size the map to the actual count rather
+        // than risk an E2BIG failure when populating it.
+        let confidentiality_mode = open_skel
+            .maps
+            .rodata_data
+            .as_deref()
+            .map(|rodata| rodata.tool_config.confidentiality_mode != 0)
+            .unwrap_or(false);
+        let cgroup_filter_ids = collect_cgroup_filter_ids(&opts, confidentiality_mode)?;
         if !cgroup_filter_ids.is_empty() {
             open_skel
                 .maps

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -624,6 +624,12 @@ pub fn get_required_bpf_programs(
         required.insert("systing_sched_process_fork");
     }
 
+    // The --cgroup filter parks a reference to each target cgroup through the
+    // cgroup iterator program; it is run by userspace, never attached.
+    if !opts.cgroup.is_empty() {
+        required.insert("systing_cgroup_target_add");
+    }
+
     // Pystacks with PID filtering needs exec tracking to discover new Python processes
     if collect_pystacks && !opts.pid.is_empty() {
         required.insert("systing_sched_process_exec");
@@ -2656,8 +2662,15 @@ fn configure_bpf_skeleton(
             .name()
             .to_str()
             .expect("BPF program name is not valid UTF-8");
-        if !required_programs.contains(name) {
+        let autoload = required_programs.contains(name);
+        // The cgroup iterator program is driven by userspace (install_cgroup_targets)
+        // once per --cgroup target; skel.attach() must not create a link for it.
+        let manual_attach = name == "systing_cgroup_target_add";
+        if !autoload {
             prog.set_autoload(false);
+        }
+        if manual_attach {
+            prog.set_autoattach(false);
         }
     }
 
@@ -2968,43 +2981,174 @@ fn collect_memory_alloc_target_pids(opts: &Config) -> Vec<u32> {
     pids.into_iter().collect()
 }
 
-/// Resolve the cgroup ids the BPF filter must hold for the configured
-/// `--cgroup` targets, deduplicated across targets.
-///
-/// Normally that is each target's own id and nothing else: the BPF side
-/// (`task_in_cgroup_filter()`) matches a task whose cgroup is a target OR has a
-/// target among its ancestors, so a target that is an interior node (a k8s pod
-/// cgroup whose tasks live in per-container children, say) is covered without
-/// enumerating its subtree — including children that did not exist yet when
-/// the trace started. A start-time snapshot of the descendants could never
-/// contain those, which is how a nested container runtime creating cgroups
-/// under a pod used to yield an empty `--cgroup` trace.
-///
-/// Under kernel lockdown confidentiality mode the ancestry walk is unavailable
-/// (it needs probe reads, which lockdown restricts) and the BPF side falls back
-/// to exact-id matching, so the pre-ancestry behaviour is kept there: enumerate
-/// each target's descendants at start, accepting that limitation.
-///
-/// The result drives both the size of the `cgroups` BPF map and its contents,
-/// which is why it is resolved before the skeleton is loaded.
-fn collect_cgroup_filter_ids(opts: &Config, confidentiality_mode: bool) -> Result<Vec<u64>> {
-    let mut ids = Vec::new();
-    let mut seen = HashSet::new();
-    for cgroup in opts.cgroup.iter() {
-        let path = std::path::Path::new(cgroup);
-        let target_ids = if confidentiality_mode {
-            crate::cgroup::collect_descendant_cgroup_ids(path)
-        } else {
-            crate::cgroup::cgroup_id(path).map(|id| vec![id])
-        }
-        .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;
-        for id in target_ids {
-            if seen.insert(id) {
-                ids.push(id);
-            }
+/// Upper bound on distinct `--cgroup` targets, mirroring `MAX_CGROUP_TARGETS`
+/// in the BPF source (the filter loops there are verifier-bounded by it).
+const MAX_CGROUP_TARGETS: usize = 64;
+
+/// One `--cgroup` target as the BPF filter consumes it: the open directory,
+/// whose fd goes into the `cgroup_targets` cgroup array (the kernel keeps the
+/// cgroup referenced for the map's lifetime), and the cgroup id (directory
+/// inode) that the matching `cgroup_target_refs` slot must report back once
+/// the iterator program has parked a reference there.
+struct CgroupTarget {
+    path: String,
+    dir: fs::File,
+    id: u64,
+}
+
+/// Does the running kernel's vmlinux BTF export the `bpf_task_under_cgroup`
+/// kfunc (Linux 6.5+)? The sched tracepoints test tasks other than current
+/// against the `--cgroup` targets through it, so the filter refuses to start
+/// without it rather than trace the wrong set of tasks.
+fn kernel_has_task_under_cgroup_kfunc() -> bool {
+    match libbpf_rs::btf::Btf::from_vmlinux() {
+        Ok(btf) => btf
+            .type_by_name::<libbpf_rs::btf::types::Func<'_>>("bpf_task_under_cgroup")
+            .is_some(),
+        Err(e) => {
+            eprintln!(
+                "Warning: failed to open vmlinux BTF ({e}); \
+                 treating bpf_task_under_cgroup as unavailable"
+            );
+            false
         }
     }
-    Ok(ids)
+}
+
+/// Resolve the `--cgroup` targets, deduplicated by cgroup id.
+///
+/// Membership is decided in the kernel (`task_under_cgroup_hierarchy()`: the
+/// task's cgroup is the target or somewhere below it, so cgroups created after
+/// the trace started match too), which is why this opens each target directory
+/// and reads its id and nothing more — no subtree enumeration. The fd and the
+/// id size the two filter maps, so this runs before the skeleton is loaded. A
+/// path that is not a cgroup directory, more than `MAX_CGROUP_TARGETS` targets,
+/// and a kernel without the kfunc the sched tracepoints need are all reported
+/// as errors up front.
+fn resolve_cgroup_targets(opts: &Config) -> Result<Vec<CgroupTarget>> {
+    let mut targets: Vec<CgroupTarget> = Vec::new();
+    if opts.cgroup.is_empty() {
+        return Ok(targets);
+    }
+    if !kernel_has_task_under_cgroup_kfunc() {
+        bail!(
+            "--cgroup needs the bpf_task_under_cgroup kfunc (Linux 6.5 and later); \
+             this kernel's BTF does not export it"
+        );
+    }
+    for cgroup in opts.cgroup.iter() {
+        let path = std::path::Path::new(cgroup);
+        let id = crate::cgroup::cgroup_id(path)
+            .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;
+        if targets.iter().any(|t| t.id == id) {
+            continue;
+        }
+        let dir = fs::File::open(path)
+            .with_context(|| format!("Failed to open cgroup directory: {cgroup}"))?;
+        targets.push(CgroupTarget {
+            path: cgroup.clone(),
+            dir,
+            id,
+        });
+    }
+    if targets.len() > MAX_CGROUP_TARGETS {
+        bail!(
+            "at most {MAX_CGROUP_TARGETS} distinct --cgroup targets are supported, got {}",
+            targets.len()
+        );
+    }
+    Ok(targets)
+}
+
+/// Hand one `--cgroup` target to BPF as a referenced `struct cgroup *`.
+///
+/// Runs the `systing_cgroup_target_add` iterator program over exactly that
+/// cgroup — a cgroup iterator on the target's directory fd with
+/// `BPF_CGROUP_ITER_SELF_ONLY` — by reading the iterator once: the read drives
+/// the program in process context, where it takes the reference and parks it
+/// in the next free `cgroup_target_refs` slot. libbpf-rs's `attach_iter` only
+/// knows map iterators, so the link is created through libbpf directly.
+fn add_cgroup_target_ref(prog: &libbpf_rs::ProgramMut<'_>, target: &CgroupTarget) -> Result<()> {
+    use libbpf_rs::libbpf_sys;
+    use libbpf_rs::AsRawLibbpf;
+    use std::io::Read;
+
+    let mut link_info = libbpf_sys::bpf_iter_link_info::default();
+    link_info.cgroup.order = libbpf_sys::BPF_CGROUP_ITER_SELF_ONLY;
+    link_info.cgroup.cgroup_fd = target.dir.as_raw_fd() as u32;
+    let attach_opts = libbpf_sys::bpf_iter_attach_opts {
+        sz: std::mem::size_of::<libbpf_sys::bpf_iter_attach_opts>() as _,
+        link_info: &mut link_info as *mut libbpf_sys::bpf_iter_link_info,
+        link_info_len: std::mem::size_of::<libbpf_sys::bpf_iter_link_info>() as _,
+        ..Default::default()
+    };
+    // SAFETY: `prog` is a loaded program owned by the live skeleton, and
+    // `attach_opts` / `link_info` outlive the call, which copies what it keeps.
+    let ptr = unsafe {
+        libbpf_sys::bpf_program__attach_iter(
+            prog.as_libbpf_object().as_ptr(),
+            &attach_opts as *const libbpf_sys::bpf_iter_attach_opts,
+        )
+    };
+    let ptr = std::ptr::NonNull::new(ptr).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Failed to attach the cgroup iterator for {}: {}",
+            target.path,
+            io::Error::last_os_error()
+        )
+    })?;
+    // SAFETY: a non-NULL return is a link libbpf created for us to own.
+    let link = unsafe { libbpf_rs::Link::from_ptr(ptr) };
+    let mut iter = libbpf_rs::Iter::new(&link)
+        .with_context(|| format!("Failed to create the cgroup iterator for {}", target.path))?;
+    let mut out = Vec::new();
+    iter.read_to_end(&mut out)
+        .with_context(|| format!("Failed to run the cgroup iterator for {}", target.path))?;
+    Ok(())
+}
+
+/// Fill the two `--cgroup` filter maps after load: slot `i` of `cgroup_targets`
+/// gets target `i`'s directory fd, slot `i` of `cgroup_target_refs` gets its
+/// cgroup reference via the iterator program, and the slot is read back to
+/// confirm it holds that target's id — a silently-empty filter is exactly what
+/// this change exists to rule out.
+fn install_cgroup_targets(skel: &mut SystingSystemSkel, targets: &[CgroupTarget]) -> Result<()> {
+    for (i, target) in targets.iter().enumerate() {
+        let key = (i as u32).to_ne_bytes();
+        let fd = (target.dir.as_raw_fd() as u32).to_ne_bytes();
+        skel.maps
+            .cgroup_targets
+            .update(&key, &fd, libbpf_rs::MapFlags::ANY)
+            .with_context(|| {
+                format!(
+                    "Failed to add cgroup {} to the cgroup_targets map",
+                    target.path
+                )
+            })?;
+        add_cgroup_target_ref(&skel.progs.systing_cgroup_target_add, target)?;
+        let slot = skel
+            .maps
+            .cgroup_target_refs
+            .lookup(&key, libbpf_rs::MapFlags::ANY)
+            .with_context(|| format!("Failed to read back cgroup_target_refs[{i}]"))?
+            .ok_or_else(|| anyhow::anyhow!("cgroup_target_refs[{i}] is missing"))?;
+        // struct cgroup_target_ref { struct cgroup __kptr *cgrp; u64 id; }:
+        // the kptr reads back as zero from userspace, the id is what we check.
+        let id = slot
+            .get(8..16)
+            .and_then(|b| b.try_into().ok())
+            .map(u64::from_ne_bytes)
+            .ok_or_else(|| anyhow::anyhow!("cgroup_target_refs[{i}] has an unexpected size"))?;
+        if id != target.id {
+            bail!(
+                "cgroup_target_refs[{i}] holds cgroup id {id} after the iterator run, \
+                 expected {} for {}",
+                target.id,
+                target.path
+            );
+        }
+    }
+    Ok(())
 }
 
 /// Override allocator libraries, checked before libc. When one of these is
@@ -3867,31 +4011,31 @@ pub fn systing(
                 format!("Failed to set missed_events map size to {num_cpus} entries")
             })?;
 
-        // Resolve the cgroup filter set before load so the cgroups map can be
-        // sized to fit. Normally that is one id per --cgroup target (the BPF side
-        // matches by ancestry); under lockdown confidentiality mode it is each
-        // target's whole subtree, and pointing --cgroup at a high-level node (a
-        // systemd slice, kubepods.slice, the root) can then enumerate far more
-        // than the static default — so size the map to the actual count rather
-        // than risk an E2BIG failure when populating it.
-        let confidentiality_mode = open_skel
-            .maps
-            .rodata_data
-            .as_deref()
-            .map(|rodata| rodata.tool_config.confidentiality_mode != 0)
-            .unwrap_or(false);
-        let cgroup_filter_ids = collect_cgroup_filter_ids(&opts, confidentiality_mode)?;
-        if !cgroup_filter_ids.is_empty() {
+        // Resolve the --cgroup targets before load: both filter maps are sized to
+        // one slot per distinct target, and the count goes into rodata so the
+        // BPF filter loops are bounded by it.
+        let cgroup_targets = resolve_cgroup_targets(&opts)?;
+        if !cgroup_targets.is_empty() {
+            let n = cgroup_targets.len() as u32;
             open_skel
                 .maps
-                .cgroups
-                .set_max_entries(cgroup_filter_ids.len() as u32)
+                .cgroup_targets
+                .set_max_entries(n)
+                .with_context(|| format!("Failed to set cgroup_targets map size to {n} entries"))?;
+            open_skel
+                .maps
+                .cgroup_target_refs
+                .set_max_entries(n)
                 .with_context(|| {
-                    format!(
-                        "Failed to set cgroups map size to {} entries",
-                        cgroup_filter_ids.len()
-                    )
+                    format!("Failed to set cgroup_target_refs map size to {n} entries")
                 })?;
+            open_skel
+                .maps
+                .rodata_data
+                .as_deref_mut()
+                .expect("'rodata' is not mmap'ed, your kernel is too old")
+                .tool_config
+                .num_cgroup_targets = n;
         }
 
         let diag = std::env::var_os("SYSTING_DIAG_RINGBUFS").is_some();
@@ -3902,19 +4046,10 @@ pub fn systing(
         if diag {
             eprintln!("[diag] open_skel.load() took {:?}", t_load.elapsed());
         }
-        // The map was sized to hold exactly these ids above, so populating it now
-        // cannot overflow.
-        let cgroup_filter_val = (1_u8).to_ne_bytes();
-        for id in &cgroup_filter_ids {
-            skel.maps
-                .cgroups
-                .update(
-                    &id.to_ne_bytes(),
-                    &cgroup_filter_val,
-                    libbpf_rs::MapFlags::ANY,
-                )
-                .with_context(|| format!("Failed to add cgroup id {id} to BPF map"))?;
-        }
+        // The maps were sized to exactly these targets above; this fills them
+        // (fds, then the references via the iterator program) and verifies each
+        // slot before any tracing program is attached.
+        install_cgroup_targets(&mut skel, &cgroup_targets)?;
 
         for pid in opts.pid.iter() {
             let val = (1_u8).to_ne_bytes();

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -601,6 +601,7 @@ pub fn get_required_bpf_programs(
     opts: &Config,
     old_kernel: bool,
     collect_pystacks: bool,
+    cgroup_kernel_mode: bool,
 ) -> HashSet<&'static str> {
     let mut required = HashSet::new();
 
@@ -624,9 +625,11 @@ pub fn get_required_bpf_programs(
         required.insert("systing_sched_process_fork");
     }
 
-    // The --cgroup filter parks a reference to each target cgroup through the
-    // cgroup iterator program; it is run by userspace, never attached.
-    if !opts.cgroup.is_empty() {
+    // In kernel mode the --cgroup filter parks a reference to each target
+    // cgroup through the cgroup iterator program; it is run by userspace, never
+    // attached. Legacy mode (no kfunc on this kernel, or forced) loads no
+    // program for the filter: the exact-match set is a map userspace fills.
+    if !opts.cgroup.is_empty() && cgroup_kernel_mode {
         required.insert("systing_cgroup_target_add");
     }
 
@@ -2496,12 +2499,17 @@ fn warn_failed_probe_attachments(skel: &SystingSystemSkel) {
     }
 }
 
+// Eight inputs: the skeleton, the config, and the per-run facts it needs at
+// open time (CPU count, kernel age, pystacks, the --cgroup mode, the ring plan)
+// — the same shape the repo allows on the other open-time configurators.
+#[allow(clippy::too_many_arguments)]
 fn configure_bpf_skeleton(
     open_skel: &mut OpenSystingSystemSkel,
     opts: &Config,
     num_cpus: u32,
     old_kernel: bool,
     collect_pystacks: bool,
+    cgroup_kernel_mode: bool,
     recorder: &Arc<SessionRecorder>,
     ring_plan: RingbufPlan,
 ) -> Result<()> {
@@ -2544,6 +2552,7 @@ fn configure_bpf_skeleton(
         rodata.tool_config.confidentiality_mode = detect_confidentiality_mode();
         if !opts.cgroup.is_empty() {
             rodata.tool_config.filter_cgroup = 1;
+            rodata.tool_config.cgroup_match_kernel = cgroup_kernel_mode as u32;
         }
         if opts.no_stack_traces {
             rodata.tool_config.no_stack_traces = 1;
@@ -2655,7 +2664,8 @@ fn configure_bpf_skeleton(
 
     // Determine which BPF programs are needed based on enabled recorders.
     // Each recorder declares its required programs; we coalesce them and disable the rest.
-    let required_programs = get_required_bpf_programs(opts, old_kernel, collect_pystacks);
+    let required_programs =
+        get_required_bpf_programs(opts, old_kernel, collect_pystacks, cgroup_kernel_mode);
 
     for mut prog in open_skel.open_object_mut().progs_mut() {
         let name = prog
@@ -2997,9 +3007,8 @@ struct CgroupTarget {
 }
 
 /// Does the running kernel's vmlinux BTF export the `bpf_task_under_cgroup`
-/// kfunc (Linux 6.5+)? The sched tracepoints test tasks other than current
-/// against the `--cgroup` targets through it, so the filter refuses to start
-/// without it rather than trace the wrong set of tasks.
+/// kfunc (Linux 6.5+)? That is the capability the kernel-side `--cgroup`
+/// matching needs; without it the filter runs in legacy mode.
 fn kernel_has_task_under_cgroup_kfunc() -> bool {
     match libbpf_rs::btf::Btf::from_vmlinux() {
         Ok(btf) => btf
@@ -3015,49 +3024,128 @@ fn kernel_has_task_under_cgroup_kfunc() -> bool {
     }
 }
 
-/// Resolve the `--cgroup` targets, deduplicated by cgroup id.
-///
-/// Membership is decided in the kernel (`task_under_cgroup_hierarchy()`: the
-/// task's cgroup is the target or somewhere below it, so cgroups created after
-/// the trace started match too), which is why this opens each target directory
-/// and reads its id and nothing more — no subtree enumeration. The fd and the
-/// id size the two filter maps, so this runs before the skeleton is loaded. A
-/// path that is not a cgroup directory, more than `MAX_CGROUP_TARGETS` targets,
-/// and a kernel without the kfunc the sched tracepoints need are all reported
-/// as errors up front.
-fn resolve_cgroup_targets(opts: &Config) -> Result<Vec<CgroupTarget>> {
-    let mut targets: Vec<CgroupTarget> = Vec::new();
-    if opts.cgroup.is_empty() {
-        return Ok(targets);
+/// Environment knob that forces the legacy `--cgroup` matching on a kernel that
+/// has the kfunc — so the fallback can be exercised (and tested) anywhere.
+const CGROUP_FILTER_LEGACY_ENV: &str = "SYSTING_CGROUP_FILTER_LEGACY";
+
+/// How the `--cgroup` filter decides membership.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CgroupMatchMode {
+    /// The kernel decides (`bpf_current_task_under_cgroup()` /
+    /// `bpf_task_under_cgroup()`): a task in the target or anywhere below it
+    /// matches, cgroups created after the trace started included.
+    Kernel,
+    /// The pre-kfunc mechanism: the target's subtree is enumerated once at
+    /// start and a task's own cgroup id is matched against that set exactly;
+    /// cgroups created afterwards are not traced.
+    LegacySnapshot,
+}
+
+/// The mode decision, kept pure so it can be unit-tested: kernel-side matching
+/// when the kfunc exists and nothing forces the fallback.
+fn cgroup_match_mode(kfunc_available: bool, force_legacy: bool) -> CgroupMatchMode {
+    if kfunc_available && !force_legacy {
+        CgroupMatchMode::Kernel
+    } else {
+        CgroupMatchMode::LegacySnapshot
     }
-    if !kernel_has_task_under_cgroup_kfunc() {
-        bail!(
-            "--cgroup needs the bpf_task_under_cgroup kfunc (Linux 6.5 and later); \
-             this kernel's BTF does not export it"
-        );
-    }
-    for cgroup in opts.cgroup.iter() {
-        let path = std::path::Path::new(cgroup);
-        let id = crate::cgroup::cgroup_id(path)
-            .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;
-        if targets.iter().any(|t| t.id == id) {
-            continue;
+}
+
+/// The resolved `--cgroup` filter: the mode plus what each mode loads into BPF.
+/// Empty (no targets, no ids) when `--cgroup` was not given.
+struct CgroupFilter {
+    mode: CgroupMatchMode,
+    /// Kernel mode: one entry per distinct target.
+    targets: Vec<CgroupTarget>,
+    /// Legacy mode: the ids of every target and of every descendant that existed
+    /// at resolve time, deduplicated.
+    legacy_ids: Vec<u64>,
+}
+
+impl CgroupFilter {
+    fn none() -> Self {
+        CgroupFilter {
+            mode: CgroupMatchMode::Kernel,
+            targets: Vec::new(),
+            legacy_ids: Vec::new(),
         }
-        let dir = fs::File::open(path)
-            .with_context(|| format!("Failed to open cgroup directory: {cgroup}"))?;
-        targets.push(CgroupTarget {
-            path: cgroup.clone(),
-            dir,
-            id,
-        });
     }
-    if targets.len() > MAX_CGROUP_TARGETS {
-        bail!(
-            "at most {MAX_CGROUP_TARGETS} distinct --cgroup targets are supported, got {}",
-            targets.len()
-        );
+
+    fn kernel_mode(&self) -> bool {
+        self.mode == CgroupMatchMode::Kernel
     }
-    Ok(targets)
+}
+
+/// Resolve the `--cgroup` targets for whichever mode the running kernel gets.
+///
+/// Kernel mode opens each target directory and reads its id and nothing more
+/// (no subtree enumeration): the fd and the id fill the two filter maps. Legacy
+/// mode enumerates each target's subtree as it exists now
+/// (`collect_descendant_cgroup_ids()`) for the exact-match set. Either way the
+/// counts size the maps, so this runs before the skeleton is opened. A path that
+/// is not a cgroup directory and more than `MAX_CGROUP_TARGETS` targets are
+/// reported as errors up front; the mode in use is printed once so a trace's
+/// log says which semantics it ran with.
+fn resolve_cgroup_filter(opts: &Config) -> Result<CgroupFilter> {
+    if opts.cgroup.is_empty() {
+        return Ok(CgroupFilter::none());
+    }
+    let force_legacy = std::env::var_os(CGROUP_FILTER_LEGACY_ENV).is_some_and(|v| !v.is_empty());
+    let mode = cgroup_match_mode(kernel_has_task_under_cgroup_kfunc(), force_legacy);
+    let mut filter = CgroupFilter {
+        mode,
+        targets: Vec::new(),
+        legacy_ids: Vec::new(),
+    };
+    match mode {
+        CgroupMatchMode::Kernel => {
+            eprintln!("--cgroup: membership decided by the kernel (bpf_task_under_cgroup)");
+            for cgroup in opts.cgroup.iter() {
+                let path = std::path::Path::new(cgroup);
+                let id = crate::cgroup::cgroup_id(path)
+                    .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;
+                if filter.targets.iter().any(|t| t.id == id) {
+                    continue;
+                }
+                let dir = fs::File::open(path)
+                    .with_context(|| format!("Failed to open cgroup directory: {cgroup}"))?;
+                filter.targets.push(CgroupTarget {
+                    path: cgroup.clone(),
+                    dir,
+                    id,
+                });
+            }
+            if filter.targets.len() > MAX_CGROUP_TARGETS {
+                bail!(
+                    "at most {MAX_CGROUP_TARGETS} distinct --cgroup targets are supported, got {}",
+                    filter.targets.len()
+                );
+            }
+        }
+        CgroupMatchMode::LegacySnapshot => {
+            eprintln!(
+                "--cgroup: {}; matching a start-time snapshot of each target's cgroups \
+                 (cgroups created under a target after this point are not traced)",
+                if force_legacy {
+                    format!("{CGROUP_FILTER_LEGACY_ENV} is set")
+                } else {
+                    "this kernel's BTF does not export bpf_task_under_cgroup".to_string()
+                }
+            );
+            let mut seen = HashSet::new();
+            for cgroup in opts.cgroup.iter() {
+                let path = std::path::Path::new(cgroup);
+                let ids = crate::cgroup::collect_descendant_cgroup_ids(path)
+                    .with_context(|| format!("Failed to access cgroup path: {cgroup}"))?;
+                for id in ids {
+                    if seen.insert(id) {
+                        filter.legacy_ids.push(id);
+                    }
+                }
+            }
+        }
+    }
+    Ok(filter)
 }
 
 /// Hand one `--cgroup` target to BPF as a referenced `struct cgroup *`.
@@ -3897,6 +3985,15 @@ pub fn systing(
         opts.pid.push(child.pid);
     }
 
+    // Resolve the --cgroup filter (mode + targets) first thing: the mode
+    // selects BPF programs and a rodata flag and the counts size the filter
+    // maps, and in legacy mode the snapshot of each target's cgroups is taken
+    // here, so it is as close to the caller's "start" as it can be — every
+    // second spent on set-up after this point (symbolizer, output sink, the
+    // skeleton) is a second in which a cgroup created under a target would
+    // still make the snapshot.
+    let cgroup_filter = resolve_cgroup_filter(&opts)?;
+
     let num_cpus = libbpf_rs::num_possible_cpus().unwrap() as u32;
     let ring_plan = plan_ringbufs(num_cpus, opts.ringbuf_size_mib, opts.ringbuf_shards);
     // One startup note, unconditional: the ring layout is the first thing to
@@ -3960,6 +4057,7 @@ pub fn systing(
             num_cpus,
             old_kernel,
             collect_pystacks,
+            cgroup_filter.kernel_mode(),
             &recorder,
             ring_plan,
         )?;
@@ -4011,12 +4109,13 @@ pub fn systing(
                 format!("Failed to set missed_events map size to {num_cpus} entries")
             })?;
 
-        // Resolve the --cgroup targets before load: both filter maps are sized to
-        // one slot per distinct target, and the count goes into rodata so the
-        // BPF filter loops are bounded by it.
-        let cgroup_targets = resolve_cgroup_targets(&opts)?;
-        if !cgroup_targets.is_empty() {
-            let n = cgroup_targets.len() as u32;
+        // Size the --cgroup filter maps for the mode resolved above (the maps of
+        // the other mode stay at their 1-entry default, unused): kernel mode
+        // gets one slot per distinct target in both target maps, with the count
+        // in rodata so the BPF filter loops are bounded by it; legacy mode gets
+        // the exact-match set sized to the ids enumerated at start.
+        if !cgroup_filter.targets.is_empty() {
+            let n = cgroup_filter.targets.len() as u32;
             open_skel
                 .maps
                 .cgroup_targets
@@ -4037,6 +4136,14 @@ pub fn systing(
                 .tool_config
                 .num_cgroup_targets = n;
         }
+        if !cgroup_filter.legacy_ids.is_empty() {
+            let n = cgroup_filter.legacy_ids.len() as u32;
+            open_skel
+                .maps
+                .cgroups
+                .set_max_entries(n)
+                .with_context(|| format!("Failed to set cgroups map size to {n} entries"))?;
+        }
 
         let diag = std::env::var_os("SYSTING_DIAG_RINGBUFS").is_some();
         let t_load = std::time::Instant::now();
@@ -4046,10 +4153,22 @@ pub fn systing(
         if diag {
             eprintln!("[diag] open_skel.load() took {:?}", t_load.elapsed());
         }
-        // The maps were sized to exactly these targets above; this fills them
-        // (fds, then the references via the iterator program) and verifies each
-        // slot before any tracing program is attached.
-        install_cgroup_targets(&mut skel, &cgroup_targets)?;
+        // The maps were sized to exactly these entries above. Kernel mode: the
+        // fds, then the references via the iterator program, each slot verified
+        // before any tracing program is attached. Legacy mode: the start-time
+        // id set.
+        install_cgroup_targets(&mut skel, &cgroup_filter.targets)?;
+        let cgroup_filter_val = (1_u8).to_ne_bytes();
+        for id in &cgroup_filter.legacy_ids {
+            skel.maps
+                .cgroups
+                .update(
+                    &id.to_ne_bytes(),
+                    &cgroup_filter_val,
+                    libbpf_rs::MapFlags::ANY,
+                )
+                .with_context(|| format!("Failed to add cgroup id {id} to BPF map"))?;
+        }
 
         for pid in opts.pid.iter() {
             let val = (1_u8).to_ne_bytes();
@@ -4882,5 +5001,38 @@ mod tests {
         assert_eq!((p.nr_rings, p.ring_bytes), (16, 16 * MIB));
         // Zero possible CPUs cannot happen, but the plan must stay loadable.
         assert_eq!(plan_ringbufs(0, 25, 0).nr_rings, 1);
+    }
+
+    #[test]
+    fn test_cgroup_match_mode_prefers_kernel_unless_forced() {
+        // The kfunc decides; the env knob only ever forces the fallback.
+        assert_eq!(cgroup_match_mode(true, false), CgroupMatchMode::Kernel);
+        assert_eq!(
+            cgroup_match_mode(true, true),
+            CgroupMatchMode::LegacySnapshot
+        );
+        assert_eq!(
+            cgroup_match_mode(false, false),
+            CgroupMatchMode::LegacySnapshot
+        );
+        assert_eq!(
+            cgroup_match_mode(false, true),
+            CgroupMatchMode::LegacySnapshot
+        );
+    }
+
+    #[test]
+    fn test_cgroup_filter_iterator_program_only_in_kernel_mode() {
+        let opts = Config {
+            cgroup: vec!["/sys/fs/cgroup/some-target".to_string()],
+            ..Default::default()
+        };
+        assert!(get_required_bpf_programs(&opts, false, false, true)
+            .contains("systing_cgroup_target_add"));
+        assert!(!get_required_bpf_programs(&opts, false, false, false)
+            .contains("systing_cgroup_target_add"));
+        let none = Config::default();
+        assert!(!get_required_bpf_programs(&none, false, false, true)
+            .contains("systing_cgroup_target_add"));
     }
 }

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -1050,10 +1050,13 @@ fn test_e2e_validation_suite() {
 // matches.
 // =============================================================================
 
-/// Recording duration for the cgroup filter test (seconds). The late cgroup and
+/// Recording duration for the cgroup filter tests (seconds). The late cgroup and
 /// its workload are created `CGROUP_LATE_CREATE_DELAY_SECS` in, which is after
-/// the targets are handed to BPF (before the trace even starts) on any
-/// machine, and leaves the rest of the window for the workload to be sampled.
+/// `systing()` has resolved the `--cgroup` targets (the first thing it does —
+/// in legacy mode that is the start-time snapshot, so the delay must exceed
+/// the time to reach it, not the whole set-up, which runs tens of seconds on
+/// an emulated guest), and leaves the rest of the window for the workload to
+/// be sampled.
 const CGROUP_FILTER_DURATION_SECS: u64 = 10;
 const CGROUP_LATE_CREATE_DELAY_SECS: u64 = 3;
 
@@ -1315,6 +1318,222 @@ fn test_e2e_cgroup_filter_follows_cgroups_created_after_start() {
     assert_eq!(
         outside_rows, 0,
         "[cgroup filter] workload pid {outside_pid} outside the --cgroup target was traced"
+    );
+    eprintln!("  outside workload pid {outside_pid}: not traced (correct)");
+}
+
+/// Sets `SYSTING_CGROUP_FILTER_LEGACY` for the duration of one test and clears
+/// it on drop (the panic path included), so the kernel-mode test in this file
+/// never inherits the forced fallback. The integration runner executes these
+/// tests with `--test-threads=1`.
+struct LegacyCgroupFilterEnv;
+
+impl LegacyCgroupFilterEnv {
+    fn set() -> LegacyCgroupFilterEnv {
+        std::env::set_var("SYSTING_CGROUP_FILTER_LEGACY", "1");
+        LegacyCgroupFilterEnv
+    }
+}
+
+impl Drop for LegacyCgroupFilterEnv {
+    fn drop(&mut self) {
+        std::env::remove_var("SYSTING_CGROUP_FILTER_LEGACY");
+    }
+}
+
+/// The legacy (pre-kfunc) `--cgroup` matching, forced through
+/// `SYSTING_CGROUP_FILTER_LEGACY` so it runs on any kernel: the fixture of the
+/// test above plus a leaf that exists under the target BEFORE the trace starts.
+/// The early task must be traced (the start-time snapshot includes the target's
+/// descendants), the late task must NOT be (a cgroup created after the snapshot
+/// is invisible to this mode — the known limitation, and the discriminator that
+/// proves the fallback was in effect), and the sibling hierarchy stays excluded.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_e2e_cgroup_filter_legacy_snapshot_fallback() {
+    use std::os::unix::fs::MetadataExt;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    let Some(cgroup_root) = systing::cgroup::cgroup2_root() else {
+        eprintln!("skipping: no cgroup v2 unified hierarchy on this system");
+        return;
+    };
+    let base = match current_cgroup_v2_path() {
+        Some(p) if p != "/" => cgroup_root.join(p.trim_start_matches('/')),
+        _ => cgroup_root,
+    };
+    //   <base>/systing-cgl-<pid>/                 <- the --cgroup target
+    //   <base>/systing-cgl-<pid>/early/           <- exists BEFORE the trace starts
+    //   <base>/systing-cgl-<pid>/mid/late/        <- created AFTER the trace starts
+    //   <base>/systing-cgl-<pid>-outside/leaf/    <- sibling, must NOT be traced
+    let tag = format!("systing-cgl-{}", std::process::id());
+    let target = base.join(&tag);
+    let early = target.join("early");
+    let mid = target.join("mid");
+    let late = mid.join("late");
+    let outside = base.join(format!("{tag}-outside"));
+    let outside_leaf = outside.join("leaf");
+
+    let mut fixture = CgroupFixture { dirs: Vec::new() };
+    match fixture.create(&target) {
+        Ok(()) => {}
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+            ) =>
+        {
+            eprintln!(
+                "skipping: cannot create a cgroup under {} ({e})",
+                base.display()
+            );
+            return;
+        }
+        Err(e) => panic!("Failed to create cgroup {}: {e}", target.display()),
+    }
+    for dir in [&early, &outside, &outside_leaf] {
+        fixture
+            .create(dir)
+            .unwrap_or_else(|e| panic!("Failed to create cgroup {}: {e}", dir.display()));
+    }
+    let early_id = std::fs::metadata(&early)
+        .expect("Failed to stat early cgroup")
+        .ino();
+
+    let early_workload = CgroupWorkload::spawn_in(&early);
+    let outside_workload = CgroupWorkload::spawn_in(&outside_leaf);
+
+    let (tx, rx) = mpsc::channel();
+    let (mid_t, late_t) = (mid.clone(), late.clone());
+    let creator = thread::spawn(move || {
+        thread::sleep(Duration::from_secs(CGROUP_LATE_CREATE_DELAY_SECS));
+        let mut created = Vec::new();
+        for dir in [&mid_t, &late_t] {
+            std::fs::create_dir(dir)
+                .unwrap_or_else(|e| panic!("Failed to create cgroup {}: {e}", dir.display()));
+            created.push(dir.clone());
+        }
+        let workload = CgroupWorkload::spawn_in(&late_t);
+        tx.send(created).expect("test thread went away");
+        workload
+    });
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let trace_path = dir.path().join("trace.pb");
+    eprintln!(
+        "Recording trace ({CGROUP_FILTER_DURATION_SECS}s, --cgroup {}, LEGACY mode forced, \
+         late cgroup at +{CGROUP_LATE_CREATE_DELAY_SECS}s)...",
+        target.display()
+    );
+    let config = Config {
+        duration: CGROUP_FILTER_DURATION_SECS,
+        output_dir: dir.path().to_path_buf(),
+        output: trace_path,
+        cgroup: vec![target.to_string_lossy().into_owned()],
+        ..Config::default()
+    };
+    let result = {
+        let _legacy = LegacyCgroupFilterEnv::set();
+        systing(config, None)
+    };
+
+    if let Ok(late_dirs) = rx.recv() {
+        fixture.dirs.extend(late_dirs);
+    }
+    let late_workload = match creator.join() {
+        Ok(workload) => workload,
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
+    result.expect("systing recording failed");
+    let early_pid = early_workload.pid();
+    let late_pid = late_workload.pid();
+    let outside_pid = outside_workload.pid();
+    drop(early_workload);
+    drop(late_workload);
+    drop(outside_workload);
+    eprintln!("Recording complete.\n");
+
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "cgroup_filter_legacy")
+        .expect("parquet -> duckdb failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+
+    // The task in a descendant that existed at start was traced, in its own
+    // leaf: the snapshot covers the subtree as it was.
+    let early_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM process WHERE pid = ?",
+            [early_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to count early workload process rows");
+    assert!(
+        early_rows > 0,
+        "[cgroup filter, legacy] workload pid {early_pid} in a leaf that existed under the \
+         --cgroup target before the trace started was not traced"
+    );
+    let early_cgroup_id: u64 = conn
+        .query_row(
+            "SELECT cgroup_id FROM process WHERE pid = ? LIMIT 1",
+            [early_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to query early workload cgroup_id");
+    assert_eq!(
+        early_cgroup_id, early_id,
+        "[cgroup filter, legacy] workload pid {early_pid} recorded with cgroup_id \
+         {early_cgroup_id}, expected its leaf {early_id}"
+    );
+    let early_events: i64 = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM stack_sample s JOIN thread t USING (utid) \
+                     JOIN process p USING (upid) WHERE p.pid = ?) \
+                  + (SELECT COUNT(*) FROM sched_slice s JOIN thread t USING (utid) \
+                     JOIN process p USING (upid) WHERE p.pid = ?)",
+            [early_pid, early_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to count early workload events");
+    assert!(
+        early_events > 0,
+        "[cgroup filter, legacy] workload pid {early_pid} has a process row but no stack \
+         samples or sched slices"
+    );
+    eprintln!(
+        "  early workload pid {early_pid}: traced, cgroup_id {early_cgroup_id} (leaf), \
+         {early_events} stack samples + sched slices"
+    );
+
+    // The task in the cgroup created after the trace started was NOT traced:
+    // that is the legacy mode's known loss, and the proof that legacy mode ran
+    // (the kernel-side matching would have caught it).
+    let late_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM process WHERE pid = ?",
+            [late_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to count late workload process rows");
+    assert_eq!(
+        late_rows, 0,
+        "[cgroup filter, legacy] workload pid {late_pid} in a cgroup created after the \
+         trace started was traced: the forced legacy mode is not in effect"
+    );
+    eprintln!("  late workload pid {late_pid}: not traced (the legacy mode's known loss)");
+
+    let outside_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM process WHERE pid = ?",
+            [outside_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to query outside workload process row");
+    assert_eq!(
+        outside_rows, 0,
+        "[cgroup filter, legacy] workload pid {outside_pid} outside the --cgroup target was \
+         traced"
     );
     eprintln!("  outside workload pid {outside_pid}: not traced (correct)");
 }

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -1037,20 +1037,22 @@ fn test_e2e_validation_suite() {
 }
 
 // =============================================================================
-// --cgroup filter: ancestry match
+// --cgroup filter: membership decided by the kernel
 //
 // Regression test for the start-time-snapshot bug: the filter used to load the
 // ids of the target cgroup and its descendants *as they existed when the trace
 // started* and match a task's leaf cgroup id exactly, so a task in a cgroup
 // created after that snapshot (a nested container runtime making cgroups inside
 // a pod) was never traced and the whole --cgroup trace came back empty. The
-// filter now matches by ancestry, so only the target's own id is loaded and a
-// leaf created mid-trace still matches through its ancestors.
+// filter now asks the kernel (bpf_current_task_under_cgroup() /
+// bpf_task_under_cgroup(): is the task's cgroup the target or below it?), so
+// only the target itself is handed over and a leaf created mid-trace still
+// matches.
 // =============================================================================
 
 /// Recording duration for the cgroup filter test (seconds). The late cgroup and
 /// its workload are created `CGROUP_LATE_CREATE_DELAY_SECS` in, which is after
-/// the filter snapshot (taken before the BPF skeleton is even loaded) on any
+/// the targets are handed to BPF (before the trace even starts) on any
 /// machine, and leaves the rest of the window for the workload to be sampled.
 const CGROUP_FILTER_DURATION_SECS: u64 = 10;
 const CGROUP_LATE_CREATE_DELAY_SECS: u64 = 3;
@@ -1264,10 +1266,10 @@ fn test_e2e_cgroup_filter_follows_cgroups_created_after_start() {
         late_rows > 0,
         "[cgroup filter] workload pid {late_pid} in a cgroup created after the trace \
          started (two levels below the --cgroup target) was not traced: the filter is \
-         matching a start-time snapshot of leaf ids, not ancestry"
+         matching a start-time snapshot of leaf ids, not the kernel's own membership test"
     );
     // ...and it was recorded in its own (new) leaf cgroup, not in the target: the
-    // match came from an ancestor, which is the whole point.
+    // kernel matched it through its ancestors, which is the whole point.
     let late_cgroup_id: u64 = conn
         .query_row(
             "SELECT cgroup_id FROM process WHERE pid = ? LIMIT 1",
@@ -1301,7 +1303,7 @@ fn test_e2e_cgroup_filter_follows_cgroups_created_after_start() {
          {late_events} stack samples + sched slices"
     );
 
-    // The sibling hierarchy is still excluded: ancestry matching must not widen
+    // The sibling hierarchy is still excluded: kernel-side matching must not widen
     // the filter beyond the target's subtree.
     let outside_rows: i64 = conn
         .query_row(

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -1037,6 +1037,287 @@ fn test_e2e_validation_suite() {
 }
 
 // =============================================================================
+// --cgroup filter: ancestry match
+//
+// Regression test for the start-time-snapshot bug: the filter used to load the
+// ids of the target cgroup and its descendants *as they existed when the trace
+// started* and match a task's leaf cgroup id exactly, so a task in a cgroup
+// created after that snapshot (a nested container runtime making cgroups inside
+// a pod) was never traced and the whole --cgroup trace came back empty. The
+// filter now matches by ancestry, so only the target's own id is loaded and a
+// leaf created mid-trace still matches through its ancestors.
+// =============================================================================
+
+/// Recording duration for the cgroup filter test (seconds). The late cgroup and
+/// its workload are created `CGROUP_LATE_CREATE_DELAY_SECS` in, which is after
+/// the filter snapshot (taken before the BPF skeleton is even loaded) on any
+/// machine, and leaves the rest of the window for the workload to be sampled.
+const CGROUP_FILTER_DURATION_SECS: u64 = 10;
+const CGROUP_LATE_CREATE_DELAY_SECS: u64 = 3;
+
+/// Cgroup directories created by the cgroup filter test, removed (deepest first)
+/// when the guard drops — on the test's panic path too, so a failed run does not
+/// leave cgroups behind. Removal is best-effort with a few retries because a
+/// cgroup stays "populated" for a moment after its last task is reaped.
+struct CgroupFixture {
+    dirs: Vec<PathBuf>,
+}
+
+impl CgroupFixture {
+    fn create(&mut self, dir: &Path) -> std::io::Result<()> {
+        std::fs::create_dir(dir)?;
+        self.dirs.push(dir.to_path_buf());
+        Ok(())
+    }
+}
+
+impl Drop for CgroupFixture {
+    fn drop(&mut self) {
+        for dir in self.dirs.iter().rev() {
+            for _ in 0..50 {
+                match std::fs::remove_dir(dir) {
+                    Ok(()) => break,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => break,
+                    Err(_) => std::thread::sleep(std::time::Duration::from_millis(100)),
+                }
+            }
+        }
+    }
+}
+
+/// A busy-loop child process placed into `cgroup` by writing its pid to that
+/// cgroup's `cgroup.procs`, killed and reaped when the guard drops.
+struct CgroupWorkload {
+    child: std::process::Child,
+}
+
+impl CgroupWorkload {
+    fn spawn_in(cgroup: &Path) -> CgroupWorkload {
+        use std::process::{Command, Stdio};
+        let child = Command::new("sh")
+            .arg("-c")
+            .arg("while :; do :; done")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to spawn cgroup workload");
+        let procs = cgroup.join("cgroup.procs");
+        std::fs::write(&procs, child.id().to_string()).unwrap_or_else(|e| {
+            panic!(
+                "Failed to move workload pid {} into {}: {e}",
+                child.id(),
+                procs.display()
+            )
+        });
+        // Read back: the move is what the test is about, so prove it happened.
+        let listed = std::fs::read_to_string(&procs).expect("Failed to read cgroup.procs");
+        assert!(
+            listed.lines().any(|l| l.trim() == child.id().to_string()),
+            "workload pid {} not listed in {} after the move (contents: {listed:?})",
+            child.id(),
+            procs.display()
+        );
+        CgroupWorkload { child }
+    }
+
+    fn pid(&self) -> i32 {
+        self.child.id() as i32
+    }
+}
+
+impl Drop for CgroupWorkload {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_e2e_cgroup_filter_follows_cgroups_created_after_start() {
+    use std::os::unix::fs::MetadataExt;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    let Some(cgroup_root) = systing::cgroup::cgroup2_root() else {
+        eprintln!("skipping: no cgroup v2 unified hierarchy on this system");
+        return;
+    };
+    // Build the fixture under this process's own cgroup (the root when the
+    // test runs in a plain VM), so it needs no delegation beyond what a root
+    // test already has:
+    //   <base>/systing-cgf-<pid>/                 <- the --cgroup target
+    //   <base>/systing-cgf-<pid>/mid/late/        <- created AFTER the trace starts
+    //   <base>/systing-cgf-<pid>-outside/leaf/    <- sibling, must NOT be traced
+    // The traced workload sits two levels below the target, so the match has to
+    // come from ancestors[level - 2], not from the target being the task's own
+    // cgroup or its parent.
+    let base = match current_cgroup_v2_path() {
+        Some(p) if p != "/" => cgroup_root.join(p.trim_start_matches('/')),
+        _ => cgroup_root,
+    };
+    let tag = format!("systing-cgf-{}", std::process::id());
+    let target = base.join(&tag);
+    let mid = target.join("mid");
+    let late = mid.join("late");
+    let outside = base.join(format!("{tag}-outside"));
+    let outside_leaf = outside.join("leaf");
+
+    let mut fixture = CgroupFixture { dirs: Vec::new() };
+    match fixture.create(&target) {
+        Ok(()) => {}
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+            ) =>
+        {
+            eprintln!(
+                "skipping: cannot create a cgroup under {} ({e})",
+                base.display()
+            );
+            return;
+        }
+        Err(e) => panic!("Failed to create cgroup {}: {e}", target.display()),
+    }
+    fixture
+        .create(&outside)
+        .unwrap_or_else(|e| panic!("Failed to create cgroup {}: {e}", outside.display()));
+    fixture
+        .create(&outside_leaf)
+        .unwrap_or_else(|e| panic!("Failed to create cgroup {}: {e}", outside_leaf.display()));
+    let target_id = std::fs::metadata(&target)
+        .expect("Failed to stat target cgroup")
+        .ino();
+
+    // The negative control exists from the start: a busy task in a sibling
+    // hierarchy the filter must keep excluding.
+    let outside_workload = CgroupWorkload::spawn_in(&outside_leaf);
+
+    // Mid-trace: create the nested cgroups and put a busy task in the leaf. This
+    // runs on a helper thread because `systing()` blocks for the whole trace.
+    // The helper hands the created dirs back so the fixture removes them.
+    let (tx, rx) = mpsc::channel();
+    let (mid_t, late_t) = (mid.clone(), late.clone());
+    let creator = thread::spawn(move || {
+        thread::sleep(Duration::from_secs(CGROUP_LATE_CREATE_DELAY_SECS));
+        let mut created = Vec::new();
+        for dir in [&mid_t, &late_t] {
+            std::fs::create_dir(dir)
+                .unwrap_or_else(|e| panic!("Failed to create cgroup {}: {e}", dir.display()));
+            created.push(dir.clone());
+        }
+        let workload = CgroupWorkload::spawn_in(&late_t);
+        tx.send(created).expect("test thread went away");
+        workload
+    });
+
+    let dir = TempDir::new().expect("Failed to create temp dir");
+    let trace_path = dir.path().join("trace.pb");
+    eprintln!(
+        "Recording trace ({CGROUP_FILTER_DURATION_SECS}s, --cgroup {}, late cgroup at +{CGROUP_LATE_CREATE_DELAY_SECS}s)...",
+        target.display()
+    );
+    let config = Config {
+        duration: CGROUP_FILTER_DURATION_SECS,
+        output_dir: dir.path().to_path_buf(),
+        output: trace_path,
+        cgroup: vec![target.to_string_lossy().into_owned()],
+        ..Config::default()
+    };
+    let result = systing(config, None);
+
+    // Collect the helper's state before asserting anything so cleanup always runs.
+    // A helper that panicked before reporting re-raises its own panic below.
+    if let Ok(late_dirs) = rx.recv() {
+        fixture.dirs.extend(late_dirs);
+    }
+    let late_workload = match creator.join() {
+        Ok(workload) => workload,
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
+    result.expect("systing recording failed");
+    let late_pid = late_workload.pid();
+    let outside_pid = outside_workload.pid();
+    let late_id = std::fs::metadata(&late)
+        .expect("Failed to stat late cgroup")
+        .ino();
+    drop(late_workload);
+    drop(outside_workload);
+    eprintln!("Recording complete.\n");
+
+    let duckdb_path = dir.path().join("trace.duckdb");
+    systing::duckdb::parquet_to_duckdb(dir.path(), &duckdb_path, "cgroup_filter")
+        .expect("parquet -> duckdb failed");
+    let conn = duckdb::Connection::open(&duckdb_path).expect("Failed to open DuckDB");
+
+    // The task in the cgroup created after the trace started was traced...
+    let late_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM process WHERE pid = ?",
+            [late_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to count late workload process rows");
+    assert!(
+        late_rows > 0,
+        "[cgroup filter] workload pid {late_pid} in a cgroup created after the trace \
+         started (two levels below the --cgroup target) was not traced: the filter is \
+         matching a start-time snapshot of leaf ids, not ancestry"
+    );
+    // ...and it was recorded in its own (new) leaf cgroup, not in the target: the
+    // match came from an ancestor, which is the whole point.
+    let late_cgroup_id: u64 = conn
+        .query_row(
+            "SELECT cgroup_id FROM process WHERE pid = ? LIMIT 1",
+            [late_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to query late workload cgroup_id");
+    assert_eq!(
+        late_cgroup_id, late_id,
+        "[cgroup filter] workload pid {late_pid} recorded with cgroup_id {late_cgroup_id}, \
+         expected its leaf {late_id} (target is {target_id})"
+    );
+    // Its activity was recorded, not just its existence.
+    let late_events: i64 = conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM stack_sample s JOIN thread t USING (utid) \
+                     JOIN process p USING (upid) WHERE p.pid = ?) \
+                  + (SELECT COUNT(*) FROM sched_slice s JOIN thread t USING (utid) \
+                     JOIN process p USING (upid) WHERE p.pid = ?)",
+            [late_pid, late_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to count late workload events");
+    assert!(
+        late_events > 0,
+        "[cgroup filter] workload pid {late_pid} has a process row but no stack samples or \
+         sched slices"
+    );
+    eprintln!(
+        "  late workload pid {late_pid}: traced, cgroup_id {late_cgroup_id} (leaf), \
+         {late_events} stack samples + sched slices"
+    );
+
+    // The sibling hierarchy is still excluded: ancestry matching must not widen
+    // the filter beyond the target's subtree.
+    let outside_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM process WHERE pid = ?",
+            [outside_pid],
+            |row| row.get(0),
+        )
+        .expect("Failed to query outside workload process row");
+    assert_eq!(
+        outside_rows, 0,
+        "[cgroup filter] workload pid {outside_pid} outside the --cgroup target was traced"
+    );
+    eprintln!("  outside workload pid {outside_pid}: not traced (correct)");
+}
+
+// =============================================================================
 // Consolidated network suite
 //
 // Records ONE trace (3s, network=true, with traffic) and runs all network


### PR DESCRIPTION
## What changes

`--cgroup <path>` traces a task when its cgroup is the target **or any cgroup below it**, cgroups created after the trace started included — the kernel decides (`task_under_cgroup_hierarchy()`, the predicate behind `bpf_task_under_cgroup()`), instead of userspace enumerating the target's descendants at start or BPF walking a task's cgroup ancestors by hand.

Three patchsets: the first matched by walking `cgrp->ancestors[]` with probe reads and comparing ids against a hash map; the review asked for the kfunc instead, and the second dropped the walk, the CO-RE flavor for pre-6.1 cgroups, the depth bound and the lockdown special case for the kernel's own test — and refused to start on a kernel without the kfunc. The third (the last commit) keeps the pre-existing behaviour as the **fallback** on such kernels instead of refusing: the start-time snapshot, with its known loss of cgroups created after the trace started.

## Why

A filtered trace of a pod whose container runtime keeps creating cgroups under the pod (a privileged container running a nested OCI runtime, with `runc:[2:INIT]` and short-lived helpers in its process mix) came back with **zero rows in every table** three times out of three over two weeks, while systing exited Ok after its full duration and an unfiltered trace on the same host attributed the same pod normally. The `--cgroup` path was correct (a wrong path is a hard `Failed to access cgroup path` error); the filter matched nothing because the tasks lived in leaves that did not exist when the start-time id snapshot was taken.

## How

Two kernel entry points into the same predicate are used, because no single one is callable from every program that shares `trace_task()`:

**Current task, every program type — `bpf_current_task_under_cgroup(map, idx)`.** The helper (since 4.8) tests `current` against a slot of a `BPF_MAP_TYPE_CGROUP_ARRAY`: a `READ_ONCE` of the slot and an `ancestors[]` compare, lock-free and NMI-safe. Userspace opens each `--cgroup` directory and puts the fd into slot `i` of the new `cgroup_targets` map (the kernel holds the cgroup reference for the map's lifetime). `trace_task()` loops over the targets with it; all of its callers outside the sched tracepoints pass `current`, including the `perf_event` sampler, the kprobe/uprobe/usdt programs, the raw tracepoints and the classic tracepoints.

**Any task, `tp_btf` programs — `bpf_task_under_cgroup(task, cgrp)`.** The sched tracepoints test tasks that are not current (the switched-in task, a wakee, a migrating task, a forked child's parent), so they call the kfunc through the new `trace_task_btf()`. The kfunc needs a trusted `struct cgroup *`; those are the references the new `SEC("iter/cgroup") systing_cgroup_target_add` program parks in slot `i` of the new `cgroup_target_refs` map (`struct cgroup __kptr *` plus the cgroup id). Userspace runs that program once per target before attaching anything: a cgroup iterator on the target's directory fd with `BPF_CGROUP_ITER_SELF_ONLY`, driven by one `read()` (process context), which takes the reference with `bpf_cgroup_from_id()` and records the id; userspace reads the slot back and refuses to start if the id is not the target's. `task_in_cgroup_filter()` loads the kptr under `bpf_rcu_read_lock()` — `struct cgroup` is one of the verifier's RCU-protected kptr types, so the load is accepted as trusted for this `KF_RCU` kfunc — and holds no lock and takes no reference per event.

**Why not the kfunc everywhere** (read at the tags in the kernel tree): at v6.6 the generic kfunc set that holds `bpf_task_under_cgroup` is registered for TRACING, SCHED_CLS and STRUCT_OPS programs only (`kernel/bpf/helpers.c` `kfunc_init()`, `kernel/bpf/btf.c` `bpf_prog_type_to_kfunc_hook()`); v6.12 adds `tracepoint` and `perf_event` to the tracing hook but gives `kprobe` its own hook without the generic set and `raw_tracepoint` none. systing's `trace_task()` is shared by all of those. **Why not `bpf_cgroup_from_id()` per event:** at v6.6 `cgroup_get_from_id()` → `kernfs_find_and_get_node_by_id()` takes a plain `spin_lock(&kernfs_idr_lock)` (`fs/kernfs/dir.c`), not callable from `sched_wakeup` (hardirq context) or from the NMI sampler; at v6.12 that path is RCU, but the program-type limits above still hold. Resolving the pointers once at start in process context sidesteps both. **Why `bpf_cgroup_from_id()` rather than `bpf_cgroup_acquire(ctx->cgroup)` in the iterator:** at v6.6 the cgroup iterator's `ctx->cgroup` is `PTR_TO_BTF_ID_OR_NULL` without `PTR_TRUSTED` (it gained that in v6.7), so the acquire would not verify there; by-id works on both.

**Which kernels take which path.** The mode is decided once at start from the capability, not the version: if the running kernel's vmlinux BTF exports `bpf_task_under_cgroup` (`kernel_has_task_under_cgroup_kfunc()`, the same probe pattern as `kernel_has_rss_stat_btf()`; the kfunc is v6.5+ — `bpf_rcu_read_lock` 6.2, the cgroup iterator 6.1, referenced kptrs 6.0), `--cgroup` runs in **kernel mode** as described above. Otherwise it runs in **legacy mode**: the mechanism this PR started from — userspace enumerates each target and every descendant cgroup that exists at start (`collect_descendant_cgroup_ids()`) into the `cgroups` hash map, sized to that count, and every program matches the task's own cgroup id against the set exactly; cgroups created under a target after the trace started are not traced. That is the old behaviour, loss included, rather than no `--cgroup` at all. A rodata flag (`tool_config.cgroup_match_kernel`) routes `trace_task()` / `trace_task_btf()` to one path or the other; rodata is a verifier constant, so the branch not taken is dead code at load, the kfunc call behind `bpf_ksym_exists()` is never reached on a kernel without it, and the iterator program is only autoloaded in kernel mode. The mode in use is printed once at start. `SYSTING_CGROUP_FILTER_LEGACY=1` forces legacy mode on any kernel, so the fallback can be exercised — and is tested, below — where no pre-6.5 kernel is at hand. Not taken: a mixed mode (the helper for `current` on every kernel, the snapshot only for the non-current tasks in the sched tracepoints) would lose less on old kernels, but a task would then match in the sampler and not in the sched events on the same host; the fallback is the old behaviour whole.

**Cost.** Paid only when `--cgroup` is set, per target (normally one): one helper call (a pointer read and an array compare) in the non-`tp_btf` programs, one map lookup plus the kfunc's `ancestors[]` compare in the sched tracepoints. No probe reads, so nothing changes under lockdown confidentiality mode.

**Map/context pairing.** All three filter maps are written only from process context — `cgroup_targets` by userspace, `cgroup_target_refs` by the iterator program run by userspace before attach, the legacy `cgroups` set by userspace at start — and only read by the tracing programs; no BPF program that runs in NMI or IRQ context writes any of them, nothing is LRU, and the references are dropped with the map on exit. The maps of the mode not in use stay at one entry.

## Tests

- `src/cgroup.rs`: `cgroup_id()` returns the target's own inode only, errors on a missing path and on a non-directory; `collect_descendant_cgroup_ids()` (legacy mode) keeps its four tests — target first, descendants deduplicated, regular files and symlinks skipped, missing path / non-directory are errors.
- `src/systing_core.rs`: the pure mode decision (`cgroup_match_mode`: kernel mode iff the kfunc exists and nothing forces the fallback) and the program selection (the iterator program is required only in kernel mode).
- `tests/trace_validation.rs::test_e2e_cgroup_filter_follows_cgroups_created_after_start` (`#[ignore]`, root + BPF; unchanged apart from wording): creates `<own cgroup>/systing-cgf-<pid>/` as the `--cgroup` target and a sibling `…-outside/leaf/` with a busy task in it, starts a 10 s trace, and **3 s in** creates `target/mid/late/` and moves a second busy task there. It asserts the late task has a process row whose `cgroup_id` is the new leaf's inode, that it has stack samples or sched slices, and that the outside task has no row.
- `tests/trace_validation.rs::test_e2e_cgroup_filter_legacy_snapshot_fallback` (`#[ignore]`, root + BPF): the same fixture under `SYSTING_CGROUP_FILTER_LEGACY=1` (set for the test's duration by a drop guard), plus a leaf that exists under the target before the trace starts with a busy task in it. It asserts the inverse pair: the early task is traced in its own leaf with stack samples or sched slices (the snapshot covers the subtree as it was), the late task has **no** row (the legacy mode's known loss, and the proof the fallback was in effect — kernel mode would have traced it), and the outside task has no row.

## Verification

- `cargo fmt --all -- --check`: pass. `cargo clippy --all-targets -- -D warnings`: pass. `cargo test --lib --bins`: 521 + 11 + 28 passed, 0 failed (the four `collect_descendant_cgroup_ids` tests are back; the mode-decision and program-selection tests are new).
- `clang -target bpf` compile of `systing_system.bpf.c` with the build's include set: clean apart from the pre-existing `read_tcp_seq_from_skb` qualifier warning.
- VM run of both e2e tests (root + BPF) on a virtme-ng guest, kernel `6.12.0 #1 SMP PREEMPT_DYNAMIC` (BTF-enabled build; 4 vCPU / 8 GiB, software-emulated CPU): **`2 passed; 0 failed; 39 filtered out`** — `test_e2e_cgroup_filter_follows_cgroups_created_after_start` (kernel mode, as in the second patchset) and `test_e2e_cgroup_filter_legacy_snapshot_fallback` (the knob set): `early workload pid 303: traced, cgroup_id 102 (leaf), 10042 stack samples + sched slices` / `late workload pid 306: not traced (the legacy mode's known loss)` / `outside workload pid 304: not traced (correct)`. A first run of this patchset failed the legacy test on its discriminator: the snapshot was taken after the skeleton was opened, ~30 s into set-up on the emulated guest, so the cgroup the test creates 3 s in was already inside it; the snapshot now happens first thing in `systing()` (see How), and the rerun is the pass above. To run them yourself: `sudo ./scripts/run-integration-tests.sh trace_validation test_e2e_cgroup_filter`.
- Not run: a 6.6 kernel. On one, `--cgroup` takes legacy mode through the BTF probe; the forced-knob run above is the same code path with the probe's answer overridden.
- Rebased onto v1.13.13 (the merges of #211, #210 and #208) after the branch went conflicting: patchsets 1 and 2 re-applied unchanged; patchset 3's one conflict was both #210 and this branch appending tests to the same module tail (both kept), plus an `#[allow(clippy::too_many_arguments)]` on `configure_bpf_skeleton`, which now takes #210's ring plan beside this branch's `--cgroup` mode. Gates and both e2e tests re-run on the rebased bytes: `2 passed; 0 failed` on the same guest (`early workload pid 297: traced … 10027 stack samples + sched slices` / `late workload pid 300: not traced` / `outside workload pid 298: not traced`).

No schema, recorder, `Cargo.toml` version or dependency change.
