### PR TITLE
bpf: put the barrier before the rss_stat index mask so the compiler keeps it [bump patch]

### DIFF
--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -1189,8 +1189,9 @@ struct rss_stat_state {
 
 /* handle_rss_stat() re-bounds its member index with a mask at the point of
  * use (see the comment there); a mask is only an exact bound when the array
- * length is a power of two. */
-_Static_assert((NR_MM_COUNTERS & (NR_MM_COUNTERS - 1)) == 0,
+ * length is a non-zero power of two. */
+_Static_assert(NR_MM_COUNTERS > 0 &&
+		       (NR_MM_COUNTERS & (NR_MM_COUNTERS - 1)) == 0,
 	       "NR_MM_COUNTERS must be a power of two for the rss_stat index mask");
 
 struct {
@@ -5482,19 +5483,30 @@ static __always_inline int handle_rss_stat(struct task_struct *task,
 			return emit_rss_stat_event(task, member, size_bytes, rss_flags);
 	}
 
-	/* Re-bound the index AT THE USE, not only at the entry check above.
-	 * Two map-helper calls separate that check from these stores, and a
-	 * newer 6.12-series verifier (and 6.18) no longer carries the bound
-	 * across them once the compiler rebuilds the index from the
-	 * sign-extended tracepoint argument: it rejects the whole object with
-	 * "R0 unbounded memory access, make sure to bounds check any such
-	 * access" at the first st->...[member] store, and the memory recorder
-	 * cannot load at all. NR_MM_COUNTERS is a power of two (asserted at
-	 * the struct), so the mask is an exact bound the verifier sees on
-	 * every kernel; barrier_var() pins the masked value in a register at
-	 * the access so the compiler cannot fold it back onto the argument. */
-	u64 idx = member & (NR_MM_COUNTERS - 1);
+	/* Re-bound the index AT THE USE, on the register the access uses.
+	 *
+	 * The entry check above is what the compiler compares, but which
+	 * register it compares is its choice: clang 21 at the default -mcpu
+	 * (v3) checks a 32-bit copy of the argument and later rebuilds the
+	 * index from the zero-extended raw argument in another register, two
+	 * map-helper calls later; clang 18 at -mcpu=v1 compares the index
+	 * register itself. Whether a bound on the copy reaches the index
+	 * register is then the verifier's choice: a vanilla 6.12.0 propagates
+	 * it, the newer 6.12-stable and 6.18 verifiers on the affected hosts
+	 * do not and reject the whole object at the first st->...[] store
+	 * ("R0 unbounded memory access, make sure to bounds check any such
+	 * access"). An explicit mask on the index register itself is bounded
+	 * on every verifier and under every compiler.
+	 *
+	 * The barrier comes FIRST. With the entry check dominating, the
+	 * optimizer proves `member & (NR_MM_COUNTERS - 1) == member` and
+	 * deletes the mask; barrier_var() makes `idx` opaque, so the mask that
+	 * follows it cannot be folded and lands on the very register used as
+	 * the index. NR_MM_COUNTERS is a power of two (asserted at the struct),
+	 * so the mask is an exact bound (umax NR_MM_COUNTERS - 1). */
+	u64 idx = member;
 	barrier_var(idx);
+	idx &= (NR_MM_COUNTERS - 1);
 
 	/* Unsynchronized per-member s64 stores — multiple threads of a tgid
 	 * may race here. Benign: worst case is a duplicate emit or one stale


### PR DESCRIPTION
**What this fixes.** #220 did not fix the verifier rejection it targeted: in the release build its mask is optimized away, and the compiled `tp_btf/rss_stat` program of v1.15.1 is instruction-identical to v1.14.0's. With the memory recorder enabled the object is still rejected at skeleton load on the affected hosts (`R0 unbounded memory access, make sure to bounds check any such access` in `systing_rss_stat_btf`; libbpf fails the skeleton with `-13`; every capture that includes the memory recorder exits 1 at start-up). Captures without the memory recorder are unaffected (the program is not autoloaded then).

**Why #220 was a no-op.** `handle_rss_stat()` checks `member >= NR_MM_COUNTERS` on entry, so at the store site the optimizer knows `member < 4`, proves `member & (NR_MM_COUNTERS - 1) == member`, and deletes the mask — before `barrier_var()` runs, so the barrier pinned the unmasked value. The verifier then sees what it saw before: the entry check on a 32-bit copy of the argument (`w2 = w8`), and the index rebuilt from the zero-extended raw argument (`r8 <<= 32; r8 >>= 32; r8 <<= 3; r0 += r8; *(u64 *)(r0 + 0x20) = r7`) two map-helper calls later.

**Two variables, both real.** Which register the compare sits on is the compiler's choice: clang 21 at its default `-mcpu` (v3) — the release build — checks the copy and indexes with the other register; clang 18 at `-mcpu=v1` compares the index register itself. Whether the bound on the copy reaches the index register is the verifier's choice: a vanilla 6.12.0 propagates it (the release object loads there), the newer 6.12.y stable and 6.18 verifiers on the affected hosts do not. That is why the project's local build and its 6.12 test VM passed in #220's verification while the release object failed in the field, and why #220's "newer verifier" explanation was only half of it.

**The change.** Barrier first, then mask: `u64 idx = member; barrier_var(idx); idx &= (NR_MM_COUNTERS - 1);`. `barrier_var()` makes `idx` opaque, so the mask that follows cannot be folded and lands on the register the access uses. Compiled with clang 21 at the build's flags (`-g -O2 -target bpf -D__TARGET_ARCH_x86`, default `-mcpu`), the program gains exactly one instruction over v1.15.1 — `r8 &= 0x3` between the zero-extension and the index shift — and the verifier carries umax 3 into the three `st->…[idx]` accesses with no reliance on copy propagation, on every verifier. The entry check stays; the `_Static_assert` now also requires `NR_MM_COUNTERS` to be non-zero. Both attach paths (`tp_btf/rss_stat` and the classic `tracepoint/kmem/rss_stat`) share the helper. No Rust changes, no new maps/programs/options.

**Verification.**
- Disassembly diff (clang 21, build flags): v1.15.1 vs this change on `tp_btf/rss_stat` = one added instruction, `r8 &= 0x3`, at the index build; the store site before/after is quoted in the review comment.
- Load check in the project's 6.12 VM (a minimal loader autoloading only `systing_rss_stat_btf`): this change's object loads — and so does the unfixed release object, because that verifier propagates the bound; the VM is the "still loads where it loaded" check, not the reproduction. The reproduction class (the affected hosts' verifiers) is confirmed once the fixed release build loads the object with the memory recorder enabled there.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo test` on the tree: results in the review comment.

**Follow-up, not in this change:** pin `-mcpu` in `build.rs` so the release build, CI and the test VM compile the same ISA and a verifier difference cannot hide behind a compiler default again.

`[bump patch]`
