### PR TITLE
bpf: re-bound the rss_stat member index at the use [bump patch]

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -1078,6 +1078,12 @@ struct rss_stat_state {
 	s64 latest_seen[NR_MM_COUNTERS];
 };
 
+/* handle_rss_stat() re-bounds its member index with a mask at the point of
+ * use (see the comment there); a mask is only an exact bound when the array
+ * length is a power of two. */
+_Static_assert((NR_MM_COUNTERS & (NR_MM_COUNTERS - 1)) == 0,
+	       "NR_MM_COUNTERS must be a power of two for the rss_stat index mask");
+
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	/* Bounds concurrent TRACED processes (tgids), not threads or events.
@@ -5367,11 +5373,25 @@ static __always_inline int handle_rss_stat(struct task_struct *task,
 			return emit_rss_stat_event(task, member, size_bytes, rss_flags);
 	}
 
+	/* Re-bound the index AT THE USE, not only at the entry check above.
+	 * Two map-helper calls separate that check from these stores, and a
+	 * newer 6.12-series verifier (and 6.18) no longer carries the bound
+	 * across them once the compiler rebuilds the index from the
+	 * sign-extended tracepoint argument: it rejects the whole object with
+	 * "R0 unbounded memory access, make sure to bounds check any such
+	 * access" at the first st->...[member] store, and the memory recorder
+	 * cannot load at all. NR_MM_COUNTERS is a power of two (asserted at
+	 * the struct), so the mask is an exact bound the verifier sees on
+	 * every kernel; barrier_var() pins the masked value in a register at
+	 * the access so the compiler cannot fold it back onto the argument. */
+	u64 idx = member & (NR_MM_COUNTERS - 1);
+	barrier_var(idx);
+
 	/* Unsynchronized per-member s64 stores — multiple threads of a tgid
 	 * may race here. Benign: worst case is a duplicate emit or one stale
 	 * last_emitted (one extra emit); never a lost sample. */
-	st->latest_seen[member] = size_bytes;
-	s64 last = st->last_emitted[member];
+	st->latest_seen[idx] = size_bytes;
+	s64 last = st->last_emitted[idx];
 	/* First sighting for this member: always emit so consumers have a
 	 * baseline (last == -1 from the 0xff memset). */
 	s64 drift = last < 0 ? (s64)tool_config.memory_rss_threshold_bytes
@@ -5381,7 +5401,7 @@ static __always_inline int handle_rss_stat(struct task_struct *task,
 	if ((u64)drift < tool_config.memory_rss_threshold_bytes)
 		return 0;
 
-	st->last_emitted[member] = size_bytes;
+	st->last_emitted[idx] = size_bytes;
 	return emit_rss_stat_event(task, member, size_bytes, rss_flags);
 }
 


### PR DESCRIPTION
**What this fixes.** With the memory recorder enabled, the BPF object fails to load on newer 6.12-series kernels (and 6.18): the verifier rejects `systing_rss_stat_btf` with `R0 unbounded memory access, make sure to bounds check any such access` at the first `st->latest_seen[member]` store in `handle_rss_stat()`, and libbpf then fails the whole skeleton (`-13`), so every capture that includes the memory recorder exits 1 at start-up. Captures without the memory recorder are unaffected (the program is not autoloaded then).

**Why it happens.** `handle_rss_stat()` range-checks `member` on entry, then makes two map-helper calls (the per-tgid state lookup and the `BPF_NOEXIST` insert on a miss) before indexing `last_emitted[]` / `latest_seen[]`. The program's own code did not change since it last loaded cleanly; the surrounding object did (per-CPU ring sharding, the cgroup-filter split), which shifted register allocation so that the index at the store is rebuilt from the sign-extended tracepoint argument and the newer verifier no longer carries the entry bound across the helper calls.

**The change.** One helper, both attach paths (`tp_btf/rss_stat` and the classic `tracepoint/kmem/rss_stat` share it): mask the index at the point of use — `idx = member & (NR_MM_COUNTERS - 1)` — with a `_Static_assert` that `NR_MM_COUNTERS` is a power of two (it is 4), and `barrier_var(idx)` so the compiler keeps the masked value in a register at the access. The entry check stays (it still short-circuits out-of-range members); the mask is the bound the verifier sees on every kernel. No behaviour change for in-range members; no new maps, programs, or options.

**Verification.**
- Verifier log excerpt from an affected 6.12-series host (the failing load of the unfixed object): in the review verdict comment.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo test` on the fixed tree: results in the verdict.
- Load check on the project's 6.12 VM guest: the `memory_recorder` e2e target (both rss_stat attach paths) on the fixed object — the guest's older verifier already accepted the unfixed object, so this is the "still loads where it loaded" check, not the reproduction.
- The fix is confirmed on an affected 6.12-series host once the fixed build loads the object with the memory recorder enabled.

`[bump patch]`
