### PR TITLE
analyze: read the PIVOT value list from the pivot's own ON clause; --cgroup: name a target off cgroup2 as its own cause

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,9 @@ lifted that limit): there, from a container with a private cgroup namespace and
 the host's cgroup filesystem mounted, a host path is visible but cannot be
 resolved, and systing says so at start — run it in the host cgroup namespace
 or use the fallback. Only the unified cgroup v2 hierarchy is supported; a
-target on a cgroup v1 hierarchy is refused the same way.
+target on a cgroup v1 hierarchy, or a directory that is not on a cgroup
+filesystem at all, is refused at start with that cause named (systing checks
+the target's filesystem before blaming the namespace).
 
 `--trace-event` - This will add an `instant` track event for each event that
 this tool captures.  The format is "<trace type>:<optional

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -539,42 +539,53 @@ impl AnalyzeDb {
                 }
                 Ok(result)
             }
-            // The binding's `prepare` is not parse-only: it executes every
-            // statement but the last of the text it is handed, so a prepare
-            // can already have run a scan (a DuckDB-expanded statement the
-            // classifier let through) and hit the memory bound. That failure
-            // is reported as the bound — never as the engine's allocation
-            // text, which would tell the caller to raise a locked setting —
-            // and the text is not prepared a second time, which would run
-            // the same scan again for the same answer.
-            Err(err) if is_memory_bound_error(&err) => Err(self.classify_query_error(err)),
-            Err(_) => {
-                // Prepare the user's own text so a SQL error names their
-                // line and column, not the wrapper's.
-                let mut stmt = self
-                    .conn
-                    .prepare(&inner)
-                    .map_err(|e| self.classify_query_error(e))?;
-                if must_wrap {
-                    // It prepares on its own but not inside the wrapper: a
-                    // shape that can read rows and that the cap cannot
-                    // bound, so it does not run at all rather than run
-                    // unbounded.
-                    bail!(
-                        "query could not be bounded by the {MAX_QUERY_ROWS}-row cap; rewrite it as a single SELECT statement"
-                    );
-                }
-                // A non-row-reading statement: run it as written. Its result
-                // is small by nature and already materialized, so the rows
-                // beyond the cap are drained and counted.
-                let (mut result, beyond_cap) = self.run_capped(&mut stmt, true)?;
-                if beyond_cap > 0 {
-                    result.truncated = true;
-                    result.total_row_count = Some(result.row_count + beyond_cap);
-                }
-                Ok(result)
-            }
+            Err(err) => self.query_after_wrapped_prepare_failed(err, &inner, must_wrap),
         }
+    }
+
+    /// The rest of [`Self::query`] once the wrapped form failed to prepare
+    /// with `err`. Split out so the decision below can be driven directly.
+    ///
+    /// The binding's `prepare` is not parse-only: it executes every
+    /// statement but the last of the text it is handed, so a prepare can
+    /// already have run a scan (a DuckDB-expanded statement the classifier
+    /// let through) and hit the memory bound. That failure is reported as
+    /// the bound — never as the engine's allocation text, which would tell
+    /// the caller to raise a locked setting — and the text is not prepared
+    /// a second time, which would run the same scan again for the same
+    /// answer. Any other prepare failure falls through to the raw form.
+    fn query_after_wrapped_prepare_failed(
+        &self,
+        err: duckdb::Error,
+        inner: &str,
+        must_wrap: bool,
+    ) -> Result<QueryResult> {
+        if is_memory_bound_error(&err) {
+            return Err(self.classify_query_error(err));
+        }
+        // Prepare the user's own text so a SQL error names their line and
+        // column, not the wrapper's.
+        let mut stmt = self
+            .conn
+            .prepare(inner)
+            .map_err(|e| self.classify_query_error(e))?;
+        if must_wrap {
+            // It prepares on its own but not inside the wrapper: a shape
+            // that can read rows and that the cap cannot bound, so it does
+            // not run at all rather than run unbounded.
+            bail!(
+                "query could not be bounded by the {MAX_QUERY_ROWS}-row cap; rewrite it as a single SELECT statement"
+            );
+        }
+        // A non-row-reading statement: run it as written. Its result is
+        // small by nature and already materialized, so the rows beyond the
+        // cap are drained and counted.
+        let (mut result, beyond_cap) = self.run_capped(&mut stmt, true)?;
+        if beyond_cap > 0 {
+            result.truncated = true;
+            result.total_row_count = Some(result.row_count + beyond_cap);
+        }
+        Ok(result)
     }
 
     /// Execute a prepared statement and read up to `MAX_QUERY_ROWS` rows into
