### PR TITLE
analyze: lock the configuration of the database the MCP server starts with, and refuse dollar-quoted text before anything reaches prepare()

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -417,16 +417,22 @@ impl AnalyzeDb {
     ///
     /// The text is classified first (`statement_shape`): comments and
     /// leading/trailing `;` are stripped so they cannot hide a statement
-    /// from the wrapper, and more than one statement is refused. A
+    /// from the wrapper, more than one statement is refused, and so is any
+    /// bare `$` (dollar-quoted strings, `$n` parameters) — the one lexical
+    /// construct under which the classifier and DuckDB could disagree about
+    /// where a statement ends. That agreement matters: the binding's
+    /// `prepare` is not parse-only, it EXECUTES every statement but the last
+    /// of the text it is handed, so nothing may reach `prepare` unless the
+    /// classifier has established that it is exactly one statement. A
     /// statement that reads rows (`SELECT`, `WITH`, `FROM`, `VALUES`, ...)
     /// runs ONLY in wrapped form: if it cannot be wrapped it is refused, and
     /// a SQL error in it is reported against the user's own text by
-    /// preparing — never executing — the raw statement. Statements that
-    /// cannot be embedded as a subquery (`SHOW`, `PRAGMA`, `DESCRIBE`,
-    /// `SUMMARIZE`, `EXPLAIN`, ...) run as written with the cap applied as
-    /// rows are read; their results are small by nature. A failure while
-    /// *executing* the wrapped statement is reported directly — the raw
-    /// statement is never re-run unbounded.
+    /// preparing the raw statement — safe only because it is one statement.
+    /// Statements that cannot be embedded as a subquery (`SHOW`, `PRAGMA`,
+    /// `DESCRIBE`, `SUMMARIZE`, `EXPLAIN`, ...) run as written with the cap
+    /// applied as rows are read; their results are small by nature. A
+    /// failure while *executing* the wrapped statement is reported directly
+    /// — the raw statement is never re-run unbounded.
     ///
     /// Execution-time errors from the wrapped form name line numbers
     /// relative to the user's text plus the wrapper's first line.
@@ -435,6 +441,9 @@ impl AnalyzeDb {
             StatementShape::Empty => bail!("empty query"),
             StatementShape::Multiple => bail!(
                 "only one statement per query is supported; remove the `;`-separated statement that follows the first one"
+            ),
+            StatementShape::Dollar => bail!(
+                "dollar-quoted strings ($$...$$) and $-parameters are not supported here; use a single-quoted string literal"
             ),
             StatementShape::Single { text, must_wrap } => (text, must_wrap),
         };
@@ -1502,6 +1511,23 @@ mod tests {
         }
         let err = db.query("  -- nothing here\n;").unwrap_err().to_string();
         assert!(err.contains("empty query"), "{err}");
+
+        // A dollar-quoted string holding a quote character used to make the
+        // classifier believe the rest of the text was a literal, and the
+        // binding's `prepare` then EXECUTED the hidden statements (it runs
+        // every statement but the last). Both shapes are refused before
+        // anything reaches `prepare`, and the hidden SET never ran.
+        let before = db.query("SELECT current_setting('memory_limit')").unwrap();
+        for sql in [
+            "SELECT $$'$$; SET memory_limit='100GB'; SELECT $$'$$",
+            "SELECT $$'$$) AS x; SET memory_limit='100GB'; SELECT * FROM (SELECT $$'$$",
+            "SELECT $$a--b$$",
+        ] {
+            let err = db.query(sql).unwrap_err().to_string();
+            assert!(err.contains("dollar-quoted"), "{sql:?}: {err}");
+        }
+        let after = db.query("SELECT current_setting('memory_limit')").unwrap();
+        assert_eq!(before.rows, after.rows);
     }
 
     #[test]

