### PR TITLE
build: pin the BPF objects' compiler flags to the release build's, allow choosing the BPF compiler, and correct the rss_stat comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y linux-tools-common libelf-dev linux-libc-dev clang libbpf-dev make pkg-config jq libjemalloc2
+      - name: Install clang 21 (the release build's BPF compiler)
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
+          sudo bash /tmp/llvm.sh 21
+          clang-21 --version
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -34,6 +39,7 @@ jobs:
           DUCKDB_LIB_DIR: "${{ github.workspace }}/libduckdb"
           DUCKDB_INCLUDE_DIR: "${{ github.workspace }}/libduckdb"
           LD_LIBRARY_PATH: "${{ github.workspace }}/libduckdb"
+          SYSTING_BPF_CLANG: "clang-21"
         run: cargo test --workspace --no-default-features
 
   fmt:
@@ -52,6 +58,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y linux-tools-common libelf-dev linux-libc-dev clang libbpf-dev make pkg-config jq libjemalloc2
+      - name: Install clang 21 (the release build's BPF compiler)
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh -O /tmp/llvm.sh
+          sudo bash /tmp/llvm.sh 21
+          clang-21 --version
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
@@ -70,4 +81,5 @@ jobs:
           DUCKDB_LIB_DIR: "${{ github.workspace }}/libduckdb"
           DUCKDB_INCLUDE_DIR: "${{ github.workspace }}/libduckdb"
           LD_LIBRARY_PATH: "${{ github.workspace }}/libduckdb"
+          SYSTING_BPF_CLANG: "clang-21"
         run: cargo clippy --workspace --no-default-features -- -D warnings

--- a/build.rs
+++ b/build.rs
@@ -96,6 +96,47 @@ fn detect_multiarch_include() -> Option<String> {
         .map(|t| format!("-I/usr/include/{t}"))
 }
 
+/// The compiler flags every BPF object is compiled with so that a local or CI
+/// build produces the release build's program, not merely the same source.
+///
+/// `-mcpu=v3`: the release build compiles with clang 21, whose default
+/// `-mcpu` for the BPF target is v3; a distro clang 18 defaults to v1. The
+/// two levels produce different programs from the same source — different
+/// register allocation around the same stores — and the verifier judges the
+/// program, not the source, so a local or CI build at v1 can load where the
+/// release object is rejected (that is how the rss_stat index bound was
+/// wrong in a release while every local check passed).
+///
+/// `-fwrapv`: the release build's toolchain compiles with `-fwrapv` (its
+/// hardening set makes signed overflow wrap). That changes the code generated
+/// for signed delta arithmetic — the memory recorder's brk/mmap/munmap exit
+/// handlers differ in register allocation without it — so pin it too; with
+/// both flags the embedded object is instruction-identical to the release's.
+/// `SYSTING_BPF_CLANG` (below) closes the remaining compiler-version gap.
+const BPF_CFLAGS: &[&str] = &["-mcpu=v3", "-fwrapv"];
+
+/// Optional override for the C compiler used for the BPF objects, so a
+/// local or CI build can use the exact compiler the release build uses
+/// (`SYSTING_BPF_CLANG=/path/to/clang-21`). Unset: libbpf-cargo's default
+/// (`clang` on PATH).
+fn bpf_clang_override() -> Option<PathBuf> {
+    println!("cargo:rerun-if-env-changed=SYSTING_BPF_CLANG");
+    env::var_os("SYSTING_BPF_CLANG")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Apply the compiler pinning every BPF object build shares.
+fn pin_bpf_compiler<'a>(
+    builder: &'a mut SkeletonBuilder,
+    clang_override: &Option<PathBuf>,
+) -> &'a mut SkeletonBuilder {
+    if let Some(clang) = clang_override {
+        builder.clang(clang);
+    }
+    builder
+}
+
 fn build_pystacks_bpf(out_dir: &Path, arch_define: &str, multiarch_include: &Option<String>) {
     let out_dir_include_arg = format!("-I{}", out_dir.display());
 
@@ -125,19 +166,22 @@ fn build_pystacks_bpf(out_dir: &Path, arch_define: &str, multiarch_include: &Opt
 
     let obj_path = out_dir.join("pystacks.bpf.o");
 
-    let mut clang_args = vec![
+    let mut clang_args: Vec<&OsStr> = BPF_CFLAGS.iter().map(OsStr::new).collect();
+    clang_args.extend([
         OsStr::new(&out_dir_include_arg),
         OsStr::new(&bpf_include_arg),
         OsStr::new(&pystacks_include_arg),
         OsStr::new(&pystacks_bpf_arg),
         OsStr::new(arch_define),
-    ];
+    ]);
 
     if let Some(ref include_path) = multiarch_include {
         clang_args.push(OsStr::new(include_path));
     }
 
-    SkeletonBuilder::new()
+    let clang_override = bpf_clang_override();
+    let mut builder = SkeletonBuilder::new();
+    pin_bpf_compiler(&mut builder, &clang_override)
         .source("src/pystacks/bpf/pystacks.bpf.c")
         .clang_args(clang_args)
         .obj(obj_path.to_str().unwrap())
@@ -253,20 +297,23 @@ fn main() {
         };
         let obj_path = out_dir.join(format!("{prefix}_tmp.bpf.o"));
 
-        let mut clang_args = vec![
+        let mut clang_args: Vec<&OsStr> = BPF_CFLAGS.iter().map(OsStr::new).collect();
+        clang_args.extend([
             OsStr::new(&include_arg),
             OsStr::new(&bpf_include_arg),
             OsStr::new(arch_define),
             OsStr::new("-DSYSTING_PYSTACKS"),
             OsStr::new(&pystacks_inc_arg),
             OsStr::new(&pystacks_bpf_arg),
-        ];
+        ]);
 
         if let Some(ref include_path) = multiarch_include {
             clang_args.push(OsStr::new(include_path));
         }
 
-        SkeletonBuilder::new()
+        let clang_override = bpf_clang_override();
+        let mut builder = SkeletonBuilder::new();
+        pin_bpf_compiler(&mut builder, &clang_override)
             .source(src)
             .clang_args(clang_args)
             .obj(obj_path.to_str().unwrap())

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -5489,14 +5489,15 @@ static __always_inline int handle_rss_stat(struct task_struct *task,
 	 * register it compares is its choice: clang 21 at the default -mcpu
 	 * (v3) checks a 32-bit copy of the argument and later rebuilds the
 	 * index from the zero-extended raw argument in another register, two
-	 * map-helper calls later; clang 18 at -mcpu=v1 compares the index
-	 * register itself. Whether a bound on the copy reaches the index
-	 * register is then the verifier's choice: a vanilla 6.12.0 propagates
-	 * it, the newer 6.12-stable and 6.18 verifiers on the affected hosts
-	 * do not and reject the whole object at the first st->...[] store
-	 * ("R0 unbounded memory access, make sure to bounds check any such
-	 * access"). An explicit mask on the index register itself is bounded
-	 * on every verifier and under every compiler.
+	 * map-helper calls later — and the verifier does not carry a bound
+	 * from a 32-bit copy of an unknown 64-bit value back to the original,
+	 * so it reaches the st->...[] stores with no bound on the index and
+	 * rejects the whole object ("R0 unbounded memory access, make sure to
+	 * bounds check any such access"). clang 18 at -mcpu=v1 happens to
+	 * compare the index register itself. Note that this store path is
+	 * live only when tool_config.memory_rss_threshold_bytes is non-zero:
+	 * at the object's default the verifier prunes it as dead code, so a
+	 * load test must set the threshold to exercise it at all.
 	 *
 	 * The barrier comes FIRST. With the entry check dominating, the
 	 * optimizer proves `member & (NR_MM_COUNTERS - 1) == member` and


### PR DESCRIPTION
**What this changes.** Every BPF object is now compiled with `-mcpu=v3 -fwrapv`, and `build.rs` honours `SYSTING_BPF_CLANG=<path>` to pick the C compiler for the BPF objects. CI installs clang 21 from apt.llvm.org and sets `SYSTING_BPF_CLANG=clang-21` for the Test Suite and Clippy jobs. The comment at the rss_stat index bound is corrected (below). No runtime change: the release build already compiled at v3 with clang 21, so its object is unchanged.

**Why the pin.** The release build's clang 21 defaults to `-mcpu=v3`; the distro clang 18 used by local builds and CI defaults to v1. The two levels produce different programs from the same source — different register allocation around the same stores — and the verifier judges the program, not the source. #220's rss_stat index bound was a no-op in the release object while the clang-18 object compared the index register itself, so no local build ever exercised the program the release shipped (#221 has the details). Measured on the current source (`tp_btf/rss_stat`): clang 21 default ≡ clang 21 `-mcpu=v3` (366 instructions); clang 18 default ≡ clang 18 `-mcpu=v1` (370); clang 18 at `-mcpu=v3` (394) still differs from clang 21 at v3 in 160 lines, so the compiler version is a second variable — `-mcpu` alone gives the release's index-register shape (the AND lands on the index register in both v3 objects), and the compiler override closes the rest. A third variable turned up in the proof build: the release build's toolchain compiles with `-fwrapv` (its hardening set makes signed overflow wrap), and without it three programs — the memory recorder's brk/mmap/munmap exit handlers — differ from the release object in register allocation around their signed delta arithmetic (60 instructions across the three; the rss_stat programs are unaffected). Pinning `-fwrapv` removes that difference.

**Compatibility.** The source already requires v3 on clang 21: `-mcpu=v1` fails there with `error: Invalid usage of the XADD return value` (the `__sync_fetch_and_add` return needs v3 atomics). Every kernel the project targets (6.6 and later) runs v3 programs. `-fwrapv` only pins what the release already compiled with.

**The comment correction.** The comment added in #221 said the rejection depended on the verifier version. It does not: the store path the bound guards is live only when `tool_config.memory_rss_threshold_bytes` is non-zero, and at the object's default the verifier prunes it as dead code — which is why every load test at the default passed on every kernel while the same object was rejected in the field. With the threshold set, as the agent sets it before loading, a 6.12.85 verifier rejects the #220 object (`R0 unbounded memory access`) and loads the #221 one. The comment now says so, and that a load test must set the threshold to exercise the path at all. (A follow-up adds a load test that iterates the configuration values the program branches on.)

**Verification.**
- A local build with `SYSTING_BPF_CLANG` pointing at clang 21.1.8: the embedded BPF object's programs are instruction-identical to the ones carved from the release binary of the same source (every program section, call and jump targets included) — in the review comment.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo test` on the tree; CI on this PR runs with the new toolchain step.

No tag bump is needed (the release object is unchanged; the comment is text); it rides the next tag.
