### PR TITLE
build-side follow-ups: libduckdb-version.sh's refusals, and only -I/-D as BPF object arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           LIBDUCKDB_VERSION="$(scripts/libduckdb-version.sh)"
           echo "libduckdb v${LIBDUCKDB_VERSION} (the DuckDB version Cargo.lock pins)"
-          wget -q "https://github.com/duckdb/duckdb/releases/download/v${LIBDUCKDB_VERSION}/libduckdb-linux-amd64.zip" -O /tmp/libduckdb.zip
+          wget -nv "https://github.com/duckdb/duckdb/releases/download/v${LIBDUCKDB_VERSION}/libduckdb-linux-amd64.zip" -O /tmp/libduckdb.zip
           unzip /tmp/libduckdb.zip -d ${{ github.workspace }}/libduckdb
       - name: Run Tests
         env:
@@ -81,7 +81,7 @@ jobs:
         run: |
           LIBDUCKDB_VERSION="$(scripts/libduckdb-version.sh)"
           echo "libduckdb v${LIBDUCKDB_VERSION} (the DuckDB version Cargo.lock pins)"
-          wget -q "https://github.com/duckdb/duckdb/releases/download/v${LIBDUCKDB_VERSION}/libduckdb-linux-amd64.zip" -O /tmp/libduckdb.zip
+          wget -nv "https://github.com/duckdb/duckdb/releases/download/v${LIBDUCKDB_VERSION}/libduckdb-linux-amd64.zip" -O /tmp/libduckdb.zip
           unzip /tmp/libduckdb.zip -d ${{ github.workspace }}/libduckdb
       - name: Run Clippy
         env:

--- a/build.rs
+++ b/build.rs
@@ -135,14 +135,21 @@ fn bpf_clang_override() -> Option<PathBuf> {
 /// caller that assembled its own list (or called `clang_args` twice) would
 /// silently compile that object without the pin. Callers pass only their
 /// object-specific arguments and never hold the builder, which is what makes
-/// the pin structural. Because clang lets a later flag win, an object argument
-/// that would override a pinned flag is refused rather than silently applied.
+/// the pin structural. Because clang lets a later flag win — and its driver
+/// has more spellings that move a pinned flag than the pin itself has
+/// (`-fstrict-overflow` drops `-fwrapv` from the cc1 line on newer compilers,
+/// `-ftrapv` beside it makes cc1 trap instead of wrap, `-Xclang` and an
+/// `@response-file` reach cc1 around any list) — an object argument is
+/// admitted only in the two forms the callers use, an include path or a
+/// define, and anything else is refused rather than enumerated. The guard
+/// covers this file's callers only: the compiler's own environment can still
+/// change its behaviour without an argument here.
 fn compile_bpf_object(source: &str, obj_path: &Path, object_args: &[&OsStr]) {
     for arg in object_args {
         let arg = arg.to_string_lossy();
         assert!(
-            !(arg.starts_with("-mcpu") || arg == "-fwrapv" || arg == "-fno-wrapv"),
-            "object argument {arg:?} for {source} would override the pinned BPF compiler flags {BPF_CFLAGS:?}"
+            arg.starts_with("-I") || arg.starts_with("-D"),
+            "object argument {arg:?} for {source} is neither an include path nor a define; only those may follow the pinned BPF compiler flags {BPF_CFLAGS:?}"
         );
     }
 

--- a/scripts/libduckdb-version.sh
+++ b/scripts/libduckdb-version.sh
@@ -1,26 +1,33 @@
 #!/usr/bin/env bash
 # Print the DuckDB release version the `duckdb` crate pins, read from Cargo.lock.
 #
-# libduckdb-sys encodes the DuckDB version it wraps as 1.MMmmPP.0 (1.10504.0 is
+# libduckdb-sys encodes the DuckDB version it wraps as 1.MMmmPP.N (1.10504.0 is
 # DuckDB v1.5.4). CI links the tests against the pre-built libduckdb of that
 # exact version, so a change to the pinned crate moves CI with it and the
 # tests run on the engine the release build bundles.
+#
+# Refuses, with a message on stderr and a non-zero exit, a lock that does not
+# name the crate exactly once, or a version outside the encoded shape: the
+# crate's older 1.x line (1.4.5 and the like) is still published beside it and
+# would otherwise decode to a version that does not exist, and a pre-release
+# suffix must not be silently read as its release.
 set -euo pipefail
 
 lock="$(cd "$(dirname "$0")/.." && pwd)/Cargo.lock"
-crate_version=$(grep -A1 '^name = "libduckdb-sys"$' "$lock" | sed -n 's/^version = "\(.*\)"$/\1/p')
-if [ -z "$crate_version" ]; then
+versions=$(grep -A1 '^name = "libduckdb-sys"$' "$lock" | sed -n 's/^version = "\(.*\)"$/\1/p' || true)
+count=$(printf '%s\n' "$versions" | grep -c . || true)
+if [ "$count" -eq 0 ]; then
     echo "libduckdb-sys not found in $lock" >&2
     exit 1
 fi
-case "$crate_version" in
-    1.*) ;;
-    *)
-        echo "unexpected libduckdb-sys version scheme: $crate_version" >&2
-        exit 1
-        ;;
-esac
+if [ "$count" -ne 1 ]; then
+    echo "libduckdb-sys appears $count times in $lock ($(echo "$versions" | tr '\n' ' ')); cannot pick one" >&2
+    exit 1
+fi
+if [[ ! "$versions" =~ ^1\.([0-9]{5,})\.[0-9]+$ ]]; then
+    echo "unexpected libduckdb-sys version scheme: $versions (expected the encoded 1.MMmmPP.N form)" >&2
+    exit 1
+fi
 
