### PR TITLE
analyze: close two ways around the MCP `query` tool's bounds — one statement per call, and a locked configuration

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -43,7 +43,7 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use query::{duckdb_value_to_json, duckdb_value_to_string};
+use query::{duckdb_value_to_json, duckdb_value_to_string, statement_shape, StatementShape};
 
 /// Distinguishes the spill directories of databases opened by one process:
 /// DuckDB names temp files by block id, which is only unique per instance, so
@@ -118,19 +118,36 @@ pub const MAX_QUERY_ROWS: usize = 10_000;
 const MAX_TRACE_INFO_PROCESSES: usize = 25;
 
 /// Result of a SQL query.
-#[derive(Debug, Serialize)]
+///
+/// Serialized as `columns`, `rows`, `row_count`, and — only when the result
+/// was cut at `MAX_QUERY_ROWS` — `truncated: true` plus `total_row_count`,
+/// which is `null` when the separate count could not be computed.
+#[derive(Debug)]
 pub struct QueryResult {
     pub columns: Vec<String>,
     pub rows: Vec<Vec<serde_json::Value>>,
     pub row_count: usize,
-    #[serde(skip_serializing_if = "is_false")]
     pub truncated: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub total_row_count: Option<usize>,
 }
 
-fn is_false(b: &bool) -> bool {
-    !b
+impl Serialize for QueryResult {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let fields = if self.truncated { 5 } else { 3 };
+        let mut s = serializer.serialize_struct("QueryResult", fields)?;
+        s.serialize_field("columns", &self.columns)?;
+        s.serialize_field("rows", &self.rows)?;
+        s.serialize_field("row_count", &self.row_count)?;
+        if self.truncated {
+            s.serialize_field("truncated", &true)?;
+            s.serialize_field("total_row_count", &self.total_row_count)?;
+        }
+        s.end()
+    }
 }
 
 /// Table information.
