### PR TITLE
build: keep the compiler's diagnostics when a BPF compile fails, and refuse an object argument that would override the pinned flags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -135,8 +135,17 @@ fn bpf_clang_override() -> Option<PathBuf> {
 /// caller that assembled its own list (or called `clang_args` twice) would
 /// silently compile that object without the pin. Callers pass only their
 /// object-specific arguments and never hold the builder, which is what makes
-/// the pin structural.
+/// the pin structural. Because clang lets a later flag win, an object argument
+/// that would override a pinned flag is refused rather than silently applied.
 fn compile_bpf_object(source: &str, obj_path: &Path, object_args: &[&OsStr]) {
+    for arg in object_args {
+        let arg = arg.to_string_lossy();
+        assert!(
+            !(arg.starts_with("-mcpu") || arg == "-fwrapv" || arg == "-fno-wrapv"),
+            "object argument {arg:?} for {source} would override the pinned BPF compiler flags {BPF_CFLAGS:?}"
+        );
+    }
+
     let mut clang_args: Vec<&OsStr> = BPF_CFLAGS.iter().map(OsStr::new).collect();
     clang_args.extend_from_slice(object_args);
 
@@ -144,12 +153,14 @@ fn compile_bpf_object(source: &str, obj_path: &Path, object_args: &[&OsStr]) {
     if let Some(clang) = bpf_clang_override() {
         builder.clang(clang);
     }
+    // `{err:?}` prints the error's cause chain, which is where the compiler's
+    // own diagnostics are; the outermost message alone names only the file.
     builder
         .source(source)
         .clang_args(clang_args)
         .obj(obj_path)
         .build()
-        .unwrap_or_else(|err| panic!("Failed to build BPF object from {source}: {err}"));
+        .unwrap_or_else(|err| panic!("Failed to build BPF object from {source}: {err:?}"));
 }
 
 fn build_pystacks_bpf(out_dir: &Path, arch_define: &str, multiarch_include: &Option<String>) {


### PR DESCRIPTION
**What this changes.** `build.rs` only, two things in `compile_bpf_object` (#229): (1) a failed BPF compile is reported with the error's cause chain (`{err:?}`) instead of its outermost message, so clang's diagnostics show again; (2) an object argument that would override a pinned compiler flag (`-mcpu…`, `-fwrapv`, `-fno-wrapv`) is refused with a message naming it. No change to successful builds or to the compiled objects — the command line each compile sees is the same as before.

**Why.** #229 replaced the two `.expect()` calls with `unwrap_or_else(|err| panic!("…: {err}"))`; `{err}` prints only the outermost message of libbpf-cargo's error, while the cause chain underneath carries the compiler's output — so a C error in a BPF source surfaced as `Failed to build BPF object from src/…: failed to build \`src/…\`` and nothing else. `.expect()` had printed the chain (it formats with `{:?}`); this restores that. Separately, #229 made the pin structural against omission (every object goes through the one helper that prepends the flags), but clang applies the last of conflicting flags, and an object argument such as `-mcpu=v1` after the pin would win. No caller passes one today; the assertion turns that into a build-time refusal.

**Verification.**
- The BPF objects built from this tree and from the parent (v1.16.3's `build.rs`, same compiler, separate target directories) compared program section by program section with `llvm-objdump`: identical instruction streams and identical bytes outside `.BTF`/`.BTF.ext` (the argument list is unchanged; only the failure path and a pre-check moved).
- `cargo fmt --all -- --check` exit 0; `cargo clippy --all-targets -- -D warnings` exit 0; `cargo test` exit 0 — 572 + 28 + 11 + 7 + 4 + 1 + 1 passed, 0 failed (the VM-only targets `#[ignore]`d); CI on this PR.

No tag bump needed (build-side only); it rides the next tag.