-encoded=${crate_version#1.}
-encoded=${encoded%%.*}
+encoded=${BASH_REMATCH[1]}
 echo "$((10#$encoded / 10000)).$((10#$encoded / 100 % 100)).$((10#$encoded % 100))"


### PR DESCRIPTION
Two build-side follow-ups from the cold reads of #230 and #231; no source, BPF, schema or version change.

## `scripts/libduckdb-version.sh` — make its refusals real (#230)

The helper decodes the DuckDB version CI downloads from `Cargo.lock`'s `libduckdb-sys` entry. Two of the refusals it advertises did not fire:

- With `set -euo pipefail`, a lock without the crate made the `grep` pipeline fail inside the assignment, so the script died with rc 1 and an empty stderr before the "libduckdb-sys not found" branch could run.
- The scheme guard `1.*)` admitted the crate's older `1.x` line, which is still published in parallel (`1.4.5` beside `1.10504.0`): `1.4.5` decoded to `0.0.4` with rc 0 and the download step then 404'd silently under `wget -q`.

A pre-release suffix (`1.10504.0-alpha.1`) was also read as its release, and a lock naming the crate twice took the first entry.

Now: the extraction tolerates an empty match (`|| true`) and tests the count (none → "not found"; more than one → "appears N times (…); cannot pick one"); the scheme guard is the anchored encoded shape `^1\.([0-9]{5,})\.[0-9]+$`, which admits `1.10504.0` (→ 1.5.4) and `1.11000.0` (→ 1.10.0) and refuses `1.4.5`, `0.10.2`, `2.20000.0` and any pre-release suffix, naming the version and the expected form; the two libduckdb downloads in `ci.yml` use `wget -nv`, so a failed download prints its reason in the job log.

Checked on eleven synthetic locks (the real encoding, a two-digit minor, a crate patch, a pre-release, the old `1.4.x` line twice, `0.x`, `2.x`, a missing crate, two duplicate-entry locks) and on the repository's own `Cargo.lock` (`1.5.4`); the CI step shape (`bash -e`, the version in a command substitution) aborts with the message on every refusal and prints `reached: libduckdb v1.5.4` on the real lock.

## `build.rs` — admit only include paths and defines as BPF object arguments (#231)

The refusal added in #231 named three spellings that override the pinned flags (`-mcpu`, `-fwrapv`, `-fno-wrapv`), but the driver has more: on a newer clang, `-fstrict-overflow` after the pin drops `-fwrapv` from the cc1 line (an older clang keeps it — exactly the local-versus-release divergence the pin exists to close), `-ftrapv` beside it makes cc1 trap instead of wrap, `-fno-strict-overflow` adds `-fwrapv-pointer`, and `-Xclang` or an `@response-file` reach cc1 around any list. Both callers pass only include paths and defines, so the guard is inverted: an object argument must start with `-I` or `-D`, anything else is refused with the argument, the source and the pinned set named. The command line is unchanged; the compiled objects were compared against a build of the unchanged `build.rs` — identical instruction streams and identical bytes outside `.BTF`/`.BTF.ext`.