--- a/src/analyze/query.rs
+++ b/src/analyze/query.rs
@@ -66,6 +66,11 @@ pub(super) enum StatementShape {
     Empty,
     /// More than one `;`-separated statement.
     Multiple,
+    /// A `$` outside a quoted run: a dollar-quoted string (`$$ ... $$`,
+    /// `$tag$ ... $tag$`) or a `$n` parameter. Neither has a use through
+    /// this path, and a dollar-quoted string can hide a quote character or
+    /// a `;` from this scan — so the text is refused rather than guessed at.
+    Dollar,
     /// Exactly one statement. `text` is that statement without comments and
     /// without leading or trailing terminators; `must_wrap` says whether it
     /// can read rows from a table — `SELECT`, `WITH`, `FROM`, `VALUES`,
@@ -79,8 +84,17 @@ pub(super) enum StatementShape {
 /// block comments included), drop leading and trailing `;`, and report
 /// whether what remains is one statement. Single- and double-quoted strings
 /// are passed through untouched, so a `;` or `--` inside a literal is not a
-/// separator or a comment. A dollar-quoted string (`$$ ... $$`) is not
-/// recognised; a `;` inside one reads as a separator, which fails closed.
+/// separator or a comment.
+///
+/// This scan has to agree with DuckDB's own lexer about where statements
+/// end, because the binding's `prepare` executes every statement but the
+/// last of the text it is given. The scan is built so that every place it
+/// can disagree errs toward seeing MORE separators (and refusing): an
+/// escape-string literal (`E'...'`) whose `\'` extends the string in DuckDB
+/// ends it here, so a `;` DuckDB hides is one this scan refuses; and the one
+/// construct that would go the other way — a dollar-quoted string, inside
+/// which a `'` makes this scan believe it is in a literal while DuckDB is
+/// not — is refused outright with every other bare `$` (`Dollar`).
 pub(super) fn statement_shape(sql: &str) -> StatementShape {
     let mut out = String::with_capacity(sql.len());
     // Byte offsets in `out` of every `;` that separates statements.
@@ -109,6 +123,7 @@ pub(super) fn statement_shape(sql: &str) -> StatementShape {
                 }
                 i += 1;
             }
+            '$' => return StatementShape::Dollar,
             '-' if next == Some('-') => {
                 while i < chars.len() && chars[i] != '\n' {
                     i += 1;
@@ -247,6 +262,28 @@ mod tests {
         );
         assert_eq!(statement_shape("  -- nothing\n;"), StatementShape::Empty);
         assert_eq!(statement_shape(""), StatementShape::Empty);
+    }
+
+    #[test]
+    fn test_statement_shape_refuses_bare_dollar() {
+        // A dollar-quoted string holding a quote character is the one
+        // shape under which this scan would think it is inside a literal
+        // while DuckDB is not; every bare `$` is refused instead.
+        for sql in [
+            "SELECT $$'$$; SET memory_limit='100GB'; SELECT $$'$$",
+            "SELECT $$'$$) AS x; SET memory_limit='100GB'; SELECT * FROM (SELECT $$'$$",
+            "SELECT $tag$a'b$tag$",
+            "SELECT $$a--b$$",
+            "SELECT id FROM t WHERE id = $1",
+            "SELECT a$b FROM t",
+        ] {
+            assert_eq!(statement_shape(sql), StatementShape::Dollar, "{sql:?}");
+        }
+        // Inside a quoted run or a comment a `$` is just a character.
+        assert_eq!(
+            single("SELECT '$$; SET x' AS s, \"a$b\" FROM t /* $5 */ -- $$"),
+            ("SELECT '$$; SET x' AS s, \"a$b\" FROM t".to_string(), true)
+        );
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -17,7 +17,7 @@ use rmcp::{
 };
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
@@ -61,15 +61,13 @@ impl DbHandle {
 
             if let Some(path) = initial_db {
                 match std::fs::canonicalize(&path) {
-                    Ok(canonical) => {
-                        match AnalyzeDb::open_with_spill_cap(&canonical, true, spill_cap) {
-                            Ok(db) => {
-                                dbs.insert(canonical.clone(), db);
-                                last_used = Some(canonical);
-                            }
-                            Err(e) => eprintln!("Warning: failed to open initial database: {e}"),
+                    Ok(canonical) => match open_locked(&canonical, spill_cap) {
+                        Ok(db) => {
+                            dbs.insert(canonical.clone(), db);
+                            last_used = Some(canonical);
                         }
-                    }
+                        Err(e) => eprintln!("Warning: failed to open initial database: {e}"),
+                    },
                     Err(e) => eprintln!("Warning: cannot resolve path '{}': {e}", path.display()),
                 }
             }
@@ -97,6 +95,21 @@ impl DbHandle {
 }
 
 const MAX_CACHED_DBS: usize = 8;
+
+/// The one way this server opens a trace database: read-only, under the
+/// spill cap, and with DuckDB's configuration locked before any SQL can
+/// reach it. Every bound the server was started with (memory limit, thread
+/// count, spill cap, external access) is frozen from here on, so SQL
+/// arriving through the tools cannot lift them with SET / PRAGMA. Both open
+/// sites — the database named on the command line and the ones opened
+/// lazily by path — go through here, so neither can be served unlocked.
+fn open_locked(canonical: &Path, spill_cap: Option<&str>) -> Result<AnalyzeDb, String> {
+    let db = AnalyzeDb::open_with_spill_cap(canonical, true, spill_cap)
+        .map_err(|e| format!("Failed to open database '{}': {e}", canonical.display()))?;
+    db.lock_configuration()
+        .map_err(|e| format!("Failed to open database '{}': {e}", canonical.display()))?;
+    Ok(db)
+}
 
 fn get_or_open<'a>(
     dbs: &'a mut HashMap<PathBuf, AnalyzeDb>,
@@ -128,13 +141,7 @@ fn get_or_open<'a>(
                 dbs.insert(k, db);
             }
         }
-        let db = AnalyzeDb::open_with_spill_cap(&canonical, true, spill_cap)
-            .map_err(|e| format!("Failed to open database '{}': {e}", canonical.display()))?;
-        // Every bound the server was started with (memory limit, thread
-        // count, spill cap, external access) is frozen from here on, so SQL
-        // arriving through the tools cannot lift them with SET / PRAGMA.
-        db.lock_configuration()
-            .map_err(|e| format!("Failed to open database '{}': {e}", canonical.display()))?;
+        let db = open_locked(&canonical, spill_cap)?;
         dbs.insert(canonical.clone(), db);
     }
 
@@ -540,7 +547,7 @@ impl SystingMcpServer {
 
     #[tool(
         name = "query",
-        description = "Execute one read-only SQL statement against a trace database. Returns JSON with 'columns' (array of column names), 'rows' (array of arrays with properly typed values — numbers as numbers, not strings), and 'row_count'. Results are capped at 10,000 rows, applied inside DuckDB (the statement runs as a subquery with LIMIT 10,001, so rows beyond the cap are never produced); if truncated, includes 'truncated: true' and 'total_row_count' from a separate count(*) over the same statement (null if that count fails). Use SQL LIMIT/OFFSET for pagination. One statement per call: comments are fine, a second ';'-separated statement is refused. DuckDB runs under fixed, locked memory and spill bounds — SET/PRAGMA of memory_limit, threads or max_temp_directory_size are refused — and a query that exceeds the memory bound fails with a message saying so: narrow the time window, add LIMIT, or aggregate. The database is read-only, so INSERT/UPDATE/DELETE will fail."
+        description = "Execute one read-only SQL statement against a trace database. Returns JSON with 'columns' (array of column names), 'rows' (array of arrays with properly typed values — numbers as numbers, not strings), and 'row_count'. Results are capped at 10,000 rows, applied inside DuckDB (the statement runs as a subquery with LIMIT 10,001, so rows beyond the cap are never produced); if truncated, includes 'truncated: true' and 'total_row_count' from a separate count(*) over the same statement (null if that count fails). Use SQL LIMIT/OFFSET for pagination. One statement per call: comments are fine, a second ';'-separated statement is refused, and so are dollar-quoted strings ($$...$$) and $-parameters — use single-quoted literals. DuckDB runs under fixed, locked memory and spill bounds — SET/PRAGMA of memory_limit, threads or max_temp_directory_size are refused — and a query that exceeds the memory bound fails with a message saying so: narrow the time window, add LIMIT, or aggregate. The database is read-only, so INSERT/UPDATE/DELETE will fail."
     )]
     async fn query(
         &self,
@@ -939,6 +946,41 @@ mod tests {
             .query("SELECT current_setting('max_temp_directory_size')")
             .unwrap();
         assert_eq!(cap.rows[0][0].as_str().unwrap(), "100.0 MiB");
+    }
+
+    /// The database named on the command line (`mcp -d <path>`, the shape a
+    /// caller that spawns this server for one trace uses) is served locked
+    /// too: it is opened before the first request and must not be the one
+    /// path that skips the lock.
+    #[test]
+    fn test_initial_db_is_locked() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("initial.duckdb");
+        {
+            let conn = duckdb::Connection::open(&db_path).unwrap();
+            conn.execute_batch("CREATE TABLE t AS SELECT range AS id FROM range(10)")
+                .unwrap();
+        }
+        let handle = DbHandle::new(Some(db_path), Some("100MiB".to_string())).unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        // No path on the request: the initial database is the one in use.
+        let refused = rt.block_on(handle.request(DbRequest::Query(
+            None,
+            "SET memory_limit = '100GB'".to_string(),
+        )));
+        let err = refused.expect_err("SET on the initial database was accepted");
+        assert!(err.contains("locked"), "{err}");
+        let cap = rt
+            .block_on(handle.request(DbRequest::Query(
+                None,
+                "SELECT current_setting('max_temp_directory_size')".to_string(),
+            )))
+            .unwrap();
+        assert_eq!(cap["rows"][0][0].as_str().unwrap(), "100.0 MiB");
+        let count = rt
+            .block_on(handle.request(DbRequest::Query(None, "SELECT count(*) FROM t".to_string())))
+            .unwrap();
+        assert_eq!(count["rows"][0][0], serde_json::json!(10));
     }
 
     /// Verify that the MCP tool router contains exactly the expected set of tools.


### PR DESCRIPTION
## What changes

Two holes left by #216 in the MCP `query` tool's bounds are closed. (1) The configuration lock now applies to the database the server is started with (`mcp -d <path>`), not only to databases opened lazily by path — both open sites go through one `open_locked` helper. (2) Any bare `$` outside a quoted run (dollar-quoted strings, `$n` parameters) is refused before the text reaches `prepare()`.

## Why

Both were found by a cold read of the shipped v1.13.19 build.

1. #216 placed `lock_configuration()` in the lazy-open branch. The command-line database is opened and cached before the first request, so the lazy branch finds it present and skips the lock: `SET memory_limit = '100GB'` through the tool was accepted on exactly the launch shape the lock was written for.

2. The classifier did not know dollar-quoting, so after `$$'$$` it believed the rest of the text was a literal and saw no `;`. That is worse than a mis-count because duckdb-rs's `Connection::prepare()` is not parse-only: it extracts every statement from the text, **executes all but the last** (materialized, outside `memory_limit` accounting) and prepares only the last. So `SELECT $$'$$; SET memory_limit='100GB'; SELECT $$'$$` ran the SET on the raw-prepare path, and `SELECT $$'$$) AS x; <anything>; SELECT * FROM (SELECT $$'$$` ran the middle statement inside the wrapper with no error.

## What the reviewer decides

1. **Refusing every bare `$`** rather than tokenizing dollar-quoting. The tool has no use for `$$…$$` or `$1`, and refusing is the shape that cannot be wrong: the classifier's job is to agree with DuckDB's lexer about where a statement ends, and with `$` gone every remaining possible disagreement (an `E'\''` escape string DuckDB reads as longer) makes the classifier see *more* separators and refuse — never fewer. The cost is that an identifier like `a$b` is refused too; none exist in trace schemas.
2. **Not counting statements with `duckdb_extract_statements`.** That would be the robust form, but duckdb-rs exposes no raw connection handle outside the crate; the doc comments record the `prepare()` fact so the next change to this path knows the constraint.

No schema, version, or BPF change.

## Tests

`mcp::tests::test_initial_db_is_locked` (drives `DbHandle::new(Some(path), …)` through the request channel: `SET memory_limit` refused, spill cap in force, reads work); `analyze::query::tests::test_statement_shape_refuses_bare_dollar` (`$$'$$` in both repro shapes, `$tag$`, `$$a--b$$`, `$1`, `a$b`; a `$` inside a literal or comment stays ordinary text); the two repros plus `$$a--b$$` added to `analyze::tests::test_query_comments_and_terminators_cannot_bypass_the_cap` with `memory_limit` asserted unchanged after them. `cargo test --lib`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — results in the PR's first comment.
