### PR TITLE
test: load the BPF object at every configuration shape that ships

### DIFF
--- a/src/bpf_load_shapes.rs
+++ b/src/bpf_load_shapes.rs
@@ -1,0 +1,508 @@
+//! Load-every-program × every-configuration-shape: the data and the
+//! arithmetic behind `tests/bpf_load_shapes.rs`.
+//!
+//! The BPF object's behaviour is configured through `.rodata` constants that
+//! userspace sets before load (`tool_config`: which recorders are on, sample
+//! rates, thresholds, filters). libbpf freezes `.rodata`, and the verifier
+//! constant-folds every branch on those constants, so the code a load
+//! verifies is exactly the code the configuration enables — a branch no
+//! shape turns on is never verified, and a defect in it ships. The
+//! instrument here is therefore two-fold: every shape that ships must LOAD
+//! (the verifier accepts the object at that configuration), and the union
+//! over all shapes of the instructions the verifier visited must cover every
+//! instruction of every program that loaded — an instruction no shape
+//! reaches names a configuration the table is missing (or dead code, which
+//! is then allowed explicitly, with a reason).
+//!
+//! [`crate::systing_core::bpf_load_probe`] performs one load at one shape and
+//! returns the per-program visited sets, read from the verifier's level-2
+//! log; this module owns the shape table, the log parsing, and the coverage
+//! arithmetic, all of which are plain functions with unit tests.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::systing_core::Config;
+
+/// One program's outcome in a load probe.
+#[derive(Debug, Clone)]
+pub struct ProgramLoad {
+    pub name: String,
+    /// Selected for load at this shape (`get_required_bpf_programs`).
+    pub autoload: bool,
+    /// Instructions in the loaded program (main body plus the subprograms
+    /// libbpf appended to it); 0 when the object did not load or the program
+    /// was not selected.
+    pub insn_total: usize,
+    /// Instruction indices the verifier visited, from the level-2 log.
+    pub visited: BTreeSet<u32>,
+    /// The program's own section of the verifier log, when one was printed.
+    pub verifier_log: Option<String>,
+}
+
+/// The outcome of one load probe.
+#[derive(Debug, Clone)]
+pub struct LoadReport {
+    /// The whole object loaded (every selected program verified).
+    pub loaded: bool,
+    /// libbpf's error when it did not.
+    pub error: Option<String>,
+    pub programs: Vec<ProgramLoad>,
+}
+
+impl LoadReport {
+    /// The programs libbpf reported as rejected by the verifier at this
+    /// shape (their log section starts with libbpf's failure line).
+    pub fn failed_programs(&self) -> Vec<&ProgramLoad> {
+        self.programs
+            .iter()
+            .filter(|p| {
+                p.autoload
+                    && p.verifier_log
+                        .as_deref()
+                        .is_some_and(|l| l.contains("BPF program load failed"))
+            })
+            .collect()
+    }
+}
+
+/// Split libbpf's captured print output into one verifier-log section per
+/// program, keyed by program name. Sections are delimited by libbpf's
+/// `prog '<name>': -- BEGIN PROG LOAD LOG --` / `-- END PROG LOAD LOG --`
+/// lines; a program that libbpf reported as failed has its failure line
+/// prepended to its section so the caller can tell the two apart.
+pub fn split_prog_load_logs(captured: &str) -> HashMap<String, String> {
+    let mut sections: HashMap<String, String> = HashMap::new();
+    let mut current: Option<(String, String)> = None;
+    for line in captured.lines() {
+        if let Some(rest) = line.strip_prefix("libbpf: prog '") {
+            if let Some((name, tail)) = rest.split_once("': ") {
+                if tail.starts_with("-- BEGIN PROG LOAD LOG --") {
+                    current = Some((name.to_string(), String::new()));
+                    continue;
+                }
+                if tail.starts_with("BPF program load failed") {
+                    sections
+                        .entry(name.to_string())
+                        .or_default()
+                        .push_str(&format!("{line}\n"));
+                    continue;
+                }
+            }
+        }
+        if line.starts_with("-- END PROG LOAD LOG --") {
+            if let Some((name, body)) = current.take() {
+                sections.entry(name).or_default().push_str(&body);
+            }
+            continue;
+        }
+        if let Some((_, body)) = current.as_mut() {
+            body.push_str(line);
+            body.push('\n');
+        }
+    }
+    // An unterminated section (the capture ended mid-log) still counts.
+    if let Some((name, body)) = current.take() {
+        sections.entry(name).or_default().push_str(&body);
+    }
+    sections
+}
+
+/// The instruction indices a level-2 verifier log shows as visited: every
+/// line of the form `<n>: (<opcode>) ...`. State lines (`from 12 to 34: ...`,
+/// `; source`, `processed N insns`) carry no index of their own.
+pub fn visited_insns(section: &str) -> BTreeSet<u32> {
+    let mut visited = BTreeSet::new();
+    for line in section.lines() {
+        let line = line.trim_start();
+        let Some((idx, rest)) = line.split_once(": ") else {
+            continue;
+        };
+        if !rest.starts_with('(') {
+            continue;
+        }
+        if let Ok(n) = idx.parse::<u32>() {
+            visited.insert(n);
+        }
+    }
+    visited
+}
+
+/// How a probe decides the memory recorder's kernel-probed legs (VFIO,
+/// THP): as the host allows, or forced on for a load-only read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegSelection {
+    /// Probe this kernel's symbols and tracepoints, as a capture does.
+    Host,
+    /// Select every leg regardless of the host, naming which folio-split
+    /// kretprobe program to load (the kernel picks one of two at capture
+    /// time; a load-only read wants each in turn).
+    Force { thp_page_prog: &'static str },
+}
+
+/// One row of the shape table: a name, the configuration it loads, and how
+/// the kernel-probed legs are decided for it.
+pub struct LoadShape {
+    pub name: &'static str,
+    pub config: Config,
+    pub legs: LegSelection,
+}
+
+fn base() -> Config {
+    // The continuous capture's defaults: sched + irq + CPU stacks, one
+    // ring plan from the host's CPU count.
+    Config {
+        continuous: 30,
+        ..Config::default()
+    }
+}
+
+/// The configurations that ship, as the agent's launcher and the on-demand
+/// lane build them. Every row is one load; a new knob is one new row. The
+/// values are the ones a continuous capture runs with, not the CLI
+/// defaults, wherever the two differ.
+pub fn shape_table() -> Vec<LoadShape> {
+    let mut shapes = Vec::new();
+    let mut add = |name: &'static str, f: &dyn Fn(&mut Config)| {
+        let mut c = base();
+        f(&mut c);
+        shapes.push(LoadShape {
+            name,
+            config: c,
+            legs: LegSelection::Host,
+        });
+    };
+
+    // CPU lane.
+    add("continuous-default", &|_| {});
+    add("continuous-sw-event", &|c| c.sw_event = true);
+    add("continuous-no-sched-no-irq", &|c| {
+        c.no_sched = true;
+        c.no_irq = true;
+    });
+    add("continuous-no-stack-traces", &|c| c.no_stack_traces = true);
+    add("continuous-no-cpu-stack-traces", &|c| {
+        c.no_cpu_stack_traces = true
+    });
+    add("continuous-no-sleep-stack-traces", &|c| {
+        c.no_sleep_stack_traces = true;
+        c.no_interruptible_stack_traces = true;
+    });
+    add("continuous-build-id", &|c| c.collect_build_id = true);
+    add("continuous-syscalls-markers", &|c| {
+        c.syscalls = true;
+        c.markers = true;
+    });
+    add("continuous-pystacks", &|c| c.collect_pystacks = true);
+    add("continuous-ringbuf-shards-8", &|c| c.ringbuf_shards = 8);
+    add("continuous-ringbuf-25mib", &|c| c.ringbuf_size_mib = 25);
+
+    // Filters (a pid that exists: our own; the cgroup filter needs a target
+    // cgroup and is a separate attach-time input, so it is not a load shape).
+    add("filter-pid", &|c| c.pid = vec![std::process::id()]);
+
+    // The generic probe handlers load only when a trace event is configured
+    // (one tracepoint every kernel has), with the pid filter so the fork
+    // and exec trackers load with them.
+    add("trace-event-tracepoint", &|c| {
+        c.trace_event = vec!["tracepoint:sched:sched_process_exit".to_string()];
+        c.pid = vec![std::process::id()];
+        c.collect_pystacks = true;
+    });
+
+    // Memory lane: the continuous launcher's shape (default rss threshold,
+    // fault/map sample rates 0 = every event), then each knob the launcher
+    // or the on-demand lane can set.
+    add("memory-default", &|c| c.memory = true);
+    add("memory-sw-event", &|c| {
+        c.memory = true;
+        c.sw_event = true;
+    });
+    add("memory-rss-threshold-0", &|c| {
+        c.memory = true;
+        c.memory_rss_threshold_bytes = Some(0);
+    });
+    add("memory-sample-rates-1", &|c| {
+        c.memory = true;
+        c.memory_fault_sample_rate = 1;
+        c.memory_map_sample_rate = 1;
+    });
+    add("memory-sample-rates-97", &|c| {
+        c.memory = true;
+        c.memory_fault_sample_rate = 97;
+        c.memory_map_sample_rate = 97;
+    });
+    add("memory-rss-classic", &|c| {
+        c.memory = true;
+        c.memory_rss_force_classic = true;
+    });
+    add("memory-alloc", &|c| {
+        c.memory = true;
+        c.memory_alloc = true;
+    });
+    add("memory-alloc-sampled", &|c| {
+        c.memory = true;
+        c.memory_alloc = true;
+        c.memory_alloc_sample_rate = 13;
+    });
+    add("memory-vfio-thp", &|c| {
+        c.memory = true;
+        c.memory_vfio = true;
+        c.memory_thp_sample_rate = 1;
+    });
+    add("memory-ringbuf-shards-8", &|c| {
+        c.memory = true;
+        c.ringbuf_shards = 8;
+    });
+
+    // Network lane.
+    add("network", &|c| c.network = true);
+    add("network-packets", &|c| {
+        c.network = true;
+        c.network_packets = true;
+    });
+    add("network-syscalls", &|c| {
+        c.network = true;
+        c.network_syscalls = true;
+    });
+
+    // Everything on: the widest autoload set in one object.
+    add("all-recorders", &|c| {
+        c.memory = true;
+        c.memory_alloc = true;
+        c.memory_vfio = true;
+        c.memory_thp_sample_rate = 1;
+        c.network = true;
+        c.network_packets = true;
+        c.network_syscalls = true;
+        c.collect_pystacks = true;
+        c.syscalls = true;
+        c.markers = true;
+        c.sw_event = true;
+    });
+
+    // The VFIO/IOMMU and THP-split legs, forced on: a host without the
+    // vfio_iommu_type1 module or the split symbols never selects these
+    // programs for a capture, so this is the only load they get on such a
+    // host — once per folio-split twin.
+    for (name, thp_page_prog) in [
+        ("memory-vfio-thp-forced", "systing_thp_split_page"),
+        (
+            "memory-vfio-thp-forced-legacy",
+            "systing_thp_split_page_legacy",
+        ),
+    ] {
+        let mut c = base();
+        c.memory = true;
+        c.memory_vfio = true;
+        c.memory_thp_sample_rate = 1;
+        shapes.push(LoadShape {
+            name,
+            config: c,
+            legs: LegSelection::Force { thp_page_prog },
+        });
+    }
+
+    shapes
+}
+
+/// Instructions of a program that no shape in the run reached, with the
+/// shapes that loaded the program. Programs that never loaded successfully
+/// at any shape are reported as such (their instruction count is unknown).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoverageGap {
+    pub program: String,
+    pub insn_total: usize,
+    pub unvisited: Vec<u32>,
+    pub loaded_by: Vec<String>,
+}
+
+/// Union the visited sets of every successful load and name, per program,
+/// the instructions no shape visited. A program selected by at least one
+/// shape but loaded by none is reported with `insn_total = 0` and an empty
+/// `loaded_by`, so the caller can fail on it too.
+pub fn coverage_gaps(reports: &[(String, LoadReport)]) -> Vec<CoverageGap> {
+    struct Acc {
+        insn_total: usize,
+        visited: BTreeSet<u32>,
+        loaded_by: Vec<String>,
+    }
+    let mut acc: BTreeMap<String, Acc> = BTreeMap::new();
+    for (shape, report) in reports {
+        for p in &report.programs {
+            if !p.autoload {
+                continue;
+            }
+            let e = acc.entry(p.name.clone()).or_insert_with(|| Acc {
+                insn_total: 0,
+                visited: BTreeSet::new(),
+                loaded_by: Vec::new(),
+            });
+            // A rejected load still shows which instructions were reached
+            // before the rejection; they count as visited for coverage (the
+            // rejection itself is the caller's finding).
+            e.visited.extend(p.visited.iter().copied());
+            if report.loaded {
+                e.insn_total = e.insn_total.max(p.insn_total);
+                e.loaded_by.push(shape.clone());
+            }
+        }
+    }
+    let mut gaps = Vec::new();
+    for (program, e) in acc {
+        if e.loaded_by.is_empty() {
+            gaps.push(CoverageGap {
+                program,
+                insn_total: 0,
+                unvisited: Vec::new(),
+                loaded_by: Vec::new(),
+            });
+            continue;
+        }
+        let unvisited: Vec<u32> = (0..e.insn_total as u32)
+            .filter(|i| !e.visited.contains(i))
+            .collect();
+        if !unvisited.is_empty() {
+            gaps.push(CoverageGap {
+                program,
+                insn_total: e.insn_total,
+                unvisited,
+                loaded_by: e.loaded_by,
+            });
+        }
+    }
+    gaps
+}
+
+/// Render a run of unvisited instruction indices as ranges (`99-145, 202-253`).
+pub fn ranges(indices: &[u32]) -> String {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < indices.len() {
+        let start = indices[i];
+        let mut end = start;
+        while i + 1 < indices.len() && indices[i + 1] == end + 1 {
+            i += 1;
+            end = indices[i];
+        }
+        if start == end {
+            out.push(format!("{start}"));
+        } else {
+            out.push(format!("{start}-{end}"));
+        }
+        i += 1;
+    }
+    out.join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "libbpf: prog 'systing_a': -- BEGIN PROG LOAD LOG --\n\
+0: R1=ctx() R10=fp0\n\
+; int systing_a(void *ctx)\n\
+0: (b7) r0 = 0\n\
+1: (79) r1 = *(u64 *)(r1 +0)\n\
+; if (tool_config.collect_memory)\n\
+2: (15) if r1 == 0x0 goto pc+5\n\
+3: (85) call bpf_get_current_pid_tgid#14\n\
+from 2 to 8: R0=0\n\
+8: (95) exit\n\
+processed 6 insns (limit 1000000) max_states_per_insn 0 total_states 1 peak_states 1 mark_read 1\n\
+-- END PROG LOAD LOG --\n\
+libbpf: prog 'systing_b': BPF program load failed: -EACCES\n\
+libbpf: prog 'systing_b': -- BEGIN PROG LOAD LOG --\n\
+0: (b7) r0 = 0\n\
+1: (95) exit\n\
+R0 unbounded memory access\n\
+-- END PROG LOAD LOG --\n";
+
+    #[test]
+    fn splits_sections_per_program() {
+        let s = split_prog_load_logs(SAMPLE);
+        assert_eq!(s.len(), 2);
+        assert!(s["systing_a"].contains("processed 6 insns"));
+        assert!(s["systing_b"].starts_with("libbpf: prog 'systing_b': BPF program load failed"));
+        assert!(s["systing_b"].contains("R0 unbounded memory access"));
+    }
+
+    #[test]
+    fn visited_reads_instruction_lines_only() {
+        let s = split_prog_load_logs(SAMPLE);
+        let v = visited_insns(&s["systing_a"]);
+        assert_eq!(v.into_iter().collect::<Vec<_>>(), vec![0, 1, 2, 3, 8]);
+    }
+
+    fn report(loaded: bool, progs: &[(&str, usize, &[u32])]) -> LoadReport {
+        LoadReport {
+            loaded,
+            error: None,
+            programs: progs
+                .iter()
+                .map(|(n, total, vis)| ProgramLoad {
+                    name: n.to_string(),
+                    autoload: true,
+                    insn_total: *total,
+                    visited: vis.iter().copied().collect(),
+                    verifier_log: None,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn coverage_unions_shapes_and_names_gaps() {
+        let reports = vec![
+            ("a".to_string(), report(true, &[("p", 10, &[0, 1, 2, 9])])),
+            (
+                "b".to_string(),
+                report(true, &[("p", 10, &[0, 3, 4, 5, 9])]),
+            ),
+        ];
+        let gaps = coverage_gaps(&reports);
+        assert_eq!(gaps.len(), 1);
+        assert_eq!(gaps[0].program, "p");
+        assert_eq!(gaps[0].unvisited, vec![6, 7, 8]);
+        assert_eq!(gaps[0].loaded_by, vec!["a", "b"]);
+        assert_eq!(ranges(&gaps[0].unvisited), "6-8");
+    }
+
+    #[test]
+    fn coverage_full_is_no_gap() {
+        let reports = vec![
+            ("a".to_string(), report(true, &[("p", 4, &[0, 1])])),
+            ("b".to_string(), report(true, &[("p", 4, &[2, 3])])),
+        ];
+        assert!(coverage_gaps(&reports).is_empty());
+    }
+
+    #[test]
+    fn never_loaded_program_is_a_gap() {
+        let reports = vec![("a".to_string(), report(false, &[("p", 0, &[0, 1])]))];
+        let gaps = coverage_gaps(&reports);
+        assert_eq!(gaps.len(), 1);
+        assert!(gaps[0].loaded_by.is_empty());
+        assert_eq!(gaps[0].insn_total, 0);
+    }
+
+    #[test]
+    fn ranges_render() {
+        assert_eq!(ranges(&[1, 2, 3, 7, 9, 10]), "1-3, 7, 9-10");
+        assert_eq!(ranges(&[]), "");
+    }
+
+    #[test]
+    fn shape_table_names_are_unique_and_cover_the_recorders() {
+        let shapes = shape_table();
+        let names: BTreeSet<&str> = shapes.iter().map(|s| s.name).collect();
+        assert_eq!(names.len(), shapes.len(), "duplicate shape name");
+        assert!(shapes
+            .iter()
+            .any(|s| s.config.memory && s.config.memory_rss_threshold_bytes == Some(0)));
+        assert!(shapes
+            .iter()
+            .any(|s| s.config.memory_vfio && s.config.memory_thp_sample_rate > 0));
+        assert!(shapes.iter().any(|s| s.config.network_packets));
+        assert!(shapes.iter().any(|s| s.config.memory_alloc));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod analyze;
 pub mod mcp;
 
 // Core library modules
+pub mod bpf_load_shapes;
 pub mod build_id_store;
 pub mod cgroup;
 pub mod duckdb;

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -5507,6 +5507,215 @@ pub fn systing(
     Ok(exit_code)
 }
 
+/// Load-only probe of the BPF object at one configuration: open the skeleton,
+/// configure it exactly as [`systing`] does for `opts` (rodata, map sizes,
+/// the autoload set), load it into the kernel, and attach nothing. The report
+/// carries, per program, whether it was selected for load, its instruction
+/// count, and — for the programs `log_level` puts at verifier log level 2 —
+/// the set of instructions the verifier visited, read from that log, so a
+/// caller can tell which code a configuration shape actually verified.
+///
+/// Why this exists: the verifier constant-folds the frozen `.rodata`
+/// configuration and prunes the branches it makes unreachable, so a load at
+/// one shape proves nothing about code another shape enables. A program the
+/// verifier rejected under the memory recorder's configuration had loaded
+/// cleanly everywhere at the defaults because the rejected instructions were
+/// dead at the defaults. `crate::bpf_load_shapes` drives this probe over the
+/// shapes that ship and unions the visited sets.
+///
+/// `log_level` is consulted once per selected program and returns the
+/// verifier log level to load it with: 0 is the plain load (the cheapest
+/// read — a rejection still comes back with its log, because libbpf retries
+/// a failed load at level 1 to fetch it), 2 records every instruction the
+/// verifier visited. Level 2 is expensive — the verifier formats a line per
+/// instruction per state, and the VM rig runs without KVM — so a coverage
+/// read asks for it only on the programs it still needs.
+///
+/// Requires CAP_BPF/CAP_PERFMON (root). libbpf's print callback is replaced
+/// for the duration of the load and restored afterwards; probes in one
+/// process are serialized on a lock, so two tests in one binary cannot
+/// interleave their captures.
+///
+/// `legs` selects how the kernel-probed memory legs are decided: `Host`
+/// probes this kernel as [`systing`] does (a leg whose symbol the host lacks
+/// is left unloaded); `Force` selects them regardless, which is what a
+/// load-only read wants — a kprobe or tracepoint program verifies without
+/// its attach target, so a host without the VFIO module can still verify
+/// the VFIO programs.
+pub fn bpf_load_probe(
+    opts: &Config,
+    legs: crate::bpf_load_shapes::LegSelection,
+    log_level: &dyn Fn(&str) -> u32,
+) -> Result<crate::bpf_load_shapes::LoadReport> {
+    use crate::bpf_load_shapes::{LegSelection, LoadReport, ProgramLoad};
+    use libbpf_rs::PrintLevel;
+    use std::collections::BTreeSet;
+
+    // The libbpf print callback is a plain function pointer, so the capture
+    // buffer is process-global, and one probe at a time owns it.
+    static CAPTURE: Mutex<String> = Mutex::new(String::new());
+    static PROBE: Mutex<()> = Mutex::new(());
+    fn capture_print(_level: PrintLevel, msg: String) {
+        if let Ok(mut buf) = CAPTURE.lock() {
+            buf.push_str(&msg);
+        }
+    }
+    let _probe = PROBE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let cgroup_filter = resolve_cgroup_filter(opts)?;
+    let num_cpus = libbpf_rs::num_possible_cpus().unwrap() as u32;
+    if opts.ringbuf_size_mib >= 4096 {
+        bail!(
+            "--ringbuf-size-mib {} is out of range: a ring is at most 4095 MiB",
+            opts.ringbuf_size_mib
+        );
+    }
+    let kernel = kernel_release_major_minor();
+    let ring_plan = plan_ringbufs(num_cpus, opts.ringbuf_size_mib, opts.ringbuf_shards, kernel);
+    let old_kernel = is_old_kernel();
+
+    // The recorder is only consulted for trace-event probes while configuring;
+    // no output sink is initialised for a load-only probe.
+    let recorder = Arc::new(SessionRecorder::new(
+        false,
+        false,
+        opts.marker_threshold,
+        opts.marker_duration_threshold,
+        false,
+    ));
+    configure_recorder(opts, &recorder);
+
+    let skel_builder = SystingSystemSkelBuilder::default();
+    let mut open_object = MaybeUninit::uninit();
+    let mut open_skel = skel_builder
+        .open(&mut open_object)
+        .with_context(|| "Failed to open BPF skeleton. Ensure BPF is supported on your kernel.")?;
+
+    let memory_legs = match legs {
+        LegSelection::Host => probe_memory_kernel_legs(opts),
+        LegSelection::Force { thp_page_prog } => MemoryKernelLegs {
+            vfio_off: None,
+            thp_pmd_off: None,
+            thp_page_prog: Some(thp_page_prog),
+        },
+    };
+    let collect_pystacks = opts.collect_pystacks;
+    configure_bpf_skeleton(
+        &mut open_skel,
+        opts,
+        num_cpus,
+        old_kernel,
+        collect_pystacks,
+        cgroup_filter.kernel_mode(),
+        &memory_legs,
+        &recorder,
+        ring_plan,
+    )?;
+
+    // The map sizing systing() performs between configure and load, for the
+    // shapes without perf counters or cgroup targets (both are attach-time
+    // inputs a load-only probe does not take): perf_counters at zero events
+    // and missed_events at one slot per CPU.
+    open_skel
+        .maps
+        .rodata_data
+        .as_deref_mut()
+        .unwrap()
+        .tool_config
+        .num_perf_counters = 0;
+    open_skel
+        .maps
+        .perf_counters
+        .set_max_entries(0)
+        .with_context(|| "Failed to set perf_counters map size to 0 entries")?;
+    open_skel
+        .maps
+        .missed_events
+        .set_max_entries(num_cpus)
+        .with_context(|| format!("Failed to set missed_events map size to {num_cpus} entries"))?;
+
+    let required = get_required_bpf_programs(
+        opts,
+        old_kernel,
+        collect_pystacks,
+        cgroup_filter.kernel_mode(),
+        &memory_legs,
+    );
+    let mut autoloaded: Vec<String> = Vec::new();
+    let mut skipped: Vec<String> = Vec::new();
+    for mut prog in open_skel.open_object_mut().progs_mut() {
+        let name = prog
+            .name()
+            .to_str()
+            .expect("BPF program name is not valid UTF-8")
+            .to_string();
+        if required.contains(name.as_str()) {
+            let level = log_level(&name);
+            if level > 0 {
+                prog.set_log_level(level);
+            }
+            autoloaded.push(name);
+        } else {
+            skipped.push(name);
+        }
+    }
+
+    CAPTURE.lock().unwrap().clear();
+    let previous = libbpf_rs::set_print(Some((PrintLevel::Debug, capture_print)));
+    let load_result = open_skel.load();
+    libbpf_rs::set_print(previous);
+    let log = std::mem::take(&mut *CAPTURE.lock().unwrap());
+
+    // Instruction counts are read from the LOADED object: subprogram calls
+    // are appended to each caller at load, and the verifier log indexes that
+    // final program, not the one the open object holds.
+    let (loaded, error, insn_counts): (bool, Option<String>, HashMap<String, usize>) =
+        match load_result {
+            Ok(skel) => {
+                let counts = skel
+                    .object()
+                    .progs()
+                    .map(|p| (p.name().to_string_lossy().into_owned(), p.insn_cnt()))
+                    .collect();
+                (true, None, counts)
+            }
+            Err(e) => (false, Some(format!("{e:#}")), HashMap::new()),
+        };
+    let sections = crate::bpf_load_shapes::split_prog_load_logs(&log);
+    let mut programs = Vec::new();
+    for name in autoloaded {
+        let visited: BTreeSet<u32> = sections
+            .get(name.as_str())
+            .map(|s| crate::bpf_load_shapes::visited_insns(s))
+            .unwrap_or_default();
+        let verifier_log = sections.get(name.as_str()).cloned();
+        let insn_total = insn_counts.get(&name).copied().unwrap_or(0);
+        programs.push(ProgramLoad {
+            name,
+            autoload: true,
+            insn_total,
+            visited,
+            verifier_log,
+        });
+    }
+    for name in skipped {
+        programs.push(ProgramLoad {
+            name,
+            autoload: false,
+            insn_total: 0,
+            visited: BTreeSet::new(),
+            verifier_log: None,
+        });
+    }
+    Ok(LoadReport {
+        loaded,
+        error,
+        programs,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/bpf_load_shapes.rs
+++ b/tests/bpf_load_shapes.rs
@@ -1,0 +1,284 @@
+//! Load every BPF program at every configuration shape that ships, and —
+//! in a second, slower read — require that the union of what the verifier
+//! visited covers every instruction of every program.
+//!
+//! Background: the BPF object's behaviour is selected through `.rodata`
+//! constants set before load; the verifier constant-folds them and prunes
+//! the branches a configuration disables, so a program that loads at one
+//! shape can still be rejected at another, and a load at the defaults says
+//! nothing about code only the memory recorder's configuration enables.
+//! `every_shape_loads` is the load-time positive control for that class:
+//! every shape in `systing::bpf_load_shapes::shape_table()` must load on this
+//! kernel, with the rejecting verifier log printed in full. It loads at
+//! verifier log level 0 and takes a few minutes even on the VM rig's
+//! KVM-less guest.
+//!
+//! `every_instruction_is_verified_by_some_shape` is the coverage read: any
+//! instruction no shape reaches names a configuration the table lacks (or
+//! dead code, which is then listed in `ALLOWED_UNVISITED` with a reason). It
+//! needs the level-2 verifier log, which costs a formatted line per
+//! instruction per state, so it asks for level 2 only on the programs whose
+//! union is still incomplete after the shapes loaded so far — most programs
+//! are covered by the first shape that selects them and drop to level 0 for
+//! the rest. It is still the slow one; run it on its own with a bound that
+//! fits the host.
+//!
+//! Requires root/BPF privileges; run via:
+//!   ./scripts/run-integration-tests.sh bpf_load_shapes
+//! (or the VM rig with a `-f every_shape_loads` filter for the gate alone).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use systing::bpf_load_shapes::{coverage_gaps, ranges, shape_table, LoadReport};
+use systing::systing_core::bpf_load_probe;
+
+/// Instructions known to be unreachable at every shipping shape, with the
+/// reason. Add a row only with the reason; the entry is `(program, ranges)`
+/// where ranges is the string `ranges()` prints.
+const ALLOWED_UNVISITED: &[(&str, &str, &str)] = &[
+    // (program, "start-end, start-end", reason)
+];
+
+/// Programs that load only with an attach-time input the table cannot
+/// carry, or only on a kernel other than this one (a twin the running
+/// kernel does not select), with the reason; they are reported, not
+/// failed, when no shape selects them.
+const SELECTED_ELSEWHERE: &[(&str, &str)] = &[
+    (
+        "systing_cgroup_target_add",
+        "loads only with a --cgroup target on a kernel with the cgroup kfuncs; the target is an attach-time input",
+    ),
+    (
+        "systing_tracepoint",
+        "kernels before 6.10 load it in place of systing_raw_tracepoint",
+    ),
+    (
+        "systing_raw_tracepoint",
+        "kernels from 6.10 load it in place of systing_tracepoint",
+    ),
+    (
+        "systing_rss_stat_btf",
+        "loads only on a kernel whose BTF carries the rss_stat tracepoint; the classic twin loads elsewhere",
+    ),
+];
+
+fn allowed(program: &str) -> Option<(&'static str, &'static str)> {
+    ALLOWED_UNVISITED
+        .iter()
+        .find(|(p, _, _)| *p == program)
+        .map(|(_, r, why)| (*r, *why))
+}
+
+/// Print every rejected program's verifier log and record the rejection.
+fn record_rejections(
+    shape: &str,
+    report: &LoadReport,
+    rejected: &mut BTreeMap<String, Vec<String>>,
+) {
+    if report.loaded {
+        return;
+    }
+    for p in report.failed_programs() {
+        eprintln!(
+            "[{shape}] program {} REJECTED:\n{}",
+            p.name,
+            p.verifier_log
+                .as_deref()
+                .unwrap_or("(no verifier log captured)")
+        );
+        rejected
+            .entry(p.name.clone())
+            .or_default()
+            .push(shape.to_string());
+    }
+    if report.failed_programs().is_empty() {
+        eprintln!(
+            "[{shape}] load failed without a per-program rejection: {}",
+            report.error.as_deref().unwrap_or("(no error text)")
+        );
+        rejected
+            .entry("(object)".to_string())
+            .or_default()
+            .push(shape.to_string());
+    }
+}
+
+fn rejection_findings(rejected: &BTreeMap<String, Vec<String>>) -> Vec<String> {
+    rejected
+        .iter()
+        .map(|(program, shapes)| {
+            format!(
+                "verifier rejected {program} at shape(s) {}",
+                shapes.join(", ")
+            )
+        })
+        .collect()
+}
+
+/// Every program in the object must be selected by at least one shape,
+/// unless it needs an attach-time input the table cannot carry.
+fn selection_findings(reports: &[(String, LoadReport)]) -> Vec<String> {
+    let mut never_selected: Vec<String> = Vec::new();
+    if let Some((_, first)) = reports.first() {
+        for p in &first.programs {
+            let selected_somewhere = reports
+                .iter()
+                .any(|(_, r)| r.programs.iter().any(|q| q.name == p.name && q.autoload));
+            if selected_somewhere {
+                continue;
+            }
+            match SELECTED_ELSEWHERE.iter().find(|(name, _)| *name == p.name) {
+                Some((_, why)) => eprintln!("[selection] {} selected by no shape ({why})", p.name),
+                None => never_selected.push(p.name.clone()),
+            }
+        }
+    }
+    if never_selected.is_empty() {
+        Vec::new()
+    } else {
+        vec![format!(
+            "programs selected by no shape in the table (add the shape that loads them, or document why they never load): {}",
+            never_selected.join(", ")
+        )]
+    }
+}
+
+/// The gate: every shape in the table loads on this kernel, and every
+/// program in the object is selected by some shape (or documented).
+#[test]
+#[ignore] // Requires root/BPF privileges
+fn every_shape_loads() {
+    let shapes = shape_table();
+    let mut reports: Vec<(String, LoadReport)> = Vec::new();
+    let mut rejected: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for shape in &shapes {
+        let started = std::time::Instant::now();
+        let report = bpf_load_probe(&shape.config, shape.legs, &|_| 0)
+            .unwrap_or_else(|e| panic!("[{}] probe failed before load: {e:#}", shape.name));
+        let selected = report.programs.iter().filter(|p| p.autoload).count();
+        eprintln!(
+            "[{}] loaded={} programs selected={} in {:.1?}",
+            shape.name,
+            report.loaded,
+            selected,
+            started.elapsed()
+        );
+        record_rejections(shape.name, &report, &mut rejected);
+        reports.push((shape.name.to_string(), report));
+    }
+
+    let mut failures = rejection_findings(&rejected);
+    failures.extend(selection_findings(&reports));
+    assert!(
+        failures.is_empty(),
+        "{} finding(s):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}
+
+/// The coverage read: the union over all shapes of the instructions the
+/// verifier visited covers every instruction of every program that loaded.
+/// Level-2 logging is requested only for programs not yet fully covered.
+#[test]
+#[ignore] // Requires root/BPF privileges; slow (level-2 verifier logs)
+fn every_instruction_is_verified_by_some_shape() {
+    let shapes = shape_table();
+    let mut reports: Vec<(String, LoadReport)> = Vec::new();
+    let mut rejected: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    // Programs whose visited union already equals their instruction count:
+    // no further shape needs the level-2 log for them.
+    let mut covered: BTreeSet<String> = BTreeSet::new();
+    let mut union: BTreeMap<String, (usize, BTreeSet<u32>)> = BTreeMap::new();
+
+    for shape in &shapes {
+        let started = std::time::Instant::now();
+        let report = bpf_load_probe(&shape.config, shape.legs, &|name| {
+            if covered.contains(name) {
+                0
+            } else {
+                2
+            }
+        })
+        .unwrap_or_else(|e| panic!("[{}] probe failed before load: {e:#}", shape.name));
+        let selected = report.programs.iter().filter(|p| p.autoload).count();
+        let logged = report
+            .programs
+            .iter()
+            .filter(|p| p.autoload && p.verifier_log.is_some())
+            .count();
+        let visited: usize = report.programs.iter().map(|p| p.visited.len()).sum();
+        eprintln!(
+            "[{}] loaded={} programs selected={} logged at level 2={} visited insns={} in {:.1?}",
+            shape.name,
+            report.loaded,
+            selected,
+            logged,
+            visited,
+            started.elapsed()
+        );
+        record_rejections(shape.name, &report, &mut rejected);
+        if report.loaded {
+            for p in report.programs.iter().filter(|p| p.autoload) {
+                let entry = union
+                    .entry(p.name.clone())
+                    .or_insert_with(|| (p.insn_total, BTreeSet::new()));
+                entry.0 = entry.0.max(p.insn_total);
+                entry.1.extend(p.visited.iter().copied());
+                if entry.0 > 0 && entry.1.len() >= entry.0 {
+                    covered.insert(p.name.clone());
+                }
+            }
+        }
+        reports.push((shape.name.to_string(), report));
+    }
+
+    let mut failures = rejection_findings(&rejected);
+
+    // Coverage: every instruction of every program that loaded must have
+    // been visited by the verifier at some shape.
+    for gap in coverage_gaps(&reports) {
+        if gap.loaded_by.is_empty() {
+            failures.push(format!(
+                "program {} was selected by a shape but loaded by none",
+                gap.program
+            ));
+            continue;
+        }
+        let rendered = ranges(&gap.unvisited);
+        match allowed(&gap.program) {
+            Some((allowed_ranges, why)) if allowed_ranges == rendered => {
+                eprintln!(
+                    "[coverage] {}: {} unvisited of {} allowed ({why})",
+                    gap.program,
+                    gap.unvisited.len(),
+                    gap.insn_total
+                );
+            }
+            Some((allowed_ranges, _)) => failures.push(format!(
+                "program {}: unvisited instructions {} (of {}) differ from the allowed {} — loaded by {}",
+                gap.program,
+                rendered,
+                gap.insn_total,
+                allowed_ranges,
+                gap.loaded_by.join(", ")
+            )),
+            None => failures.push(format!(
+                "program {}: instructions {} (of {}) are verified by NO shape in the table — a configuration is missing, or the code is dead (then allow it with a reason); loaded by {}",
+                gap.program,
+                rendered,
+                gap.insn_total,
+                gap.loaded_by.join(", ")
+            )),
+        }
+    }
+
+    failures.extend(selection_findings(&reports));
+    assert!(
+        failures.is_empty(),
+        "{} finding(s):\n  {}",
+        failures.len(),
+        failures.join("\n  ")
+    );
+}


### PR DESCRIPTION
A load-only test that opens the BPF object, configures it exactly as a capture does for each configuration shape that ships, and loads it into the kernel — attaching nothing — and fails on any rejection with the verifier log printed whole. A second, slower test unions the instructions the verifier visited across all shapes and names any instruction no shape reaches.

Why: the object's behaviour is selected by `.rodata` constants (`tool_config`: which recorders are on, sample rates, thresholds, filters) that userspace sets before load. libbpf freezes `.rodata` and the verifier constant-folds every branch on those constants, so a load verifies exactly the code the configuration enables and prunes the rest. The rss_stat rejection fixed in #220/#221 was invisible to every load we ran because the store path is gated by `memory_rss_threshold_bytes != 0`: at the object's defaults that threshold is 0, the branch is dead, and the program loaded everywhere; with the memory recorder's configuration the branch is live and the verifier rejected it. A load at one shape says nothing about another shape, and a shape nobody loads before a tag is a shape that is first loaded on a real host.

What is in the change:
- `systing_core::bpf_load_probe(opts, legs, log_level)`: the open → configure → load sequence of `systing()` (the same `configure_bpf_skeleton`, the same autoload selection, the same map sizing for the shapes without perf counters or cgroup targets), attaching nothing. `legs` selects the kernel-probed memory legs as the host allows or forces them on: a kprobe or tracepoint program verifies without its attach target, so a host without the vfio_iommu_type1 module can still verify the VFIO programs, which a capture on such a host never selects. `log_level` is consulted once per selected program: 0 is the plain load (libbpf refetches the log at level 1 on a rejection), 2 records every instruction the verifier visited. The report carries, per program: selected or not, instruction count (read from the loaded object, after subprogram appending), the visited set, and the program's section of the verifier log.
- `bpf_load_shapes`: the shape table (every row one `Config`, with the values a continuous capture runs with where they differ from the CLI defaults — CPU lane defaults and off arms, sw-event, build-id, syscalls/markers, pystacks, ring shards and sizes, the pid filter, a trace-event row; the memory recorder at its continuous shape, at rss threshold 0, at fault/map sample rates 1 and 97, the classic rss_stat twin, memory-alloc plain and sampled, VFIO + THP; the three network shapes; everything on; and two forced rows for the VFIO/THP legs, one per folio-split kretprobe twin), the level-2 log parsing (`split_prog_load_logs`, `visited_insns`), and the coverage arithmetic (`coverage_gaps`, `ranges`) — plain functions with unit tests.
- `tests/bpf_load_shapes.rs`, two `#[ignore]` root tests. `every_shape_loads` is the gate: every shape loads, and every program in the object is selected by some shape unless listed in `SELECTED_ELSEWHERE` with the reason (a twin the running kernel does not pick, or a program that needs an attach-time input such as a cgroup target); it loads at level 0 and takes a few minutes even on a KVM-less guest. `every_instruction_is_verified_by_some_shape` is the coverage read: any instruction of a loaded program that no shape visited fails unless listed in `ALLOWED_UNVISITED` with a reason; it asks for level 2 only on programs whose union is still incomplete after the shapes loaded so far, because a level-2 load costs a formatted line per instruction per state (the first cut logged every program at every shape and did not finish in 30 minutes under TCG).

A new knob is one new row in the table. The tests run where the other root tests run (`./scripts/run-integration-tests.sh bpf_load_shapes`, or the VM rig with `-f every_shape_loads` for the gate alone).

Test plan
- Unit tests for the parser, the coverage union and the table: `cargo test --lib bpf_load_shapes` — 7 passed.
- VM rig (the project's `bzImage-v6.12-bpf`, vanilla 6.12, TCG guest): `every_shape_loads` at this tree — 1 passed, 167 s in the guest; 30 shapes, 10–66 programs selected each, 2.3–25.7 s per shape.
- Positive control (not committed): the same test on the v1.15.1 `handle_rss_stat` form — #221's barrier-first mask reverted in the working tree — fails with `verifier rejected systing_rss_stat_btf at shape(s) memory-default, memory-sw-event, memory-sample-rates-1, memory-sample-rates-97, memory-alloc, memory-alloc-sampled, memory-vfio-thp, memory-ringbuf-shards-8, all-recorders, memory-vfio-thp-forced, memory-vfio-thp-forced-legacy`, each with the same verifier words the affected hosts reported, `R0 unbounded memory access, make sure to bounds check any such access … processed 407 insns`, while `memory-rss-threshold-0` and `memory-rss-classic` load. The same vanilla kernel that accepted that object at the defaults rejects it at the recorder's configuration, so the shape — not the verifier version — is what the earlier local and VM loads were missing.
- Not covered here: the other kernels in use (newer 6.12.y stable and 6.18 verifiers). The rig has only the vanilla 6.12 image today; a kernel matrix is the next step of the same program, and this test is the thing that runs on it.
