### PR TITLE
build: compile every BPF object through one helper that owns the flag pin, document the empty-override case, and drop CI's write scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
     pull_request:
       branches:
         - main
+
+# The jobs only build and test; nothing here writes to the repository.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Suite

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ cargo build
 sudo ./target/debug/systing --duration 60
 ```
 
+The BPF objects are compiled with `-mcpu=v3 -fwrapv` (pinned in `build.rs`)
+so a local build produces the same programs as a release build; set
+`SYSTING_BPF_CLANG=/path/to/clang-21` to also use the release build's
+compiler version (clang 21), otherwise `clang` on `PATH` is used.
+
 Alternatively, install directly with cargo. Use `--locked` so the build uses
 the dependency versions from `Cargo.lock`:
 

--- a/build.rs
+++ b/build.rs
@@ -117,8 +117,8 @@ const BPF_CFLAGS: &[&str] = &["-mcpu=v3", "-fwrapv"];
 
 /// Optional override for the C compiler used for the BPF objects, so a
 /// local or CI build can use the exact compiler the release build uses
-/// (`SYSTING_BPF_CLANG=/path/to/clang-21`). Unset: libbpf-cargo's default
-/// (`clang` on PATH).
+/// (`SYSTING_BPF_CLANG=/path/to/clang-21`). Unset or empty: libbpf-cargo's
+/// default (`clang` on PATH).
 fn bpf_clang_override() -> Option<PathBuf> {
     println!("cargo:rerun-if-env-changed=SYSTING_BPF_CLANG");
     env::var_os("SYSTING_BPF_CLANG")
@@ -126,15 +126,30 @@ fn bpf_clang_override() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
-/// Apply the compiler pinning every BPF object build shares.
-fn pin_bpf_compiler<'a>(
-    builder: &'a mut SkeletonBuilder,
-    clang_override: &Option<PathBuf>,
-) -> &'a mut SkeletonBuilder {
-    if let Some(clang) = clang_override {
+/// Compile one BPF object with the compiler pinning every BPF object build
+/// shares: the pinned flags ([`BPF_CFLAGS`]) and the `SYSTING_BPF_CLANG`
+/// override.
+///
+/// The pinned flags are prepended here, not by the callers: libbpf-cargo's
+/// `clang_args` REPLACES the argument list rather than appending to it, so a
+/// caller that assembled its own list (or called `clang_args` twice) would
+/// silently compile that object without the pin. Callers pass only their
+/// object-specific arguments and never hold the builder, which is what makes
+/// the pin structural.
+fn compile_bpf_object(source: &str, obj_path: &Path, object_args: &[&OsStr]) {
+    let mut clang_args: Vec<&OsStr> = BPF_CFLAGS.iter().map(OsStr::new).collect();
+    clang_args.extend_from_slice(object_args);
+
+    let mut builder = SkeletonBuilder::new();
+    if let Some(clang) = bpf_clang_override() {
         builder.clang(clang);
     }
     builder
+        .source(source)
+        .clang_args(clang_args)
+        .obj(obj_path)
+        .build()
+        .unwrap_or_else(|err| panic!("Failed to build BPF object from {source}: {err}"));
 }
 
 fn build_pystacks_bpf(out_dir: &Path, arch_define: &str, multiarch_include: &Option<String>) {
@@ -166,27 +181,19 @@ fn build_pystacks_bpf(out_dir: &Path, arch_define: &str, multiarch_include: &Opt
 
     let obj_path = out_dir.join("pystacks.bpf.o");
 
-    let mut clang_args: Vec<&OsStr> = BPF_CFLAGS.iter().map(OsStr::new).collect();
-    clang_args.extend([
+    let mut object_args = vec![
         OsStr::new(&out_dir_include_arg),
         OsStr::new(&bpf_include_arg),
         OsStr::new(&pystacks_include_arg),
         OsStr::new(&pystacks_bpf_arg),
         OsStr::new(arch_define),
-    ]);
+    ];
 
     if let Some(ref include_path) = multiarch_include {
-        clang_args.push(OsStr::new(include_path));
+        object_args.push(OsStr::new(include_path));
     }
 
-    let clang_override = bpf_clang_override();
-    let mut builder = SkeletonBuilder::new();
-    pin_bpf_compiler(&mut builder, &clang_override)
-        .source("src/pystacks/bpf/pystacks.bpf.c")
-        .clang_args(clang_args)
-        .obj(obj_path.to_str().unwrap())
-        .build()
-        .expect("Failed to build pystacks BPF object");
+    compile_bpf_object("src/pystacks/bpf/pystacks.bpf.c", &obj_path, &object_args);
 
     // Generate pystacks skeleton for typed access to BSS variables and maps.
     let pystacks_skel_path = out_dir.join("pystacks.skel.rs");
@@ -297,28 +304,20 @@ fn main() {
         };
         let obj_path = out_dir.join(format!("{prefix}_tmp.bpf.o"));
 
-        let mut clang_args: Vec<&OsStr> = BPF_CFLAGS.iter().map(OsStr::new).collect();
-        clang_args.extend([
+        let mut object_args = vec![
             OsStr::new(&include_arg),
             OsStr::new(&bpf_include_arg),
             OsStr::new(arch_define),
             OsStr::new("-DSYSTING_PYSTACKS"),
             OsStr::new(&pystacks_inc_arg),
             OsStr::new(&pystacks_bpf_arg),
-        ]);
+        ];
 
         if let Some(ref include_path) = multiarch_include {
-            clang_args.push(OsStr::new(include_path));
+            object_args.push(OsStr::new(include_path));
         }
 
-        let clang_override = bpf_clang_override();
-        let mut builder = SkeletonBuilder::new();
-        pin_bpf_compiler(&mut builder, &clang_override)
-            .source(src)
-            .clang_args(clang_args)
-            .obj(obj_path.to_str().unwrap())
-            .build()
-            .expect("Failed to build BPF skeleton");
+        compile_bpf_object(src, &obj_path, &object_args);
 
         println!("cargo:rerun-if-changed={src}");
     }


### PR DESCRIPTION
**What this changes.** `build.rs` only: the two BPF object builds now go through one helper, `compile_bpf_object(source, obj_path, object_args)`, which assembles the compiler argument list itself — the `-mcpu=v3 -fwrapv` pin from #222 first, then the object's include paths and defines — applies the `SYSTING_BPF_CLANG` override and runs the compile. `pin_bpf_compiler` is gone. Plus three doc/CI nits. No runtime change and no change to the compiled BPF objects.

**Why.** libbpf-cargo's `clang_args` *replaces* the builder's argument list. After #222 the pin held only because each of the two object builds happened to start its own `Vec` with `BPF_CFLAGS` and call `clang_args` exactly once; a third object, or a second call on the same builder, would have compiled without the pin and nothing would have said so. A first cut of this change moved the prepend into `pin_bpf_compiler` but still handed the builder back to the caller, which could call `clang_args` again — the same hole one step removed. With the helper owning the builder from `new()` to `build()`, the pin is a property of the code shape rather than of the call sites agreeing.

**The nits.** `SYSTING_BPF_CLANG=""` already meant unset (the override filters an empty value) — its doc comment now says so; the README Quick start gains one sentence on the pin and the override; `.github/workflows/ci.yml` gets `permissions: contents: read` (the jobs only build and test; the actions cache does not use the job token's scopes).

**Verification.**
- The BPF objects built from this tree and from the parent (v1.15.5's `build.rs`, same compiler, separate target directories) were compared program section by program section with `llvm-objdump`: identical instruction streams for `systing_system_tmp.bpf.o` (63 program sections), `pystacks.bpf.o` and the linked `systing_system.bpf.o` (63), and identical bytes outside `.BTF`/`.BTF.ext` (the only byte differences are `.BTF` source-path strings, which differ between the two checkouts).
- `cargo fmt --all -- --check` exit 0; `cargo clippy --all-targets -- -D warnings` exit 0; `cargo test` exit 0 — 562 + 28 + 11 + 7 + 4 + 1 + 1 passed, 0 failed (the VM-only targets `#[ignore]`d); CI on this PR runs with the new `permissions` block.

No tag bump is needed (build-side only); it rides the next tag.
