### PR TITLE
Close the still-running sched slices at the tracing gate, not after the stop sequence

### DIFF
--- a/src/analyze/sched_aggregate.rs
+++ b/src/analyze/sched_aggregate.rs
@@ -66,6 +66,14 @@
 //!   that its state is unknown); CPUs with no events at all are reported as
 //!   unobserved, never assumed idle or busy. Waits that do not end inside the
 //!   window are counted as censored, never extrapolated.
+//! - The default window is the trace's own extent: from its first slice or
+//!   runnable marker to the end of its last slice. The recorder closes the
+//!   slices still open when collection stops at the instant the tracing gate
+//!   closed, so that end is the end of collection. (Traces written by
+//!   recorders before that change closed them after the stop sequence — ring
+//!   drain and thread joins — so on a loaded host their window, `slice_len`
+//!   maximum and every per-window count or rate carry that stop latency;
+//!   compare such rows by `window_ns`, not by `max`.)
 //!
 //! Percentiles come from a log-linear histogram (16 sub-buckets per octave,
 //! upper bucket edge reported, so a percentile is at most 6.25% above the

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -420,6 +420,13 @@ impl SchedEventRecorder {
     /// 2. Emit unpaired IRQs/softirqs with dur=0
     /// 3. Drain every locally buffered record type to the collector
     ///
+    /// `end_ts` is the instant event collection ended — the tracing gate, not
+    /// the time this method happens to run — and is where the final slices
+    /// close. A switch observed in the last microseconds before the gate can
+    /// carry a timestamp past it (the gate and the event clock are read
+    /// independently), so a slice that would end before it started is
+    /// closed with zero length instead of a negative one.
+    ///
     /// Returns the streaming collector so the caller can call finish() on it.
     pub fn finish(&mut self, end_ts: i64) -> Result<Option<Box<dyn RecordCollector + Send>>> {
         if self.streaming_collector.is_some() {
@@ -428,7 +435,7 @@ impl SchedEventRecorder {
                 .cpu_states
                 .iter()
                 .map(|(cpu, state)| {
-                    let dur = end_ts - state.start_ts;
+                    let dur = (end_ts - state.start_ts).max(0);
                     SchedSliceRecord {
                         ts: state.start_ts,
                         dur,
@@ -665,6 +672,75 @@ mod tests {
             .expect("runnable state from the waking event");
         assert_eq!(m.utid, woken.utid);
         assert_eq!(data.process_exits.len(), 1);
+    }
+
+    /// The final slice of a task still running when collection stops closes
+    /// at the end timestamp the caller passes — the tracing gate — and not
+    /// at any later time: `finish()` runs after the stop sequence (ring
+    /// drain, thread joins), and a slice closed "now" would carry all of it.
+    /// A switch whose timestamp lands past the gate (the event clock and the
+    /// gate are read independently, so the last in-flight event can) closes
+    /// with zero length, never a negative one.
+    #[test]
+    fn test_finish_closes_running_slices_at_the_gate() {
+        let mut recorder = create_test_recorder();
+        let handle = SharedInMemoryCollector::new();
+        recorder.set_streaming_collector(Box::new(handle.clone()));
+
+        let switch = |ts: u64, cpu: u32, tgidpid: u64| task_event {
+            r#type: event_type::SCHED_SWITCH,
+            ts,
+            cpu,
+            next: task_info {
+                tgidpid,
+                ..Default::default()
+            },
+            prev: task_info {
+                tgidpid,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // CPU 0: task 100 runs from 1_000 and is still running at the gate.
+        recorder.handle_event(switch(1_000, 0, 100));
+        // CPU 1: task 200 was switched in at 9_500, and a later switch to
+        // task 300 is stamped 10_020 — past the gate the caller will pass.
+        recorder.handle_event(switch(9_500, 1, 200));
+        recorder.handle_event(switch(10_020, 1, 300));
+
+        // The gate closed at 10_000; finish() itself runs "later".
+        recorder.finish(10_000).unwrap();
+        let inner = handle.0.lock().unwrap();
+        let data = inner.data();
+
+        let on_cpu = |cpu: i32| -> Vec<&SchedSliceRecord> {
+            data.sched_slices.iter().filter(|s| s.cpu == cpu).collect()
+        };
+
+        // CPU 0: one final slice, ended exactly at the gate.
+        let cpu0 = on_cpu(0);
+        assert_eq!(cpu0.len(), 1);
+        assert_eq!(cpu0[0].ts, 1_000);
+        assert_eq!(cpu0[0].dur, 9_000);
+        assert_eq!(cpu0[0].end_state, None);
+
+        // CPU 1: the completed slice keeps its event-clock length (9_500 →
+        // 10_020), and the task switched in past the gate gets a zero-length
+        // final slice, not a negative one.
+        let cpu1 = on_cpu(1);
+        assert_eq!(cpu1.len(), 2);
+        let completed = cpu1
+            .iter()
+            .find(|s| s.ts == 9_500)
+            .expect("the completed slice on CPU 1");
+        assert_eq!(completed.dur, 520);
+        let last = cpu1
+            .iter()
+            .find(|s| s.ts == 10_020)
+            .expect("the final slice on CPU 1");
+        assert_eq!(last.dur, 0);
+        assert_eq!(last.end_state, None);
     }
 
     #[test]

--- a/src/session_recorder.rs
+++ b/src/session_recorder.rs
@@ -1510,9 +1510,18 @@ impl SessionRecorder {
     /// Flushes all streaming recorders and writes process/thread metadata to
     /// the configured sink. Streaming must have been initialized via
     /// `init_streaming_output` before calling this method.
+    ///
+    /// `end_ts` is the `CLOCK_BOOTTIME` instant at which event collection
+    /// ended (the tracing gate), and it is where the sched slices still open
+    /// at that point close. It must be the gate and not "now": this runs after
+    /// the rings have been drained and every collection thread joined, which
+    /// on a loaded host is seconds or minutes later, and a slice closed at
+    /// that later time would stretch the trace's last slice per CPU by the
+    /// whole stop sequence.
     pub fn generate_parquet_trace(
         &self,
         tpu_recorder: Option<crate::tpu::recorder::TpuRecorder>,
+        end_ts: i64,
     ) -> Result<()> {
         // Per-stage elapsed lines below let fleet log pipelines attribute
         // stop-phase cost without relying on collector timestamp granularity.
@@ -1523,9 +1532,6 @@ impl SessionRecorder {
             *start = std::time::Instant::now();
         };
         eprintln!("Generating Parquet trace...");
-
-        // Get the end timestamp for flushing streaming data
-        let end_ts = get_clock_value(libc::CLOCK_BOOTTIME) as i64;
 
         // Step 1: Finish streaming collection in every event recorder shard
         // and retrieve the collector. The shards share one underlying writer

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -4243,6 +4243,11 @@ impl Drop for StopPhase {
     }
 }
 
+/// Runs the capture until it is asked to stop, then runs the stop sequence.
+///
+/// Returns the `CLOCK_BOOTTIME` instant at which the tracing gate closed —
+/// the end of event collection, and the timestamp the trace's open sched
+/// slices close at.
 #[allow(clippy::too_many_arguments)]
 fn run_tracing_loop(
     handles: ThreadHandles,
@@ -4253,7 +4258,7 @@ fn run_tracing_loop(
     shutdown_signal: Arc<AtomicBool>,
     skel: &mut SystingSystemSkel,
     traced_child: &Option<crate::traced_command::TracedChild>,
-) -> Result<()> {
+) -> Result<i64> {
     sd_notify()?;
 
     if let Some(child) = traced_child.as_ref() {
@@ -4335,11 +4340,18 @@ fn run_tracing_loop(
         thread::sleep(Duration::from_secs(CONTINUOUS_MODE_STOP_DELAY_SECS));
     }
     println!("Stopping...");
-    {
+    // The instant event collection ends. Everything below (draining the
+    // rings, joining the pollers and the symbol loader) can take seconds on a
+    // loaded host, and the still-running sched slices must close at the gate,
+    // not at whatever time the trace is finally written — see
+    // `SessionRecorder::generate_parquet_trace`.
+    let capture_end_ts = {
         let _p = stop_phase("disable tracing gate");
         skel.maps.data_data.as_deref_mut().unwrap().tracing_enabled = false;
+        let ts = get_clock_value(libc::CLOCK_BOOTTIME) as i64;
         ringbuf_shutdown.signal();
-    }
+        ts
+    };
     {
         let _p = stop_phase("join ring buffer consumers");
         for thread in handles.ringbuf_threads {
@@ -4460,7 +4472,7 @@ fn run_tracing_loop(
         );
     }
 
-    Ok(())
+    Ok(capture_end_ts)
 }
 
 /// Main tracing function that sets up and runs the BPF-based system tracer.
@@ -4587,6 +4599,9 @@ pub fn systing(
     // joined after skel is dropped.
     let mut tpu_thread: Option<std::thread::JoinHandle<Result<crate::tpu::recorder::TpuRecorder>>> =
         None;
+    // The instant the tracing gate closed, set by `run_tracing_loop` inside
+    // the skel scope and consumed when the trace is written after it.
+    let capture_end_ts: i64;
 
     {
         let mut skel_builder = SystingSystemSkelBuilder::default();
@@ -5261,7 +5276,7 @@ pub fn systing(
             tpu_metrics_thread,
         };
 
-        run_tracing_loop(
+        capture_end_ts = run_tracing_loop(
             handles,
             &opts,
             stop_tx,
@@ -5341,7 +5356,7 @@ pub fn systing(
     println!("Writing Parquet trace files to {sink}...");
     {
         let _p = stop_phase("symbolize and write parquet");
-        recorder.generate_parquet_trace(tpu_recorder)?;
+        recorder.generate_parquet_trace(tpu_recorder, capture_end_ts)?;
     }
     println!("Successfully wrote Parquet trace files");
 


### PR DESCRIPTION
## What changes

The sched slices still open when a capture stops now close at the instant the tracing gate closed — the end of event collection — instead of at the time the trace is finally written. `run_tracing_loop` reads `CLOCK_BOOTTIME` right after it disables the gate and returns it; `systing()` hands it to `generate_parquet_trace(tpu_recorder, end_ts)`, which passes it to every recorder shard's `finish(end_ts)` in place of the clock read that used to happen there. `finish()` closes a slice whose start stamped past the gate with zero length instead of a negative one. Docs on the three functions and in the `sched aggregate` module say what the window end means.

## Why

`generate_parquet_trace()` runs at the end of the stop sequence: after the 1 s continuous-mode stop delay, the ring-buffer drain, the joins of every poller and recorder thread and the symbol loader. On a busy host that is seconds, and under a large event backlog minutes. The final slice per CPU (`end_state = NULL`, "still running at trace end") was being cut with `dur = now − start`, so each one absorbed the whole stop latency.

`sched aggregate` takes its default window from the trace's own extent (`MIN(ts)` … `MAX(ts + dur)` over `sched_slice`), so those slices stretched the window by the same amount: across a large continuous-profiling population the window was ≈11 s at the median for a 10 s capture (the stop delay plus fast joins), but on ≈0.5 % of captures it ran to tens of seconds and up to ≈5 minutes with zero dropped events — every per-window count, `*_per_s` rate, `slice_len` maximum and the work-conservation fraction on those rows were computed over a span that contained no events. The signature on the rows is exact: `slice_len_max_ns` ≈ the window's excess over the capture length on every row, normal ones included (≈1 s: the stop delay), which also means `slice_len_max_ns` was measuring the stop phase, never a real slice.

Moving the end to the gate makes the window the span events were collected over, which is what every per-window figure divides by.

## What the reviewer decides

1. **Where the gate timestamp is read.** Immediately after `tracing_enabled = false`, before the ring consumers are told to shut down — the last instant at which a BPF program could have stamped an event. The event clock (`bpf_ktime_get_boot_ns`) and the gate read are independent, so an in-flight event can stamp microseconds past the gate; `finish()` clamps that slice to zero length rather than emitting a negative duration, and the new unit test pins both the gate close and the clamp.
2. **No change to `sched aggregate`'s window query for traces written by earlier recorders.** Their open slices still end after the stop sequence. A belt would be to take the window end from the last *completed* slice or marker (`MAX(ts + dur) WHERE end_state IS NOT NULL`, `MAX(ts)` otherwise) — but for traces from this recorder that would end the window at the last switch instead of the gate and shorten idle hosts' windows, so it is left out; the module docs tell a reader of older rows to compare by `window_ns` and to read `slice_len_p99_ns` rather than the maximum. Happy to add the belt behind a flag if wanted.

No schema, version, or BPF change; the `sched aggregate` output shape is unchanged.

## Tests

`sched::tests::test_finish_closes_running_slices_at_the_gate` — a task still running closes exactly at the passed `end_ts`; a completed slice keeps its event-clock length; a task switched in past the gate gets a zero-length final slice. The existing `test_finish_drains_all_buffered_record_types` keeps its explicit `end_ts`. `cargo test --lib --bins sched`, `cargo clippy --all-targets`, `cargo fmt --check` — results in the PR's first comment.