@@ -253,16 +270,11 @@ pub struct AnalyzeDb {
 
 /// Text DuckDB puts at the front of every `OutOfMemoryException` message,
 /// whether the buffer pool hit `memory_limit` or a spill hit
-/// `max_temp_directory_size` ("failed to offload data block"). Matched as a
-/// substring because the binding may wrap the engine's message.
+/// `max_temp_directory_size` ("failed to offload data block"). The binding's
+/// `Display` prints the engine's message bare, so it is matched as a prefix:
+/// a user's own string literal that happens to contain the words cannot
+/// trigger the rewrite.
 const DUCKDB_OOM_MARKER: &str = "Out of Memory Error";
-
-/// Strip trailing whitespace and statement terminators so the text can be
-/// embedded as a subquery.
-fn trim_statement(sql: &str) -> &str {
-    sql.trim()
-        .trim_end_matches(|c: char| c == ';' || c.is_whitespace())
-}
 
 impl AnalyzeDb {
     /// Open a trace database.
@@ -281,11 +293,12 @@ impl AnalyzeDb {
     /// passes it here (any DuckDB size string, e.g. "8GiB") so an oversized
     /// aggregation fails that one query instead of killing the process.
     ///
-    /// This is a structural default, not a jail: unlike `temp_directory`,
-    /// DuckDB does not lock this setting when external access is disabled,
-    /// so in-session SQL can still raise it (covered by a test). That is the
-    /// right trade for the intended failure mode — queries that never think
-    /// about spill — and it keeps deliberate in-session tuning possible.
+    /// On its own this is a structural default, not a jail: unlike
+    /// `temp_directory`, DuckDB does not lock this setting when external
+    /// access is disabled, so in-session SQL can still raise it (covered by a
+    /// test), which keeps deliberate tuning possible on the CLI. The MCP
+    /// server, whose SQL is untrusted, freezes it along with every other
+    /// setting by calling [`AnalyzeDb::lock_configuration`] right after open.
     pub fn open_with_spill_cap(
         path: &Path,
         read_only: bool,
@@ -360,7 +373,7 @@ impl AnalyzeDb {
     /// offending column or table.
     fn classify_query_error(&self, err: duckdb::Error) -> anyhow::Error {
         let msg = err.to_string();
-        if msg.contains(DUCKDB_OOM_MARKER) {
+        if msg.starts_with(DUCKDB_OOM_MARKER) {
             let bound = match self.mem_limit_mib {
                 Some(m) => format!(" ({m} MiB)"),
                 None => String::new(),
@@ -371,6 +384,21 @@ impl AnalyzeDb {
         } else {
             err.into()
         }
+    }
+
+    /// Freeze DuckDB's configuration for the rest of this connection's life:
+    /// every later `SET` / `RESET` / `PRAGMA` of a configuration option
+    /// (`memory_limit`, `threads`, `max_temp_directory_size`, ...) fails with
+    /// DuckDB's own "configuration has been locked" error, and the lock
+    /// itself cannot be undone. The MCP server calls this right after
+    /// `open`, so SQL that reaches it — including SQL an AI assistant was
+    /// talked into running — cannot lift the memory and spill bounds the
+    /// server was started with. The CLI does not lock, so an operator's own
+    /// in-session tuning keeps working there.
+    pub fn lock_configuration(&self) -> Result<()> {
+        self.conn
+            .execute_batch("SET lock_configuration = true")
+            .map_err(|e| anyhow::anyhow!("failed to lock the DuckDB configuration: {e}"))
     }
 
     /// Execute a SQL query and return typed results.
@@ -384,17 +412,35 @@ impl AnalyzeDb {
     /// process past its cgroup limit. When the result is truncated,
     /// `total_row_count` comes from a separate `SELECT count(*) FROM (<sql>)`,
     /// which re-runs the query's pipeline once under DuckDB's memory bound
-    /// without materializing rows.
+    /// without materializing rows (the inner ORDER BY runs again too; that is
+    /// time, not memory).
     ///
-    /// Statements that cannot be embedded as a subquery (`SHOW`, `PRAGMA`,
-    /// `SET`, `COPY`, ...) fail to *prepare* in wrapped form; they then run
-    /// exactly as written, with the row cap applied as rows are read. A
-    /// failure while *executing* the wrapped statement is reported directly —
-    /// the raw statement is never re-run unbounded.
+    /// The text is classified first (`statement_shape`): comments and
+    /// leading/trailing `;` are stripped so they cannot hide a statement
+    /// from the wrapper, and more than one statement is refused. A
+    /// statement that reads rows (`SELECT`, `WITH`, `FROM`, `VALUES`, ...)
+    /// runs ONLY in wrapped form: if it cannot be wrapped it is refused, and
+    /// a SQL error in it is reported against the user's own text by
+    /// preparing — never executing — the raw statement. Statements that
+    /// cannot be embedded as a subquery (`SHOW`, `PRAGMA`, `DESCRIBE`,
+    /// `SUMMARIZE`, `EXPLAIN`, ...) run as written with the cap applied as
+    /// rows are read; their results are small by nature. A failure while
+    /// *executing* the wrapped statement is reported directly — the raw
+    /// statement is never re-run unbounded.
+    ///
+    /// Execution-time errors from the wrapped form name line numbers
+    /// relative to the user's text plus the wrapper's first line.
     pub fn query(&self, sql: &str) -> Result<QueryResult> {
-        let inner = trim_statement(sql);
-        // The newline before the closing paren keeps a trailing `--` comment
-        // in the user's SQL from swallowing it.
+        let (inner, must_wrap) = match statement_shape(sql) {
+            StatementShape::Empty => bail!("empty query"),
+            StatementShape::Multiple => bail!(
+                "only one statement per query is supported; remove the `;`-separated statement that follows the first one"
+            ),
+            StatementShape::Single { text, must_wrap } => (text, must_wrap),
+        };
+        // The newline before the closing paren is a belt on top of the
+        // comment stripping: a `--` the classifier missed still cannot
+        // swallow it.
         let wrapped = format!(
             "SELECT * FROM (\n{inner}\n) AS __systing_query LIMIT {}",
             MAX_QUERY_ROWS + 1
@@ -405,16 +451,26 @@ impl AnalyzeDb {
                 let (mut result, beyond_cap) = self.run_capped(&mut stmt, false)?;
                 if beyond_cap > 0 {
                     result.truncated = true;
-                    result.total_row_count = self.count_rows(inner);
+                    result.total_row_count = self.count_rows(&inner);
                 }
                 Ok(result)
             }
             Err(_) => {
-                // Not a SELECT-shaped statement (or a SQL error that the raw
-                // form reports against the user's own text): run it as
-                // written. The result is already materialized, so the rows
-                // beyond the cap are drained and counted as before.
-                let mut stmt = self.conn.prepare(sql)?;
+                // Prepare the user's own text so a SQL error names their
+                // line and column, not the wrapper's.
+                let mut stmt = self.conn.prepare(&inner)?;
+                if must_wrap {
+                    // It prepares on its own but not inside the wrapper: a
+                    // shape that can read rows and that the cap cannot
+                    // bound, so it does not run at all rather than run
+                    // unbounded.
+                    bail!(
+                        "query could not be bounded by the {MAX_QUERY_ROWS}-row cap; rewrite it as a single SELECT statement"
+                    );
+                }
+                // A non-row-reading statement: run it as written. Its result
+                // is small by nature and already materialized, so the rows
+                // beyond the cap are drained and counted.
                 let (mut result, beyond_cap) = self.run_capped(&mut stmt, true)?;
                 if beyond_cap > 0 {
                     result.truncated = true;
@@ -1025,12 +1081,13 @@ mod tests {
         assert!(err.is_err(), "malformed spill cap was silently accepted");
     }
 
-    /// Documents the cap's trust boundary: `enable_external_access(false)`
-    /// locks `temp_directory` but NOT `max_temp_directory_size`, so SQL run
-    /// in-session can still raise the bound. The flag is a structural
-    /// default protecting against queries that never think about spill (the
-    /// real-world failure mode), not a jail against adversarial SQL — an
-    /// adversary with query access could raise it back. If DuckDB ever
+    /// Documents the cap's trust boundary on an UNLOCKED connection (the CLI):
+    /// `enable_external_access(false)` locks `temp_directory` but NOT
+    /// `max_temp_directory_size`, so SQL run in-session can still raise the
+    /// bound. The flag alone is a structural default protecting against
+    /// queries that never think about spill (the real-world failure mode);
+    /// the MCP server closes the adversarial case with `lock_configuration`
+    /// (see `test_lock_configuration_refuses_settings`). If DuckDB ever
     /// starts locking this setting alongside temp_directory, this test
     /// fails and the doc-comments should be updated to promise more.
     #[test]
@@ -1376,6 +1433,15 @@ mod tests {
             Some("Binder Error: Referenced column \"nope\" not found".to_string()),
         );
         assert!(db.classify_query_error(other).to_string().contains("nope"));
+        // A user's own string literal containing the marker is not an OOM.
+        let literal = duckdb::Error::DuckDBFailure(
+            duckdb::ffi::Error::new(1),
+            Some("Binder Error: column \"Out of Memory Error\" not found".to_string()),
+        );
+        assert!(db
+            .classify_query_error(literal)
+            .to_string()
+            .starts_with("Binder Error"));
 
         // End to end: a sort that cannot fit in a tiny memory limit with a
         // tiny spill cap is refused by DuckDB's out-of-memory class, and the
@@ -1392,5 +1458,160 @@ mod tests {
             err.starts_with("query exceeded the DuckDB memory bound"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_query_comments_and_terminators_cannot_bypass_the_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_query_test_db(dir.path());
+
+        // Each of these used to fail the wrapped prepare on the internal `;`
+        // and fall back to an unbounded raw run.
+        for sql in [
+            "SELECT bucket FROM t; -- all of them",
+            "SELECT bucket FROM t;\n-- note",
+            "SELECT bucket FROM t; /* x */",
+            ";SELECT bucket FROM t",
+            "/* leading */ SELECT bucket FROM t /* trailing */ ;",
+        ] {
+            let result = db.query(sql).unwrap();
+            assert_eq!(result.row_count, MAX_QUERY_ROWS, "{sql:?}");
+            assert!(result.truncated, "{sql:?} was not capped");
+            assert_eq!(result.total_row_count, Some(25000), "{sql:?}");
+        }
+
+        // A comment-looking sequence inside a string literal is data.
+        let result = db
+            .query("SELECT '-- not a comment; still one statement' AS s, id FROM t")
+            .unwrap();
+        assert!(result.truncated);
+        assert_eq!(
+            result.rows[0][0],
+            serde_json::json!("-- not a comment; still one statement")
+        );
+
+        // More than one statement is refused outright, whatever the second
+        // one is — it never runs.
+        for sql in [
+            "SELECT 1; SELECT 2",
+            "SELECT id FROM t; SET memory_limit = '100GB'",
+            "SELECT id FROM t LIMIT 1; PRAGMA max_temp_directory_size = '100GB'",
+        ] {
+            let err = db.query(sql).unwrap_err().to_string();
+            assert!(err.contains("one statement"), "{sql:?}: {err}");
+        }
+        let err = db.query("  -- nothing here\n;").unwrap_err().to_string();
+        assert!(err.contains("empty query"), "{err}");
+    }
+
+    #[test]
+    fn test_query_refuses_row_readers_it_cannot_wrap() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_query_test_db(dir.path());
+
+        // `CALL` and `EXECUTE` run whatever they name, so they may not take
+        // the raw path; neither can be a subquery, so both are refused with
+        // the fixed message — never run unbounded.
+        db.conn
+            .execute_batch("PREPARE q AS SELECT id FROM t")
+            .unwrap();
+        for sql in ["EXECUTE q", "CALL pragma_table_info('t')"] {
+            let err = db.query(sql).unwrap_err().to_string();
+            assert!(err.contains("could not be bounded"), "{sql:?}: {err}");
+        }
+        // The same rows are reachable through a bounded SELECT.
+        assert_eq!(
+            db.query("SELECT * FROM pragma_table_info('t')")
+                .unwrap()
+                .row_count,
+            2
+        );
+    }
+
+    #[test]
+    fn test_query_cap_boundaries_and_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_query_test_db(dir.path());
+
+        // Descending order is kept through the wrapper: the first cap-many
+        // rows of the query's own order come back.
+        let result = db.query("SELECT id FROM t ORDER BY id DESC").unwrap();
+        assert!(result.truncated);
+        assert_eq!(result.rows[0][0], serde_json::json!(24999));
+        assert_eq!(
+            result.rows[MAX_QUERY_ROWS - 1][0],
+            serde_json::json!(25000 - MAX_QUERY_ROWS)
+        );
+
+        // Exactly cap + 1 rows is the smallest truncated result.
+        let result = db
+            .query(&format!("SELECT id FROM t WHERE id <= {MAX_QUERY_ROWS}"))
+            .unwrap();
+        assert_eq!(result.row_count, MAX_QUERY_ROWS);
+        assert!(result.truncated);
+        assert_eq!(result.total_row_count, Some(MAX_QUERY_ROWS + 1));
+    }
+
+    #[test]
+    fn test_query_result_json_shape() {
+        let not_truncated = QueryResult {
+            columns: vec!["a".into()],
+            rows: vec![vec![serde_json::json!(1)]],
+            row_count: 1,
+            truncated: false,
+            total_row_count: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&not_truncated).unwrap(),
+            serde_json::json!({"columns": ["a"], "rows": [[1]], "row_count": 1})
+        );
+        let uncounted = QueryResult {
+            columns: vec!["a".into()],
+            rows: vec![],
+            row_count: 0,
+            truncated: true,
+            total_row_count: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&uncounted).unwrap(),
+            serde_json::json!({"columns": ["a"], "rows": [], "row_count": 0, "truncated": true, "total_row_count": null})
+        );
+    }
+
+    #[test]
+    fn test_lock_configuration_refuses_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_query_test_db(dir.path());
+        let before = db.query("SELECT current_setting('memory_limit')").unwrap();
+        db.lock_configuration().unwrap();
+
+        // Every spelling of "raise the bound" is refused with DuckDB's
+        // locked-configuration class, and none changes the setting.
+        for sql in [
+            "SET memory_limit = '100GB'",
+            "SET max_memory = '100GB'",
+            "SET threads = 1",
+            "SET max_temp_directory_size = '100GB'",
+            "PRAGMA max_temp_directory_size = '100GB'",
+            "PRAGMA memory_limit = '100GB'",
+            "RESET memory_limit",
+            "SET GLOBAL memory_limit = '100GB'",
+            "SET lock_configuration = false",
+        ] {
+            let err = db.query(sql).unwrap_err().to_string();
+            assert!(err.contains("locked"), "{sql:?}: {err}");
+        }
+        let after = db.query("SELECT current_setting('memory_limit')").unwrap();
+        assert_eq!(before.rows, after.rows);
+
+        // Reads are unaffected, including the statements that take the raw
+        // path.
+        assert_eq!(
+            db.query("SELECT count(*) FROM t").unwrap().rows[0][0],
+            serde_json::json!(25000)
+        );
+        assert_eq!(db.query("PRAGMA table_info('t')").unwrap().row_count, 2);
+        assert_eq!(db.query("SHOW TABLES").unwrap().row_count, 1);
+        assert!(db.query("SELECT id FROM t").unwrap().truncated);
     }
 }

--- a/src/analyze/query.rs
+++ b/src/analyze/query.rs
@@ -58,9 +58,224 @@ pub(super) fn duckdb_value_to_string(value: duckdb::types::Value) -> String {
     }
 }
 
+/// What a query's text turned out to be once comments and statement
+/// terminators are removed.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum StatementShape {
+    /// Nothing but whitespace, comments and terminators.
+    Empty,
+    /// More than one `;`-separated statement.
+    Multiple,
+    /// Exactly one statement. `text` is that statement without comments and
+    /// without leading or trailing terminators; `must_wrap` says whether it
+    /// can read rows from a table — `SELECT`, `WITH`, `FROM`, `VALUES`,
+    /// `TABLE`, `PIVOT`, `UNPIVOT`, and `CALL` / `EXECUTE`, which run
+    /// whatever they name — and so may only run inside the
+    /// `SELECT * FROM (...) LIMIT n` wrapper.
+    Single { text: String, must_wrap: bool },
+}
+
+/// Classify `sql` for the row cap: strip `--` and `/* */` comments (nested
+/// block comments included), drop leading and trailing `;`, and report
+/// whether what remains is one statement. Single- and double-quoted strings
+/// are passed through untouched, so a `;` or `--` inside a literal is not a
+/// separator or a comment. A dollar-quoted string (`$$ ... $$`) is not
+/// recognised; a `;` inside one reads as a separator, which fails closed.
+pub(super) fn statement_shape(sql: &str) -> StatementShape {
+    let mut out = String::with_capacity(sql.len());
+    // Byte offsets in `out` of every `;` that separates statements.
+    let mut separators: Vec<usize> = Vec::new();
+    let chars: Vec<char> = sql.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        let next = chars.get(i + 1).copied();
+        match c {
+            '\'' | '"' => {
+                // Copy the quoted run verbatim; a doubled quote is an escape.
+                out.push(c);
+                i += 1;
+                while i < chars.len() {
+                    out.push(chars[i]);
+                    if chars[i] == c {
+                        if chars.get(i + 1) == Some(&c) {
+                            out.push(c);
+                            i += 2;
+                            continue;
+                        }
+                        break;
+                    }
+                    i += 1;
+                }
+                i += 1;
+            }
+            '-' if next == Some('-') => {
+                while i < chars.len() && chars[i] != '\n' {
+                    i += 1;
+                }
+                out.push(' ');
+            }
+            '/' if next == Some('*') => {
+                let mut depth = 1usize;
+                i += 2;
+                while i < chars.len() && depth > 0 {
+                    if chars[i] == '/' && chars.get(i + 1) == Some(&'*') {
+                        depth += 1;
+                        i += 2;
+                    } else if chars[i] == '*' && chars.get(i + 1) == Some(&'/') {
+                        depth -= 1;
+                        i += 2;
+                    } else {
+                        i += 1;
+                    }
+                }
+                out.push(' ');
+            }
+            ';' => {
+                // A terminator only counts once a statement precedes it;
+                // leading ones are dropped here and trailing ones are
+                // trimmed below.
+                if !out.trim().is_empty() {
+                    separators.push(out.len());
+                    out.push(';');
+                }
+                i += 1;
+            }
+            _ => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+
+    let text = out
+        .trim()
+        .trim_end_matches(|c: char| c == ';' || c.is_whitespace());
+    if text.is_empty() {
+        return StatementShape::Empty;
+    }
+    // Separators followed only by whitespace and comments were trimmed off
+    // the end; one inside the remaining text splits statements.
+    let start = out.len() - out.trim_start().len();
+    let end = start + text.len();
+    if separators.iter().any(|&p| p >= start && p < end) {
+        return StatementShape::Multiple;
+    }
+    let first_word: String = text
+        .trim_start_matches(|c: char| c == '(' || c.is_whitespace())
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect::<String>()
+        .to_ascii_lowercase();
+    let must_wrap = matches!(
+        first_word.as_str(),
+        "select" | "with" | "from" | "values" | "table" | "pivot" | "unpivot" | "call" | "execute"
+    );
+    StatementShape::Single {
+        text: text.to_string(),
+        must_wrap,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn single(sql: &str) -> (String, bool) {
+        match statement_shape(sql) {
+            StatementShape::Single { text, must_wrap } => (text, must_wrap),
+            other => panic!("expected a single statement for {sql:?}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_statement_shape_strips_comments_and_terminators() {
+        assert_eq!(
+            single("SELECT bucket FROM t; -- all of them"),
+            ("SELECT bucket FROM t".to_string(), true)
+        );
+        assert_eq!(
+            single("SELECT bucket FROM t;\n-- note\n"),
+            ("SELECT bucket FROM t".to_string(), true)
+        );
+        assert_eq!(
+            single("SELECT bucket FROM t; /* x */"),
+            ("SELECT bucket FROM t".to_string(), true)
+        );
+        assert_eq!(
+            single(";SELECT bucket FROM t"),
+            ("SELECT bucket FROM t".to_string(), true)
+        );
+        assert_eq!(
+            single("/* a /* nested */ b */ SELECT 1"),
+            ("SELECT 1".to_string(), true)
+        );
+        assert_eq!(
+            single("  ;; \n WITH b AS (SELECT 1) SELECT * FROM b ; ; "),
+            ("WITH b AS (SELECT 1) SELECT * FROM b".to_string(), true)
+        );
+    }
+
+    #[test]
+    fn test_statement_shape_keeps_literals_intact() {
+        assert_eq!(
+            single("SELECT '--not a comment; really' AS s, \"we;ird\" FROM t"),
+            (
+                "SELECT '--not a comment; really' AS s, \"we;ird\" FROM t".to_string(),
+                true
+            )
+        );
+        assert_eq!(
+            single("SELECT 'it''s; fine' FROM t"),
+            ("SELECT 'it''s; fine' FROM t".to_string(), true)
+        );
+    }
+
+    #[test]
+    fn test_statement_shape_classifies_multiple_and_empty() {
+        assert_eq!(
+            statement_shape("SELECT 1; SELECT 2"),
+            StatementShape::Multiple
+        );
+        assert_eq!(
+            statement_shape("SELECT id FROM t; SET memory_limit = '100GB'"),
+            StatementShape::Multiple
+        );
+        assert_eq!(
+            statement_shape("SELECT 'a' ; -- x\n SELECT 'b'"),
+            StatementShape::Multiple
+        );
+        assert_eq!(statement_shape("  -- nothing\n;"), StatementShape::Empty);
+        assert_eq!(statement_shape(""), StatementShape::Empty);
+    }
+
+    #[test]
+    fn test_statement_shape_must_wrap_keywords() {
+        for sql in [
+            "select 1",
+            "WITH x AS (SELECT 1) SELECT * FROM x",
+            "FROM t SELECT id",
+            "VALUES (1), (2)",
+            "TABLE t",
+            "(SELECT 1) UNION ALL (SELECT 2)",
+            "(\n  (SELECT 1)\n)",
+            "PIVOT t ON bucket",
+            "CALL pragma_table_info('t')",
+            "EXECUTE q",
+        ] {
+            assert!(single(sql).1, "{sql:?} must run wrapped");
+        }
+        for sql in [
+            "SHOW TABLES",
+            "PRAGMA table_info('t')",
+            "DESCRIBE t",
+            "SUMMARIZE t",
+            "SET memory_limit = '1GB'",
+            "EXPLAIN SELECT 1",
+        ] {
+            assert!(!single(sql).1, "{sql:?} takes the raw path");
+        }
+    }
 
     #[test]
     fn test_duckdb_value_to_json_types() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -130,6 +130,11 @@ fn get_or_open<'a>(
         }
         let db = AnalyzeDb::open_with_spill_cap(&canonical, true, spill_cap)
             .map_err(|e| format!("Failed to open database '{}': {e}", canonical.display()))?;
+        // Every bound the server was started with (memory limit, thread
+        // count, spill cap, external access) is frozen from here on, so SQL
+        // arriving through the tools cannot lift them with SET / PRAGMA.
+        db.lock_configuration()
+            .map_err(|e| format!("Failed to open database '{}': {e}", canonical.display()))?;
         dbs.insert(canonical.clone(), db);
     }
 
@@ -535,7 +540,7 @@ impl SystingMcpServer {
 
     #[tool(
         name = "query",
-        description = "Execute a read-only SQL query against a trace database. Returns JSON with 'columns' (array of column names), 'rows' (array of arrays with properly typed values — numbers as numbers, not strings), and 'row_count'. Results are capped at 10,000 rows, applied inside DuckDB (the query runs as a subquery with LIMIT 10,001, so rows beyond the cap are never produced); if truncated, includes 'truncated: true' and 'total_row_count' from a separate count(*) over the same query. Use SQL LIMIT/OFFSET for pagination. DuckDB runs under a fixed memory bound; a query that exceeds it fails with a message saying so — narrow the time window, add LIMIT, or aggregate. The database is read-only, so INSERT/UPDATE/DELETE will fail."
+        description = "Execute one read-only SQL statement against a trace database. Returns JSON with 'columns' (array of column names), 'rows' (array of arrays with properly typed values — numbers as numbers, not strings), and 'row_count'. Results are capped at 10,000 rows, applied inside DuckDB (the statement runs as a subquery with LIMIT 10,001, so rows beyond the cap are never produced); if truncated, includes 'truncated: true' and 'total_row_count' from a separate count(*) over the same statement (null if that count fails). Use SQL LIMIT/OFFSET for pagination. One statement per call: comments are fine, a second ';'-separated statement is refused. DuckDB runs under fixed, locked memory and spill bounds — SET/PRAGMA of memory_limit, threads or max_temp_directory_size are refused — and a query that exceeds the memory bound fails with a message saying so: narrow the time window, add LIMIT, or aggregate. The database is read-only, so INSERT/UPDATE/DELETE will fail."
     )]
     async fn query(
         &self,
@@ -903,6 +908,38 @@ pub async fn run_mcp_server(
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    /// A database the server opens is locked: the bounds it was opened with
+    /// cannot be changed by SQL arriving through the tools.
+    #[test]
+    fn test_get_or_open_locks_configuration() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("locked.duckdb");
+        {
+            let conn = duckdb::Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE t AS SELECT range AS id FROM range(10)")
+                .unwrap();
+        }
+        let mut dbs = HashMap::new();
+        let mut last_used = None;
+        let db = get_or_open(&mut dbs, &mut last_used, Some("100MiB"), Some(db_path)).unwrap();
+        for sql in [
+            "SET memory_limit = '100GB'",
+            "SET max_temp_directory_size = '100GB'",
+            "PRAGMA threads = 1",
+        ] {
+            let err = db.query(sql).unwrap_err().to_string();
+            assert!(err.contains("locked"), "{sql:?}: {err}");
+        }
+        assert_eq!(
+            db.query("SELECT count(*) FROM t").unwrap().rows[0][0],
+            serde_json::json!(10)
+        );
+        let cap = db
+            .query("SELECT current_setting('max_temp_directory_size')")
+            .unwrap();
+        assert_eq!(cap.rows[0][0].as_str().unwrap(), "100.0 MiB");
+    }
 
     /// Verify that the MCP tool router contains exactly the expected set of tools.
     ///


### PR DESCRIPTION
## What changes

Two ways around the bounds systing#213 put on the MCP `query` tool are closed. A statement is classified before anything runs: comments and stray `;` are stripped, a second `;`-separated statement is refused, and a statement that can read rows (`SELECT`, `WITH`, `FROM`, `VALUES`, `TABLE`, `PIVOT`, `UNPIVOT`, and `CALL` / `EXECUTE`, which run whatever they name) only ever runs inside the `SELECT * FROM (...) LIMIT 10001` wrapper — never as written. The MCP server also locks DuckDB's configuration right after opening a database, so `SET memory_limit`, `SET threads`, `PRAGMA max_temp_directory_size` and every other setting change are refused by DuckDB itself.

## Why

#213's fallback — run the statement as written when it cannot be wrapped — had two holes. (1) `SELECT ... FROM big; -- note` keeps an internal `;`, the wrapped prepare fails on it, and the raw statement ran unbounded and fully materialized, exactly the pre-#213 shape the tool description says cannot happen. (2) `SET memory_limit = ...` and friends took the same path and ran, so SQL arriving through the tool could lift the memory and spill bounds the server was started with; DuckDB's own out-of-memory text used to suggest doing precisely that, and a model acting on it grows the process past its cgroup.

## What the reviewer decides

1. **Locking the configuration on the MCP path** (`SET lock_configuration = true` after open; irreversible for the connection). It closes the whole settings family rather than a name denylist that `RESET`, `SET GLOBAL` or `PRAGMA memory_limit` would walk around. Cost: nothing on the MCP side can tune DuckDB in-session any more — including `search_path` — which no tool or prompt does today. The CLI keeps its unlocked behaviour.
2. **Refusing, not running, a statement that can read rows but that the wrapper cannot take.** A SQL error in it is still reported against the user's own text (the raw statement is prepared, not executed). `CALL` and `EXECUTE` land here by design — `CALL pragma_table_info('t')` becomes a fixed "rewrite it as a single SELECT" error and `SELECT * FROM pragma_table_info('t')` is the bounded form; `EXECUTE` of a prepared statement would otherwise run unbounded. I found no valid single `SELECT` that DuckDB accepts bare but rejects as a subquery; if one exists it gets the same error instead of an unbounded run.
3. **One statement per call.** Multiple statements were never useful through this tool; they are now an error naming the rule.

Smaller: the out-of-memory marker is matched as a prefix (the binding prints the engine's message bare), so a string literal cannot trigger the rewrite; a truncated result whose separate `count(*)` fails now carries `total_row_count: null` instead of omitting the field; the tool description says all of this. No schema, version, or BPF change.

## Tests

`analyze::query::tests::test_statement_shape_*` (comments, terminators, literals, nesting, multiple/empty, the keyword split); `analyze::tests::test_query_comments_and_terminators_cannot_bypass_the_cap`, `test_query_refuses_row_readers_it_cannot_wrap` (`EXECUTE`, `CALL`), `test_query_cap_boundaries_and_order` (`ORDER BY ... DESC`, exact cap + 1), `test_query_result_json_shape`, `test_lock_configuration_refuses_settings` (nine spellings refused, reads unaffected), the literal case in `test_query_out_of_memory_is_reported_as_the_bound`; `mcp::tests::test_get_or_open_locks_configuration`. `cargo test --lib` 547 passed / 0 failed, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
