### PR TITLE
Name the cause when a --cgroup target cannot be resolved from the tracer's cgroup namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,12 @@ decided by the kernel's `bpf_task_under_cgroup()`, which needs **Linux kernel
 BTF) systing falls back to matching a snapshot of the target's cgroups taken
 when the trace starts, so cgroups created under the target afterwards are not
 traced; the mode in use is printed at start. Setting
-`SYSTING_CGROUP_FILTER_LEGACY=1` forces the fallback on any kernel.
+`SYSTING_CGROUP_FILTER_LEGACY` to any non-empty value (`=1` will do) forces the
+fallback on any kernel. The kernel resolves the target within systing's own
+cgroup namespace: from a container with a private cgroup namespace and the
+host's cgroup filesystem mounted, a host path is visible but cannot be
+resolved, and systing says so at start — run it in the host cgroup namespace
+or use the fallback.
 
 `--trace-event` - This will add an `instant` track event for each event that
 this tool captures.  The format is "<trace type>:<optional

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -1561,9 +1561,10 @@ static bool current_in_cgroup_filter(void)
  * this KF_RCU kfunc). The rcu section holds no lock and takes no reference:
  * one map lookup and one ancestors[] compare per target.
  *
- * Kernels without the kfunc (< 6.5) never get here - userspace refuses
- * --cgroup on them - and bpf_ksym_exists() keeps every program that inlines
- * this loadable there for traces without --cgroup.
+ * Kernels without the kfunc (< 6.5) never get here - userspace selects the
+ * legacy snapshot matching on them (tool_config.cgroup_match_kernel == 0,
+ * see task_in_legacy_cgroup_set) - and bpf_ksym_exists() keeps every program
+ * that inlines this loadable there.
  */
 static bool task_in_cgroup_filter(struct task_struct *task)
 {
@@ -1773,6 +1774,12 @@ static bool trace_task_common(struct task_struct *task)
  * the sched tracepoints: the --cgroup test here is on current, through the
  * helper every program type may call). A caller in a tp_btf program that
  * tests a task other than current uses trace_task_btf() instead.
