### PR TITLE
ci: link the tests against the DuckDB version the crate pins, read from Cargo.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
-      - name: Download pre-built DuckDB library
+      - name: Download the pre-built DuckDB library the crate pins
         run: |
-          wget -q https://github.com/duckdb/duckdb/releases/download/v1.4.2/libduckdb-linux-amd64.zip -O /tmp/libduckdb.zip
+          LIBDUCKDB_VERSION="$(scripts/libduckdb-version.sh)"
+          echo "libduckdb v${LIBDUCKDB_VERSION} (the DuckDB version Cargo.lock pins)"
+          wget -q "https://github.com/duckdb/duckdb/releases/download/v${LIBDUCKDB_VERSION}/libduckdb-linux-amd64.zip" -O /tmp/libduckdb.zip
           unzip /tmp/libduckdb.zip -d ${{ github.workspace }}/libduckdb
       - name: Run Tests
         env:
@@ -75,9 +77,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
-      - name: Download pre-built DuckDB library
+      - name: Download the pre-built DuckDB library the crate pins
         run: |
-          wget -q https://github.com/duckdb/duckdb/releases/download/v1.4.2/libduckdb-linux-amd64.zip -O /tmp/libduckdb.zip
+          LIBDUCKDB_VERSION="$(scripts/libduckdb-version.sh)"
+          echo "libduckdb v${LIBDUCKDB_VERSION} (the DuckDB version Cargo.lock pins)"
+          wget -q "https://github.com/duckdb/duckdb/releases/download/v${LIBDUCKDB_VERSION}/libduckdb-linux-amd64.zip" -O /tmp/libduckdb.zip
           unzip /tmp/libduckdb.zip -d ${{ github.workspace }}/libduckdb
       - name: Run Clippy
         env:

--- a/scripts/libduckdb-version.sh
+++ b/scripts/libduckdb-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Print the DuckDB release version the `duckdb` crate pins, read from Cargo.lock.
+#
+# libduckdb-sys encodes the DuckDB version it wraps as 1.MMmmPP.0 (1.10504.0 is
+# DuckDB v1.5.4). CI links the tests against the pre-built libduckdb of that
+# exact version, so a change to the pinned crate moves CI with it and the
+# tests run on the engine the release build bundles.
+set -euo pipefail
+
+lock="$(cd "$(dirname "$0")/.." && pwd)/Cargo.lock"
+crate_version=$(grep -A1 '^name = "libduckdb-sys"$' "$lock" | sed -n 's/^version = "\(.*\)"$/\1/p')
+if [ -z "$crate_version" ]; then
+    echo "libduckdb-sys not found in $lock" >&2
+    exit 1
+fi
+case "$crate_version" in
+    1.*) ;;
+    *)
+        echo "unexpected libduckdb-sys version scheme: $crate_version" >&2
+        exit 1
+        ;;
+esac
+
+encoded=${crate_version#1.}
+encoded=${encoded%%.*}
+echo "$((10#$encoded / 10000)).$((10#$encoded / 100 % 100)).$((10#$encoded % 100))"


### PR DESCRIPTION
**What this changes.** CI only. `.github/workflows/ci.yml`'s two "download pre-built DuckDB" steps (Test Suite, Clippy) no longer hard-code `v1.4.2`: they run the new `scripts/libduckdb-version.sh`, which reads the `libduckdb-sys` version from `Cargo.lock` and decodes it (`1.MMmmPP.0` → `M.m.P`; `1.10504.0` → `1.5.4`), and download that release's `libduckdb-linux-amd64.zip`. The step logs the version it linked. No source change.

**Why.** The release build bundles the DuckDB the `duckdb` crate pins — v1.5.4 today — while CI's `--no-default-features` jobs linked the tests against v1.4.2. A green CI therefore did not exercise engine-semantics-dependent SQL (ASOF JOIN matching, window tie order, quantiles) on the engine that ships; #227's ASOF-vs-range-join equivalence test, for one, ran on 1.4.2. Deriving the version from `Cargo.lock` makes CI follow every crate bump without a second place to edit.

**Verification.**
- `bash scripts/libduckdb-version.sh` on this tree prints `1.5.4` (from `libduckdb-sys 1.10504.0`); the script refuses a lock without the crate or with an unexpected version scheme.
- CI on this PR: the download step's log line reads `libduckdb v1.5.4 (the DuckDB version Cargo.lock pins)` and the Test Suite / Clippy jobs run against it — that log line is the proof the change is meant to produce.

No tag bump needed (CI only).