@@ -1688,10 +1699,15 @@ mod tests {
         // shape is refused before it reaches `prepare`, so no such type is
         // ever created; the same pivot with its values named runs wrapped
         // (one row per id here, so the cap and the count are exercised).
+        // Only the pivot's own ON clause counts: the bypass probe, a
+        // pivot whose only `IN (` sits in its source subquery, is refused
+        // too (DuckDB still expands it; it left a type behind before).
         for sql in [
             "PIVOT t ON bucket USING count(id)",
             "pivot_wider t on bucket using count(id) group by id",
             "PIVOT t ON bucket USING count(id) -- IN (0, 1)",
+            "PIVOT (SELECT * FROM t WHERE id IN (3, 4, 5)) ON bucket USING count(id)",
+            "PIVOT t ON bucket IN (0, 1), id USING count(*)",
         ] {
             let err = db.query(sql).unwrap_err().to_string();
             assert!(err.contains("PIVOT without an IN"), "{sql:?}: {err}");
@@ -1706,6 +1722,13 @@ mod tests {
         assert_eq!(pivoted.row_count, MAX_QUERY_ROWS);
         assert!(pivoted.truncated);
         assert_eq!(pivoted.total_row_count, Some(25000));
+        let pivoted = db
+            .query(
+                "PIVOT (SELECT * FROM t WHERE id IN (3, 4, 5)) ON bucket IN (3, 4, 5) USING count(id) GROUP BY id",
+            )
+            .unwrap();
+        assert_eq!(pivoted.row_count, 3);
+        assert!(!pivoted.truncated);
         let enums = db
             .query("SELECT count(*) FROM duckdb_types() WHERE type_name LIKE '__pivot_enum%'")
             .unwrap();
@@ -1717,16 +1740,51 @@ mod tests {
         // `is_memory_bound_error` is what keeps a prepare that hit the bound
         // from being retried unwrapped and from surfacing the engine's
         // allocation text (which names the setting the lock refuses).
-        let oom = duckdb::Error::DuckDBFailure(
-            duckdb::ffi::Error::new(1),
-            Some(format!("{DUCKDB_OOM_MARKER}: could not allocate block")),
+        let oom = || {
+            duckdb::Error::DuckDBFailure(
+                duckdb::ffi::Error::new(1),
+                Some(format!("{DUCKDB_OOM_MARKER}: could not allocate block")),
+            )
+        };
+        let other = || {
+            duckdb::Error::DuckDBFailure(
+                duckdb::ffi::Error::new(1),
+                Some("Binder Error: column nope not found".to_string()),
+            )
+        };
+        assert!(is_memory_bound_error(&oom()));
+        assert!(!is_memory_bound_error(&other()));
+
+        // The decision itself, driven with a statement whose raw form would
+        // prepare and run fine: after a memory-bound failure of the wrapped
+        // prepare the raw form is NOT prepared (no rows come back, the
+        // error is the bound's fixed text, not the engine's); after any
+        // other failure it is, and a non-row-reading statement runs raw.
+        let dir = tempfile::tempdir().unwrap();
+        let db = open_query_test_db(dir.path());
+        let err = db
+            .query_after_wrapped_prepare_failed(oom(), "SELECT 1 AS one", false)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.starts_with("query exceeded the DuckDB memory bound"),
+            "unexpected: {err}"
         );
-        assert!(is_memory_bound_error(&oom));
-        let other = duckdb::Error::DuckDBFailure(
-            duckdb::ffi::Error::new(1),
-            Some("Binder Error: column nope not found".to_string()),
-        );
-        assert!(!is_memory_bound_error(&other));
+        assert!(!err.contains("allocate"), "engine text leaked: {err}");
+        let err = db
+            .query_after_wrapped_prepare_failed(oom(), "SELECT 1 AS one", true)
+            .unwrap_err()
+            .to_string();
+        assert!(err.starts_with("query exceeded the DuckDB memory bound"));
+        let raw = db
+            .query_after_wrapped_prepare_failed(other(), "SELECT 1 AS one", false)
+            .unwrap();
+        assert_eq!(raw.rows, vec![vec![serde_json::json!(1)]]);
+        let err = db
+            .query_after_wrapped_prepare_failed(other(), "SELECT 1 AS one", true)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("could not be bounded"), "{err}");
     }
 
     #[test]

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -330,10 +330,15 @@ pub struct AnalyzeDb {
 
 /// Text DuckDB puts at the front of every `OutOfMemoryException` message,
 /// whether the buffer pool hit `memory_limit` or a spill hit
-/// `max_temp_directory_size` ("failed to offload data block"). The binding's
-/// `Display` prints the engine's message bare, so it is matched as a prefix:
-/// a user's own string literal that happens to contain the words cannot
-/// trigger the rewrite.
+/// `max_temp_directory_size` ("failed to offload data block"): both bounds
+/// throw that one exception class (DuckDB 1.5.4, the version `libduckdb-sys`
+/// pins: the block-offload throw in `src/storage/temporary_file_manager.cpp`
+/// for the spill bound, `src/storage/buffer/buffer_pool.cpp` for the buffer
+/// pool), and the class renders with the "Out of Memory Error" prefix
+/// (`src/common/exception.cpp`, `ExceptionType::OUT_OF_MEMORY`). The
+/// binding's `Display` prints the engine's message bare, so it is matched as
+/// a prefix: a user's own string literal that happens to contain the words
+/// cannot trigger the rewrite.
 const DUCKDB_OOM_MARKER: &str = "Out of Memory Error";
 
 /// Whether `err` is DuckDB reporting that a query ran into the memory bound

--- a/src/analyze/query.rs
+++ b/src/analyze/query.rs
@@ -89,42 +89,110 @@ pub(super) enum StatementShape {
     Single { text: String, must_wrap: bool },
 }
 
-/// Whether `text` (comments already stripped) contains an `IN (` token
-/// outside a quoted run — the `PIVOT ... ON col IN (...)` value list that
-/// keeps DuckDB from expanding the pivot into an enum-building statement.
-/// An `IN (...)` anywhere else in the text (a WHERE clause) also counts:
-/// this scan errs toward accepting a pivot whose ON clause it cannot place,
-/// and the row cap and the memory bound still hold for it.
-fn has_in_list(text: &str) -> bool {
+/// Whether a `PIVOT` / `PIVOT_WIDER` statement (`text`, comments already
+/// stripped) names a value list for EVERY pivot column: in its own `ON`
+/// clause — the first `ON` at the statement's own paren depth, after the
+/// source — each comma-separated element carries an `IN (` at that depth,
+/// up to the clause's end (`USING`, `GROUP`, `ORDER`, `LIMIT`, or the end
+/// of the text). Only that list keeps DuckDB from expanding the pivot
+/// into an enum-building statement; an `IN (` anywhere else — inside a
+/// parenthesised source subquery, a WHERE clause — is not one, so it does
+/// not count (the bypass this closes: `PIVOT (SELECT * FROM t WHERE id IN (3))
+/// ON bucket USING count(id)` is still expanded). A pivot whose `ON`
+/// clause this scan cannot find is refused with the rest.
+fn pivot_names_every_value_list(text: &str) -> bool {
+    /// A token at the statement's own paren depth.
+    enum Tok {
+        /// A word (lowercased), and whether the next non-blank character
+        /// after it is `(`.
+        Word(String, bool),
+        Comma,
+    }
     let chars: Vec<char> = text.chars().collect();
     let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
-        if c == '\'' || c == '"' {
-            i += 1;
-            while i < chars.len() && chars[i] != c {
-                i += 1;
-            }
-            i += 1;
-            continue;
-        }
-        let word_start = i == 0 || !(chars[i - 1].is_ascii_alphanumeric() || chars[i - 1] == '_');
-        if word_start
-            && c.eq_ignore_ascii_case(&'i')
-            && matches!(chars.get(i + 1), Some(n) if n.eq_ignore_ascii_case(&'n'))
-            && !matches!(chars.get(i + 2), Some(n) if n.is_ascii_alphanumeric() || *n == '_')
-        {
-            let mut j = i + 2;
-            while j < chars.len() && chars[j].is_whitespace() {
-                j += 1;
-            }
-            if chars.get(j) == Some(&'(') {
-                return true;
-            }
+    // The statement may sit inside outer parens (`( PIVOT ... )`): its own
+    // depth is where its first word is.
+    let mut depth = 0i32;
+    while i < chars.len() && (chars[i].is_whitespace() || chars[i] == '(') {
+        if chars[i] == '(' {
+            depth += 1;
         }
         i += 1;
     }
-    false
+    let base = depth;
+    let mut toks: Vec<Tok> = Vec::new();
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            '\'' | '"' => {
+                i += 1;
+                while i < chars.len() && chars[i] != c {
+                    i += 1;
+                }
+                i += 1;
+            }
+            '(' => {
+                depth += 1;
+                i += 1;
+            }
+            ')' => {
+                depth -= 1;
+                i += 1;
+            }
+            ',' if depth == base => {
+                toks.push(Tok::Comma);
+                i += 1;
+            }
+            _ if c.is_ascii_alphanumeric() || c == '_' => {
+                let start = i;
+                while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                    i += 1;
+                }
+                if depth == base {
+                    let word: String = chars[start..i]
+                        .iter()
+                        .collect::<String>()
+                        .to_ascii_lowercase();
+                    let mut j = i;
+                    while j < chars.len() && chars[j].is_whitespace() {
+                        j += 1;
+                    }
+                    toks.push(Tok::Word(word, chars.get(j) == Some(&'(')));
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    // The pivot's own ON clause: from the first top-level `ON` after the
+    // first word to the first clause keyword after it. A second top-level
+    // `ON` before that keyword means the first one was a join's, in a
+    // source written without parentheses (`PIVOT t JOIN u ON ... ON col`):
+    // its predicate is not a value list, so the pivot is refused rather
+    // than read from the wrong clause; the same source in parentheses
+    // reads fine.
+    let Some(on) = toks
+        .iter()
+        .skip(1)
+        .position(|t| matches!(t, Tok::Word(w, _) if w == "on"))
+        .map(|p| p + 1)
+    else {
+        return false;
+    };
+    let clause = &toks[on + 1..];
+    let end = clause
+        .iter()
+        .position(|t| matches!(t, Tok::Word(w, _) if matches!(w.as_str(), "using" | "group" | "order" | "limit")))
+        .unwrap_or(clause.len());
+    let clause = &clause[..end];
+    !clause.is_empty()
+        && !clause
+            .iter()
+            .any(|t| matches!(t, Tok::Word(w, _) if w == "on"))
+        && clause.split(|t| matches!(t, Tok::Comma)).all(|element| {
+            element
+                .iter()
+                .any(|t| matches!(t, Tok::Word(w, true) if w == "in"))
+        })
 }
 
 /// Classify `sql` for the row cap: strip `--` and `/* */` comments (nested
@@ -229,10 +297,12 @@ pub(super) fn statement_shape(sql: &str) -> StatementShape {
         .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
         .collect::<String>()
         .to_ascii_lowercase();
-    // A pivot that names no `IN (...)` list is parser-expanded by DuckDB
-    // into an enum-building statement ahead of the SELECT, which `prepare`
-    // would execute; refuse it before anything reaches the binding.
-    if matches!(first_word.as_str(), "pivot" | "pivot_wider") && !has_in_list(text) {
+    // A pivot whose ON clause leaves any pivot column without an `IN (...)`
+    // list is parser-expanded by DuckDB into an enum-building statement
+    // ahead of the SELECT, which `prepare` would execute; refuse it before
+    // anything reaches the binding.
+    if matches!(first_word.as_str(), "pivot" | "pivot_wider") && !pivot_names_every_value_list(text)
+    {
         return StatementShape::PivotWithoutIn;
     }
     // Every statement that reads rows runs wrapped; `pivot_wider` is the
@@ -383,7 +453,9 @@ mod tests {
         // DuckDB expands a pivot with no value list into `CREATE TYPE ... AS
         // ENUM (SELECT DISTINCT ...)` + the SELECT, and the binding's
         // `prepare` executes the first of the two — so the shape is refused
-        // before it can reach `prepare`.
+        // before it can reach `prepare`. Only a list in the pivot's own ON
+        // clause counts: one in the source subquery, a WHERE clause, a
+        // comment or a literal leaves the pivot column unlisted.
         for sql in [
             "PIVOT t ON bucket",
             "PIVOT t ON bucket USING count(id)",
@@ -391,6 +463,22 @@ mod tests {
             "PIVOT t ON bucket USING count(id) -- IN (0, 1) in a comment",
             "PIVOT t ON bucket USING count(id) WHERE s = 'IN (x)'",
             "( PIVOT t ON bucket USING count(id) )",
+            // The bypass this closes: the only `IN (` sits in the source subquery.
+            "PIVOT (SELECT * FROM t WHERE id IN (3, 4, 5)) ON bucket USING count(id)",
+            "PIVOT (SELECT * FROM t WHERE id IN (3)) ON bucket USING count(id) GROUP BY id",
+            // Not runnable DuckDB (a WHERE after USING) — and the ON clause
+            // names no list either way.
+            "PIVOT t ON bucket USING count(id) WHERE id IN (1, 2)",
+            // Two pivot columns, one of them unlisted.
+            "PIVOT t ON bucket IN (0, 1), id USING count(*)",
+            "PIVOT t ON bucket, id IN (1) USING count(*)",
+            // No ON clause at all.
+            "PIVOT t USING count(id)",
+            // A join source written without parentheses: the first ON is
+            // the join's, so its predicate must not vouch for the pivot
+            // column (write the source as a parenthesised subquery).
+            "PIVOT t JOIN u ON u.k IN (1) ON bucket USING count(*)",
+            "PIVOT t JOIN u ON t.k = u.k ON bucket IN (0) USING count(*)",
         ] {
             assert_eq!(
                 statement_shape(sql),
@@ -398,14 +486,21 @@ mod tests {
                 "{sql:?}"
             );
         }
-        // With the values named the statement is one statement; it runs
-        // wrapped like every other row reader. `IN(` without a space and an
-        // `IN (...)` elsewhere in the text both count.
+        // With every pivot column's values named the statement is one
+        // statement; it runs wrapped like every other row reader. `IN(`
+        // without a space, an expression pivot column, a quoted column, a
+        // parenthesised source and outer parens all read the same.
         for sql in [
             "PIVOT t ON bucket IN (0, 1) USING count(id)",
             "PIVOT t ON bucket IN(0, 1) USING count(id)",
             "pivot_wider t on bucket in (0) using sum(id)",
-            "PIVOT t ON bucket USING count(id) WHERE id IN (1, 2)",
+            "PIVOT t ON bucket IN (0, 1) USING count(id) GROUP BY id",
+            "PIVOT t ON bucket IN (0), id IN (1, 2) USING count(*)",
+            "PIVOT t ON lower(comm) IN ('a', 'b') USING count(*) GROUP BY id",
+            "PIVOT t ON \"bucket\" IN (0) USING count(id)",
+            "PIVOT (SELECT * FROM t WHERE id IN (3, 4)) ON bucket IN (0, 1) USING count(id)",
+            "PIVOT (SELECT * FROM t JOIN u ON t.k = u.k) ON bucket IN (0) USING count(*)",
+            "( PIVOT t ON bucket IN (0) USING count(id) )",
         ] {
             assert!(single(sql).1, "{sql:?} must run wrapped");
         }

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -133,6 +133,42 @@ pub fn cgroup_id(path: &Path) -> io::Result<u64> {
     Ok(meta.ino())
 }
 
+/// Which filesystem a `--cgroup` path sits on, as far as the filter cares.
+///
+/// [`cgroup_id`] is the inode of whatever directory the path names, so it
+/// resolves just as happily on a plain directory as on a cgroup; the
+/// filesystem's magic is what tells a real cgroup2 target from a mistyped
+/// path or a cgroup v1 mount, and the kernel refuses both of those the same
+/// way it refuses a cgroup outside the tracer's cgroup namespace.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CgroupFs {
+    /// The unified cgroup v2 hierarchy (`CGROUP2_SUPER_MAGIC`).
+    V2,
+    /// A legacy cgroup v1 hierarchy (`CGROUP_SUPER_MAGIC`).
+    V1,
+    /// Not a cgroup filesystem at all; carries the `statfs` magic.
+    Other(libc::c_long),
+}
+
+/// The filesystem kind of the directory at `path`, from `statfs(2)`.
+pub fn cgroup_fs(path: &Path) -> io::Result<CgroupFs> {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    // SAFETY: `c_path` is a NUL-terminated path that outlives the call and
+    // `st` is a zeroed `struct statfs` the kernel fills in whole.
+    let mut st: libc::statfs = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::statfs(c_path.as_ptr(), &mut st) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(match st.f_type {
+        libc::CGROUP2_SUPER_MAGIC => CgroupFs::V2,
+        libc::CGROUP_SUPER_MAGIC => CgroupFs::V1,
+        other => CgroupFs::Other(other),
+    })
+}
+
 /// Collect the cgroup id (directory inode) of `path` and of every cgroup nested
 /// beneath it in the cgroup2 hierarchy.
 ///

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -4198,20 +4198,47 @@ const CGROUP_FROM_ID_NAMESPACE_FIX_KERNELS: &str = "6.6.117 / 6.12.58 / 6.18";
 
 /// The error for a `--cgroup` target whose `cgroup_target_refs` slot came back
 /// empty after the iterator run: the cause is named from what the path says
-/// NOW (`now` is a fresh `cgroup_id()` of the same path), because the empty
-/// slot has three different explanations and only one of them is about
-/// where systing runs.
+/// NOW (`now` is a fresh `cgroup_id()` of the same path, `fs` a `statfs` of
+/// it), because the empty slot has four different explanations and only one
+/// of them is about where systing runs.
 ///
 /// The kernel takes its reference with `bpf_cgroup_from_id(id)`; it returns
 /// nothing when that id no longer names a cgroup (removed, or removed and
 /// re-created with a new inode since systing resolved it a moment earlier),
-/// when the path is on a cgroup v1 hierarchy (ids are looked up in the
-/// unified v2 hierarchy only), or — on kernels before
-/// [`CGROUP_FROM_ID_NAMESPACE_FIX_KERNELS`] — when the cgroup sits outside the
-/// calling process's cgroup namespace: a container with a private cgroup
-/// namespace and the host's cgroup filesystem mounted sees the host path but
-/// cannot resolve it. Pure, so the wording is unit-tested.
-fn empty_cgroup_target_slot_cause(path: &str, expected_id: u64, now: io::Result<u64>) -> String {
+/// when the path is not on the unified cgroup v2 hierarchy at all — a cgroup
+/// v1 mount, or a plain directory whose inode `cgroup_id()` resolved just as
+/// readily (ids are looked up in the v2 hierarchy only) — or, on kernels
+/// before [`CGROUP_FROM_ID_NAMESPACE_FIX_KERNELS`], when the cgroup sits
+/// outside the calling process's cgroup namespace: a container with a private
+/// cgroup namespace and the host's cgroup filesystem mounted sees the host
+/// path but cannot resolve it. When the filesystem could not be read the last
+/// two causes are named together. Pure, so the wording is unit-tested.
+fn empty_cgroup_target_slot_cause(
+    path: &str,
+    expected_id: u64,
+    now: io::Result<u64>,
+    fs: io::Result<crate::cgroup::CgroupFs>,
+) -> String {
+    use crate::cgroup::CgroupFs;
+    let namespace_cause = |also_v1: bool| {
+        let v1 = if also_v1 {
+            "Either the path is on a cgroup v1 hierarchy (only the unified cgroup v2 \
+             hierarchy is supported), or — "
+        } else {
+            "The path is on the cgroup v2 hierarchy, so — "
+        };
+        format!(
+            "--cgroup {path}: the kernel could not resolve this cgroup (id {expected_id}), \
+             so the iterator program left its slot empty. {v1}on a kernel before \
+             {CGROUP_FROM_ID_NAMESPACE_FIX_KERNELS}, where the kernel resolves the id \
+             within the tracer's cgroup namespace — systing runs in a container with a \
+             private cgroup namespace and the host's cgroup filesystem mounted: the path \
+             is visible but the cgroup is outside the namespace the kernel resolves it \
+             in. Run systing in the host cgroup namespace, or set \
+             {CGROUP_FILTER_LEGACY_ENV} to match a snapshot of the target's cgroups \
+             taken at start instead"
+        )
+    };
     match now {
         Err(e) if e.kind() == io::ErrorKind::NotFound => format!(
             "--cgroup {path}: this cgroup (id {expected_id}) was removed while systing \
@@ -4222,18 +4249,22 @@ fn empty_cgroup_target_slot_cause(path: &str, expected_id: u64, now: io::Result<
              had id {expected_id}, the directory at that path now has id {current}), so \
              the kernel could not take a reference to the one that was resolved"
         ),
-        _ => format!(
-            "--cgroup {path}: the kernel could not resolve this cgroup (id {expected_id}), \
-             so the iterator program left its slot empty. Either the path is on a cgroup \
-             v1 hierarchy (only the unified cgroup v2 hierarchy is supported), or — on a \
-             kernel before {CGROUP_FROM_ID_NAMESPACE_FIX_KERNELS}, where the kernel \
-             resolves the id within the tracer's cgroup namespace — systing runs in a \
-             container with a private cgroup namespace and the host's cgroup filesystem \
-             mounted: the path is visible but the cgroup is outside the namespace the \
-             kernel resolves it in. Run systing in the host cgroup namespace, or set \
-             {CGROUP_FILTER_LEGACY_ENV} to match a snapshot of the target's cgroups \
-             taken at start instead"
-        ),
+        _ => match fs {
+            Ok(CgroupFs::V1) => format!(
+                "--cgroup {path}: this path is on a cgroup v1 hierarchy, and only the \
+                 unified cgroup v2 hierarchy is supported (the kernel looks the id up \
+                 there, so it could not resolve id {expected_id}). Give a cgroup under \
+                 the cgroup2 mount instead, usually /sys/fs/cgroup"
+            ),
+            Ok(CgroupFs::Other(magic)) => format!(
+                "--cgroup {path}: this path is not on a cgroup filesystem at all (its \
+                 filesystem magic is {magic:#x}), so the directory's inode {expected_id} \
+                 is not a cgroup id the kernel can resolve. Give a cgroup directory under \
+                 the cgroup2 mount instead, usually /sys/fs/cgroup"
+            ),
+            Ok(CgroupFs::V2) => namespace_cause(false),
+            Err(_) => namespace_cause(true),
+        },
     }
 }
 
@@ -4264,12 +4295,15 @@ fn install_cgroup_targets(skel: &mut SystingSystemSkel, targets: &[CgroupTarget]
         if id == 0 {
             // Ask the filesystem again before naming a cause: the slot is
             // empty either because the cgroup is gone (or has been replaced)
-            // since it was resolved, or because the kernel could not look
+            // since it was resolved, because the path was never a cgroup2
+            // directory to begin with, or because the kernel could not look
             // its id up from where systing runs.
-            let now = crate::cgroup::cgroup_id(std::path::Path::new(&target.path));
+            let path = std::path::Path::new(&target.path);
+            let now = crate::cgroup::cgroup_id(path);
+            let fs = crate::cgroup::cgroup_fs(path);
             bail!(
                 "{}",
-                empty_cgroup_target_slot_cause(&target.path, target.id, now)
+                empty_cgroup_target_slot_cause(&target.path, target.id, now, fs)
             );
         }
         if id != target.id {
@@ -6861,11 +6895,14 @@ mod tests {
     #[test]
     fn test_empty_cgroup_target_slot_cause_names_what_the_path_says_now() {
         let path = "/sys/fs/cgroup/kubepods.slice/pod-x";
+        let v2 = || Ok(crate::cgroup::CgroupFs::V2);
+        let unread = || Err(io::Error::from(io::ErrorKind::PermissionDenied));
         // The cgroup vanished between resolving it and the iterator run.
         let gone = empty_cgroup_target_slot_cause(
             path,
             4242,
             Err(io::Error::from(io::ErrorKind::NotFound)),
+            unread(),
         );
         assert!(
             gone.contains("was removed while systing was starting"),
@@ -6875,7 +6912,7 @@ mod tests {
         assert!(!gone.contains("cgroup namespace"), "{gone}");
 
         // Removed and re-created: the path is back with a different inode.
-        let replaced = empty_cgroup_target_slot_cause(path, 4242, Ok(9001));
+        let replaced = empty_cgroup_target_slot_cause(path, 4242, Ok(9001), v2());
         assert!(
             replaced.contains("was replaced while systing was starting"),
             "{replaced}"
@@ -6886,26 +6923,86 @@ mod tests {
         );
         assert!(!replaced.contains("cgroup namespace"), "{replaced}");
 
-        // Still there with the same id: the kernel refused the lookup, which
-        // on a pre-backport kernel is the namespace, on any kernel a v1
-        // hierarchy. The message names the kernel bar and both cures.
-        let refused = empty_cgroup_target_slot_cause(path, 4242, Ok(4242));
+        // Still there with the same id on the cgroup2 hierarchy: the kernel
+        // refused the lookup, which leaves only the pre-backport namespace
+        // cause. The message names the kernel bar and both cures, and no
+        // longer hedges about a v1 hierarchy the filesystem ruled out.
+        let refused = empty_cgroup_target_slot_cause(path, 4242, Ok(4242), v2());
         assert!(refused.contains("cgroup namespace"), "{refused}");
         assert!(
             refused.contains(CGROUP_FROM_ID_NAMESPACE_FIX_KERNELS),
             "{refused}"
         );
-        assert!(refused.contains("cgroup v1 hierarchy"), "{refused}");
+        assert!(refused.contains("on the cgroup v2 hierarchy"), "{refused}");
+        assert!(!refused.contains("cgroup v1 hierarchy"), "{refused}");
         assert!(refused.contains("host cgroup namespace"), "{refused}");
         assert!(refused.contains(CGROUP_FILTER_LEGACY_ENV), "{refused}");
+
+        // The same, but the filesystem could not be read: both remaining
+        // causes are named, as before the filesystem was consulted.
+        let either = empty_cgroup_target_slot_cause(path, 4242, Ok(4242), unread());
+        assert!(either.contains("cgroup v1 hierarchy"), "{either}");
+        assert!(either.contains("cgroup namespace"), "{either}");
+        assert!(either.contains(CGROUP_FILTER_LEGACY_ENV), "{either}");
         // Any other stat failure (EACCES, EIO…) says nothing it cannot know
         // and falls to the same cause as an unchanged id.
         let unknown = empty_cgroup_target_slot_cause(
             path,
             4242,
             Err(io::Error::from(io::ErrorKind::PermissionDenied)),
+            unread(),
         );
-        assert_eq!(unknown, refused);
+        assert_eq!(unknown, either);
+
+        // A cgroup v1 mount: the filesystem says so, and the namespace is
+        // not offered as a cause.
+        let v1 =
+            empty_cgroup_target_slot_cause(path, 4242, Ok(4242), Ok(crate::cgroup::CgroupFs::V1));
+        assert!(v1.contains("is on a cgroup v1 hierarchy"), "{v1}");
+        assert!(v1.contains("cgroup2 mount"), "{v1}");
+        assert!(!v1.contains("cgroup namespace"), "{v1}");
+
+        // A plain directory (a mistyped path): `cgroup_id()` resolved its
+        // inode like any other, but it is on no cgroup filesystem — the
+        // fourth cause, named with the filesystem magic it did find.
+        let plain = empty_cgroup_target_slot_cause(
+            "/tmp/pod-x",
+            4242,
+            Ok(4242),
+            Ok(crate::cgroup::CgroupFs::Other(0x0187_3e19)),
+        );
+        assert!(
+            plain.contains("not on a cgroup filesystem at all"),
+            "{plain}"
+        );
+        assert!(plain.contains("0x1873e19"), "{plain}");
+        assert!(
+            plain.contains("/tmp/pod-x") && plain.contains("4242"),
+            "{plain}"
+        );
+        assert!(!plain.contains("cgroup namespace"), "{plain}");
+    }
+
+    #[test]
+    fn test_cgroup_fs_reads_the_filesystem_magic() {
+        use crate::cgroup::{cgroup_fs, CgroupFs};
+        // A directory that is certainly not a cgroup: the magic is whatever
+        // the temp filesystem's is, never a cgroup one.
+        let dir = tempfile::tempdir().expect("tempdir");
+        match cgroup_fs(dir.path()).expect("statfs of a temp dir") {
+            CgroupFs::Other(_) => {}
+            other => panic!("a temp dir read as a cgroup filesystem: {other:?}"),
+        }
+        // A missing path is an error, never a guessed kind.
+        let missing = dir.path().join("missing");
+        assert!(cgroup_fs(&missing).is_err());
+        // The cgroup2 root, where the host mounts one.
+        if let Some(root) = crate::cgroup::cgroup2_root() {
+            assert_eq!(
+                cgroup_fs(&root).expect("statfs of the cgroup2 root"),
+                CgroupFs::V2
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Two follow-ups to #239, batched (the analyze `query` guard and the `--cgroup` empty-slot cause), each its own commit.

**1. analyze: refuse a PIVOT unless its own ON clause lists every pivot column, and test the no-re-prepare arm.** The `query` tool's PIVOT check (`has_in_list`) scanned the whole statement text for `IN (`, so a PIVOT whose only `IN (` sat in its SOURCE subquery — `PIVOT (SELECT * FROM t WHERE id IN (3, 4, 5)) ON bucket USING count(id)` — was classified as a listed pivot and wrapped: DuckDB still expands it into `CREATE TYPE __pivot_enum_… AS ENUM (SELECT DISTINCT …)` + the SELECT, `prepare()` executes the enum scan outside the row cap, and the type stays in the read-only database's temp catalog (a `__pivot_enum` count of 0 → 1 through the shipped `AnalyzeDb::query`). The check is now `pivot_names_every_value_list`: the statement is tokenised at its own paren depth, the pivot's ON clause is the first top-level `ON` after the first word up to the first top-level `USING` / `GROUP` / `ORDER` / `LIMIT` or the end, and every comma-separated element of it must carry a top-level `IN (`; a source subquery's `IN (`, a WHERE, a comment, a literal, a second unlisted pivot column or no ON clause at all is refused as `PivotWithoutIn`, and so is a join source written without parentheses (its own `ON` ahead of the pivot's — the join predicate must not vouch for the pivot column; the same source in parentheses reads fine). The prepare-time memory-bound path is factored as `query_after_wrapped_prepare_failed(err, inner, must_wrap)` and the test drives it directly with a memory-bound-shaped `duckdb::Error`: the bound's fixed text and no rows (deleting the arm returns rows, so the test fails), while a Binder-shaped error runs the raw form or bails "could not be bounded" under `must_wrap`. The `… USING count(id) WHERE id IN (1, 2)` case moved to the refused list with its comment corrected (it was never runnable DuckDB syntax).

**2. --cgroup: name a target off the cgroup2 hierarchy as its own cause; cite DuckDB's one OOM class.** The empty-slot cause naming from #239 asks the filesystem what the target path says now, and `cgroup_id()` is the inode of whatever directory the path names: a mistyped `--cgroup /tmp/pod-x`, or a cgroup on a v1 mount, resolved to an id like any cgroup and was then reported as "a v1 hierarchy or the cgroup namespace". A `statfs` of the path (`cgroup::cgroup_fs`) now tells the causes apart: removed and replaced as before, a cgroup v1 hierarchy, a directory on no cgroup filesystem at all (named with the magic it did find), and — only when the path is on the cgroup2 hierarchy — the pre-backport namespace cause, worded without the v1 hedge; when the filesystem cannot be read the last two are named together, as before. The README sentence follows. The analyze classifier's doc cites the DuckDB 1.5.4 sources for both bounds raising `OutOfMemoryException` (the block-offload throw in `temporary_file_manager.cpp` for the spill bound, the buffer pool for `memory_limit`), which is why the one "Out of Memory Error" prefix covers `memory_limit` and `max_temp_directory_size` alike.

**Tests** (`cargo test --no-default-features` on the exact tree; fmt and clippy `--all-targets -D warnings` clean): `analyze::query::tests::test_statement_shape_refuses_pivot_without_an_in_list` (the probe shape, the two-column and the join-source cases refused; ten accepted shapes, a parenthesised source with `ON bucket IN (0, 1)` and a parenthesised join source among them), `analyze::tests::test_query_comments_and_terminators_cannot_bypass_the_cap` (engine-driven: the probe shape refused with `__pivot_enum` count 0 after it; the listed form on the same source runs wrapped, 3 rows), `analyze::tests::test_query_reports_a_prepare_time_memory_failure_as_the_bound`, `test_empty_cgroup_target_slot_cause_names_what_the_path_says_now` (every arm: removed, replaced, cgroup2 + namespace, unreadable fs + both causes, v1, a plain directory), `test_cgroup_fs_reads_the_filesystem_magic` (a temp dir reads as no cgroup fs, a missing path errors, the cgroup2 root reads V2 where mounted). No BPF, no capture-path or recorder change; the BPF object is untouched.