+ *
+ * The task argument feeds the pid/tgid checks only: in kernel mode the
+ * --cgroup decision is bpf_current_task_under_cgroup(), which judges current
+ * whatever task was passed. There is no runtime guard (a helper call per
+ * event on the sampling paths is not worth it), so a new caller must pass
+ * current or use trace_task_btf().
  */
 static bool trace_task(struct task_struct *task)
 {

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -3133,9 +3133,7 @@ struct CgroupTarget {
 /// matching needs; without it the filter runs in legacy mode.
 fn kernel_has_task_under_cgroup_kfunc() -> bool {
     match libbpf_rs::btf::Btf::from_vmlinux() {
-        Ok(btf) => btf
-            .type_by_name::<libbpf_rs::btf::types::Func<'_>>("bpf_task_under_cgroup")
-            .is_some(),
+        Ok(btf) => btf_has_func(&btf, "bpf_task_under_cgroup"),
         Err(e) => {
             eprintln!(
                 "Warning: failed to open vmlinux BTF ({e}); \
@@ -3144,6 +3142,15 @@ fn kernel_has_task_under_cgroup_kfunc() -> bool {
             false
         }
     }
+}
+
+/// Does `btf` carry a FUNC named `name`? Kfuncs are ordinary kernel
+/// functions in vmlinux BTF, so this is the capability probe for any of
+/// them; it is the part of `kernel_has_task_under_cgroup_kfunc` a test can
+/// point at a real BTF with known positive and negative names.
+fn btf_has_func(btf: &libbpf_rs::btf::Btf<'_>, name: &str) -> bool {
+    btf.type_by_name::<libbpf_rs::btf::types::Func<'_>>(name)
+        .is_some()
 }
 
 /// Environment knob that forces the legacy `--cgroup` matching on a kernel that
@@ -3322,6 +3329,31 @@ fn add_cgroup_target_ref(prog: &libbpf_rs::ProgramMut<'_>, target: &CgroupTarget
 /// cgroup reference via the iterator program, and the slot is read back to
 /// confirm it holds that target's id — a silently-empty filter is exactly what
 /// this change exists to rule out.
+/// Userspace mirror of the BPF side's `struct cgroup_target_ref` (one entry
+/// of `cgroup_target_refs`): a kptr to the target cgroup, which reads back
+/// as zero from userspace, and the target's cgroup id beside it. The layout
+/// is what the id accessor derives its offset from; the size is checked
+/// against the bytes the map hands back, so a change on the BPF side fails
+/// loudly here instead of reading the wrong eight bytes.
+#[repr(C)]
+struct CgroupTargetRef {
+    cgrp: u64,
+    id: u64,
+}
+
+/// The `id` field of a `cgroup_target_refs` value as read from the map;
+/// `None` when the value is not the size of the struct.
+fn cgroup_target_ref_id(value: &[u8]) -> Option<u64> {
+    if value.len() != std::mem::size_of::<CgroupTargetRef>() {
+        return None;
+    }
+    let at = std::mem::offset_of!(CgroupTargetRef, id);
+    value
+        .get(at..at + std::mem::size_of::<u64>())
+        .and_then(|b| b.try_into().ok())
+        .map(u64::from_ne_bytes)
+}
+
 fn install_cgroup_targets(skel: &mut SystingSystemSkel, targets: &[CgroupTarget]) -> Result<()> {
     for (i, target) in targets.iter().enumerate() {
         let key = (i as u32).to_ne_bytes();
@@ -3342,13 +3374,23 @@ fn install_cgroup_targets(skel: &mut SystingSystemSkel, targets: &[CgroupTarget]
             .lookup(&key, libbpf_rs::MapFlags::ANY)
             .with_context(|| format!("Failed to read back cgroup_target_refs[{i}]"))?
             .ok_or_else(|| anyhow::anyhow!("cgroup_target_refs[{i}] is missing"))?;
-        // struct cgroup_target_ref { struct cgroup __kptr *cgrp; u64 id; }:
-        // the kptr reads back as zero from userspace, the id is what we check.
-        let id = slot
-            .get(8..16)
-            .and_then(|b| b.try_into().ok())
-            .map(u64::from_ne_bytes)
+        // The kptr reads back as zero from userspace; the id beside it is
+        // what the iterator program filled in (or left at zero).
+        let id = cgroup_target_ref_id(&slot)
             .ok_or_else(|| anyhow::anyhow!("cgroup_target_refs[{i}] has an unexpected size"))?;
+        if id == 0 {
+            bail!(
+                "--cgroup {}: the kernel could not resolve this cgroup (id {}) from the \
+                 tracer's cgroup namespace, so the iterator program left its slot empty. \
+                 That happens when systing runs in a container with a private cgroup \
+                 namespace and the host's cgroup filesystem mounted: the path is visible \
+                 but the cgroup is outside the namespace the kernel resolves it in. Run \
+                 systing in the host cgroup namespace, or set {CGROUP_FILTER_LEGACY_ENV} \
+                 to match a snapshot of the target's cgroups taken at start instead",
+                target.path,
+                target.id
+            );
+        }
         if id != target.id {
             bail!(
                 "cgroup_target_refs[{i}] holds cgroup id {id} after the iterator run, \
@@ -5278,5 +5320,41 @@ mod tests {
         let none = Config::default();
         assert!(!get_required_bpf_programs(&none, false, false, true)
             .contains("systing_cgroup_target_add"));
+    }
+
+    #[test]
+    fn cgroup_target_ref_id_reads_the_id_beside_the_kptr() {
+        // The value the map hands back: the kptr (zero from userspace) then
+        // the id, native endian, at the offset the mirror struct derives.
+        let mut value = [0u8; 16];
+        value[8..16].copy_from_slice(&0x1234_5678_9abc_def0u64.to_ne_bytes());
+        assert_eq!(cgroup_target_ref_id(&value), Some(0x1234_5678_9abc_def0));
+        // An unfilled slot reads as id 0 (the cgroup-namespace case).
+        assert_eq!(cgroup_target_ref_id(&[0u8; 16]), Some(0));
+        // Anything but the struct's size is refused, not mis-read.
+        assert_eq!(cgroup_target_ref_id(&[0u8; 8]), None);
+        assert_eq!(cgroup_target_ref_id(&[0u8; 24]), None);
+        assert_eq!(std::mem::size_of::<CgroupTargetRef>(), 16);
+        assert_eq!(std::mem::offset_of!(CgroupTargetRef, id), 8);
+    }
+
+    #[test]
+    fn btf_func_probe_sees_real_functions_and_not_invented_ones() {
+        // The capability probe behind the --cgroup mode choice, pointed at
+        // the running kernel's BTF: a function every Linux kernel exports
+        // must be found, an invented name must not. Skipped (with a note)
+        // where vmlinux BTF cannot be read.
+        let Ok(btf) = libbpf_rs::btf::Btf::from_vmlinux() else {
+            eprintln!("vmlinux BTF unavailable: skipping the BTF probe check");
+            return;
+        };
+        assert!(btf_has_func(&btf, "schedule"));
+        assert!(btf_has_func(&btf, "do_exit"));
+        assert!(!btf_has_func(&btf, "systing_no_such_kernel_function"));
+        // Reported, not asserted: whether this kernel has the kfunc.
+        eprintln!(
+            "bpf_task_under_cgroup in vmlinux BTF: {}",
+            btf_has_func(&btf, "bpf_task_under_cgroup")
+        );
     }
 }

--- a/tests/trace_validation.rs
+++ b/tests/trace_validation.rs
@@ -1538,6 +1538,126 @@ fn test_e2e_cgroup_filter_legacy_snapshot_fallback() {
     eprintln!("  outside workload pid {outside_pid}: not traced (correct)");
 }
 
+/// Kernel-mode `--cgroup` from a private cgroup namespace whose root does not
+/// contain the target: the kernel resolves the target within the caller's
+/// namespace, so it cannot be found, and systing must say so and name the
+/// fallback instead of failing on a bare map check. Runs systing as a child
+/// process (the test process's own namespaces are left alone): the child
+/// joins a leaf cgroup, unshares its cgroup namespace there, and asks for a
+/// sibling of that leaf. The second half runs the same command with the
+/// fallback forced and expects a trace.
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn test_e2e_cgroup_filter_outside_cgroupns_names_the_cause() {
+    use std::process::Command;
+
+    let Some(cgroup_root) = systing::cgroup::cgroup2_root() else {
+        eprintln!("skipping: no cgroup v2 unified hierarchy on this system");
+        return;
+    };
+    if !Path::new("/usr/bin/unshare").exists() {
+        eprintln!("skipping: no /usr/bin/unshare on this system");
+        return;
+    }
+    let base = match current_cgroup_v2_path() {
+        Some(p) if p != "/" => cgroup_root.join(p.trim_start_matches('/')),
+        _ => cgroup_root,
+    };
+    //   <base>/systing-cgn-<pid>/inside/   <- the child joins this, then unshares
+    //                                         its cgroup namespace: this leaf is
+    //                                         the namespace's root
+    //   <base>/systing-cgn-<pid>/outside/  <- the --cgroup target: a sibling,
+    //                                         outside that root
+    let tag = format!("systing-cgn-{}", std::process::id());
+    let parent = base.join(&tag);
+    let inside = parent.join("inside");
+    let outside = parent.join("outside");
+
+    let mut fixture = CgroupFixture { dirs: Vec::new() };
+    match fixture.create(&parent) {
+        Ok(()) => {}
+        Err(e)
+            if matches!(
+                e.kind(),
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::ReadOnlyFilesystem
+            ) =>
+        {
+            eprintln!(
+                "skipping: cannot create a cgroup under {} ({e})",
+                base.display()
+            );
+            return;
+        }
+        Err(e) => panic!("Failed to create cgroup {}: {e}", parent.display()),
+    }
+    for dir in [&inside, &outside] {
+        fixture
+            .create(dir)
+            .unwrap_or_else(|e| panic!("Failed to create cgroup {}: {e}", dir.display()));
+    }
+
+    let out_dir = TempDir::new().expect("Failed to create temp dir");
+    let script = format!(
+        "echo $$ > {procs} && exec /usr/bin/unshare -C {systing} --cgroup {target} \
+         --duration 1 --no-stack-traces --output-dir {out} --output {out}/trace.pb",
+        procs = inside.join("cgroup.procs").display(),
+        systing = env!("CARGO_BIN_EXE_systing"),
+        target = outside.display(),
+        out = out_dir.path().display(),
+    );
+    let run = |force_legacy: bool| {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(&script);
+        if force_legacy {
+            cmd.env("SYSTING_CGROUP_FILTER_LEGACY", "1");
+        } else {
+            cmd.env_remove("SYSTING_CGROUP_FILTER_LEGACY");
+        }
+        let output = cmd
+            .output()
+            .expect("Failed to run systing in a cgroup namespace");
+        (
+            output.status.success(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        )
+    };
+
+    eprintln!(
+        "Running systing --cgroup {} from a private cgroup namespace rooted at {}",
+        outside.display(),
+        inside.display()
+    );
+    let (ok, stderr) = run(false);
+    if stderr.contains("does not export bpf_task_under_cgroup") {
+        eprintln!("kernel mode unavailable on this kernel; the namespace check only applies there");
+    } else {
+        assert!(
+            !ok,
+            "[cgroupns] systing should refuse a target outside its cgroup namespace:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("from the tracer's cgroup namespace"),
+            "[cgroupns] the refusal must name the cause:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("SYSTING_CGROUP_FILTER_LEGACY"),
+            "[cgroupns] the refusal must name the fallback:\n{stderr}"
+        );
+        eprintln!("  refused with the cause named (correct)");
+    }
+
+    let (ok, stderr) = run(true);
+    assert!(
+        ok,
+        "[cgroupns] the forced fallback should trace the same target:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("SYSTING_CGROUP_FILTER_LEGACY is set"),
+        "[cgroupns] the fallback run must announce its mode:\n{stderr}"
+    );
+    eprintln!("  forced fallback traced it (correct)");
+}
+
 // =============================================================================
 // Consolidated network suite
 //


### PR DESCRIPTION
## What changes

Follow-up to #209 (`--cgroup` matching decided by the kernel):

1. **A `--cgroup` target the kernel cannot resolve from the tracer's cgroup namespace is refused with the cause named.** In kernel mode the iterator program parks a reference to each target with `bpf_cgroup_from_id()`, and the kernel resolves that id within the calling process's cgroup namespace. From a container with a private cgroup namespace and the host's cgroup filesystem mounted (the `kubectl debug` / privileged-pod pattern), a host path is visible — the fd steps have no namespace check — but the id is outside the namespace, the iterator gets nothing, and systing failed on a bare map check (`cgroup_target_refs[0] holds cgroup id 0 after the iterator run, expected N`). It now says: the kernel could not resolve this cgroup from the tracer's cgroup namespace; run systing in the host cgroup namespace, or set `SYSTING_CGROUP_FILTER_LEGACY` to match a start-time snapshot instead.
2. **A new e2e test reproduces that case** (`test_e2e_cgroup_filter_outside_cgroupns_names_the_cause`): a child process joins a leaf cgroup, `unshare -C`s there so that leaf is its namespace root, and runs the `systing` binary with `--cgroup <sibling of the leaf>`. Kernel mode must exit non-zero with the cause and the knob named; the same command with the knob set must trace.
3. **`install_cgroup_targets` reads the id from a layout, not from bytes 8..16.** A `#[repr(C)]` mirror of the BPF side's `struct cgroup_target_ref { struct cgroup __kptr *cgrp; u64 id; }` supplies the offset (`offset_of!`), and the value's size is checked against the mirror, so a change on the BPF side fails loudly.
4. **The BTF probe has a unit test.** `kernel_has_task_under_cgroup_kfunc()` now calls `btf_has_func(&btf, name)`, tested against the running kernel's BTF with a function every kernel exports, an invented name, and a report of whether the kfunc is present.
5. Comments and docs: the stale BPF comment ("userspace refuses `--cgroup` on kernels without the kfunc" — it falls back) is corrected; `trace_task()`'s comment says its `task` argument feeds only the pid checks in kernel mode (the `--cgroup` decision is on `current` through the helper) and why there is no runtime guard; the README says any non-empty value of `SYSTING_CGROUP_FILTER_LEGACY` forces the fallback and carries the cgroup-namespace note.

## Why not an automatic fallback

The mode is a rodata constant (`tool_config.cgroup_match_kernel`) fixed before the skeleton loads, and the iterator runs after load; falling back automatically would mean re-opening and re-loading the skeleton in legacy mode for that run — a second BPF load and a second code path to test — for a case the host-level unit never hits (it runs in the root cgroup namespace). The named cause plus the knob is the honest cure for the human debug-container case. If the automatic fallback is wanted anyway, it is a contained change at the same bail site.

## Kernel facts the refusal rests on

`cgroup_get_from_id()` (`kernel/cgroup/cgroup.c`, 6.6 through 6.18) looks the id up in the cgroup kernfs and then checks that the cgroup descends from the calling process's cgroup namespace root (`cgroup_is_descendant(cgrp, root_cgrp)`), returning `-ENOENT` otherwise; `bpf_cgroup_from_id()` is a thin kfunc over it. The fd-based steps (`cgroup_targets`, the iterator attach by fd) have no namespace check, which is why the failure surfaced only at the id step.

## Tests

- `cargo fmt --all -- --check`: pass. `cargo clippy --all-targets -- -D warnings`: pass (re-run on the committed bytes). `cargo test --lib --bins`: 539 + 11 + 28 passed, 0 failed — `cgroup_target_ref_id_reads_the_id_beside_the_kptr` and `btf_func_probe_sees_real_functions_and_not_invented_ones` by name.
- `clang -target bpf` compile of `systing_system.bpf.c` with the build's include set: clean apart from the pre-existing `read_tcp_seq_from_skb` qualifier warning (the BPF change is two comments).
- VM run of the three `--cgroup` e2e tests (root + BPF) on a virtme-ng guest, kernel `6.12.0` (BTF-enabled build; 4 vCPU / 8 GiB, software-emulated CPU): **`3 passed; 0 failed; 39 filtered out`** — the kernel-mode and forced-legacy tests as before, and the new `test_e2e_cgroup_filter_outside_cgroupns_names_the_cause`: `Running systing --cgroup /sys/fs/cgroup/systing-cgn-252/outside from a private cgroup namespace rooted at /sys/fs/cgroup/systing-cgn-252/inside` → `refused with the cause named (correct)` → `forced fallback traced it (correct)`. To run them yourself: `sudo ./scripts/run-integration-tests.sh trace_validation test_e2e_cgroup_filter`.

## Not changed

The mode choice and both matching paths; the BPF programs (one comment); no schema, recorder, `Cargo.toml` version or dependency change.
