### PR TITLE
duckdb import: project away the columns a newer trace carries instead of failing the import; VFIO/THP doc items

### DIFF
--- a/SCHEMA_CHANGES.md
+++ b/SCHEMA_CHANGES.md
@@ -443,6 +443,30 @@ old behaviour — a capture without its CPU stack sampler is not a capture.
 `systing-analyze trace info` (and the MCP `trace_info` tool) report the four
 new fields under `system`.
 
+## Parquet import across schema versions (no schema version change)
+
+The parquet→DuckDB import (`parquet_to_duckdb`, `systing-util convert`) is
+`INSERT INTO <table> BY NAME SELECT … FROM read_parquet(…)`, and DuckDB's
+`BY NAME` has two faces. A target column the parquet lacks — an OLDER trace
+read by a NEWER systing — is filled with NULL, which is how every "NULL in
+traces from systing < 1.N" note in this file works. A parquet column the
+target lacks — a NEWER trace read by an OLDER systing — used to fail the
+whole import with a binder error on the first unknown column, so a trace
+written after a schema bump was unreadable by any systing before it. The
+import now reads the parquet's column list first and projects the unknown
+columns away, one warning line per table naming them and this systing's
+schema version, and the database is a complete database of the READER's
+schema (`_schema_version` says which; the newer columns are simply not in
+it). A caller that wants the old refusal — a test, or a pipeline that must
+not analyse a trace with columns it cannot see — passes
+`ImportOptions { strict_schema: true }` (`systing-util convert
+--strict-schema`), which fails with a message naming the table, the unknown
+columns and the reader's schema version. Neither the parquet directory nor
+`_traces` records the WRITER's schema version (`_traces.systing_version` is
+the converting binary's, see the v12 entry), so the report of what was
+dropped reaches only the importing process — the recorder's version in the
+parquet directory remains the planned follow-up.
+
 ## Schema Version 21 (systing 1.18.0) — 2026-09-04
 
 The network-packets recorder learns to sample, and says so. On a big host
@@ -497,9 +521,9 @@ on the arch syscall wrappers (`__x64_sys_mmap` …, `__arm64_sys_*`,
 the network recorder's TIME_WAIT hooks (`tcp_time_wait`,
 `inet_twsk_hashdance_schedule`, `inet_twsk_deschedule_put`: fentry in
 place of kprobes), as the DEFAULT, on the claim that trampolines detach in
-milliseconds. That claim was wrong, and the next release (unreleased at
-the time of writing; 1.17.0–1.17.2 shipped the trampoline default) makes
-the classic form the default again with the trampoline form opt-in
+milliseconds. That claim was wrong, and 1.17.4 (1.17.0–1.17.3 shipped the
+trampoline default) makes the classic form the default again with the
+trampoline form opt-in
 (`--kernel-hooks trampoline`; `sysinfo.memory_syscall_leg` /
 `network_tw_leg` say which ran). What the kernel does, read at v6.6, v6.12
 and v6.18: a perf-attached
@@ -531,8 +555,8 @@ The tables keep their columns; the new columns are nullable.
 ### Added columns
 - `sysinfo`: added `memory_syscall_leg VARCHAR` — how the mmap/munmap/brk
   hooks attached for the capture: `tracepoint` (the classic tracepoints as
-  the default form, from the correction release), `fentry` (the trampoline
-  set — the default in 1.17.0–1.17.2, opt-in after), `tracepoint:nosym` (the
+  the default form, from 1.17.4), `fentry` (the trampoline
+  set — the default in 1.17.0–1.17.3, opt-in from 1.17.4), `tracepoint:nosym` (the
   classic tracepoints under the trampoline form, because the arch syscall
   wrappers are not in kallsyms — riscv before 6.6), `tracepoint:nobtf` (the
   classic tracepoints under the trampoline form, because vmlinux BTF has no
@@ -594,7 +618,7 @@ The tables keep their columns; the new columns are nullable.
   `freeze = true`. Rows from 1.16.x may carry a spurious `true` on such
   splits; from 1.17.0 the value is the flag the kernel passed.
 - `memory_thp` rows with `kind = 'pmd'` on a build that inlined the worker
-  (from the next release, unreleased): the probe now falls back first to
+  (from 1.17.5): the probe now falls back first to
   the global funnel `split_huge_pmd_locked` (6.10+; `sysinfo.memory_thp_leg
   = on:pmd-global` / `on:pmd-only:global`) and only then to the public entry
   `__split_huge_pmd` (`on:pmd-entry`, as in v19). On 6.12 and 6.18 both
@@ -775,8 +799,11 @@ is written whenever the memory recorder runs.
   ioctl at once) — systing prints `memory-vfio: N iommu map/unmap runs or
   VFIO ioctl windows not counted` — so the table is a floor in that case.
   Two more reading rules: a container attached to several IOMMU domains
-  fires the tracepoints once per domain, so its runs are counted once per
-  domain (compare `count` against `memory_vfio` sizes per domain count);
+  maps every pinned run once per domain (`vfio_iommu_map` loops over the
+  container's domain list), so its `map` runs are counted once per domain
+  (compare `count` against `memory_vfio` sizes per domain count), while on
+  unmap only the first domain is unmapped run by run and each further
+  domain gets one `unmap` event of the whole region's size;
   and `size_order` is floor(log2) of the run, so a run that is not a
   power of two (a partially huge-page-backed tail) lands in the order
   below its size — `bytes` is exact, `count` per order is the rounding.

--- a/src/bin/systing_util.rs
+++ b/src/bin/systing_util.rs
@@ -34,7 +34,8 @@ use std::sync::LazyLock;
 use std::thread;
 use std::time::Instant;
 use systing::duckdb::{
-    create_schema, get_trace_info, import_duckdb_traces, TraceImportMapping, SCHEMA_VERSION,
+    create_schema, get_trace_info, import_column_list, import_duckdb_traces, ImportOptions,
+    ImportReport, TraceImportMapping, SCHEMA_VERSION,
 };
 use systing::ParquetPaths;
 
@@ -82,6 +83,12 @@ enum Commands {
         /// Verbose output (show timing breakdown)
         #[arg(short, long)]
         verbose: bool,
+
+        /// Refuse a Parquet input carrying a column this systing's schema does
+        /// not have (a trace written by a newer systing) instead of importing
+        /// the known columns and warning about the rest
+        #[arg(long)]
+        strict_schema: bool,
     },
 
     /// Validate trace data for correctness
@@ -3100,6 +3107,7 @@ fn run_convert(
     trace_id: Option<String>,
     recursive: bool,
     verbose: bool,
+    import_options: ImportOptions,
 ) -> Result<()> {
     let start_time = Instant::now();
 
@@ -3450,7 +3458,10 @@ fn run_convert(
 
     // Import Parquet files for a table, filtering to only existing files.
     // Handles trace_id injection for Parquet directories (which don't have trace_id column).
-    let import_table = |table_name: &str, get_path: fn(&ParquetPaths) -> &PathBuf| -> Result<()> {
+    let mut import_report = ImportReport::default();
+    let mut import_table = |table_name: &str,
+                            get_path: fn(&ParquetPaths) -> &PathBuf|
+     -> Result<()> {
         let start = Instant::now();
 
         // Separate paths by whether they need trace_id injection
@@ -3475,8 +3486,13 @@ fn run_convert(
 
         // Import files that already have trace_id. BY NAME so parquet files
         // written by older systing versions (with fewer columns) import
-        // cleanly - missing columns become NULL. Prefix the sort with trace_id
-        // so rows from different traces stay contiguous (better BitPacking).
+        // cleanly - missing columns become NULL; a column this systing does
+        // not know (a newer writer) is projected away by import_column_list,
+        // or refused under --strict-schema. The list binds to the first
+        // file's schema, as read_parquet always did: a list mixing two
+        // schema generations fails inside the scan, not here. Prefix the
+        // sort with trace_id so rows from different traces stay contiguous
+        // (better BitPacking).
         if !with_trace_id.is_empty() {
             let multi_order = systing::duckdb::import_order_by(table_name)
                 .map(|o| format!(" ORDER BY trace_id, {o}"))
@@ -3486,17 +3502,37 @@ fn run_convert(
                 .map(|p| format!("'{}'", p.replace('\'', "''")))
                 .collect::<Vec<_>>()
                 .join(", ");
-            conn.execute_batch(&format!(
-                "INSERT INTO {table_name} BY NAME SELECT * FROM read_parquet([{paths_list}]){multi_order}"
-            ))?;
+            let source_sql = format!("read_parquet([{paths_list}])");
+            if let Some(columns) = import_column_list(
+                &conn,
+                table_name,
+                &source_sql,
+                import_options,
+                &mut import_report,
+            )? {
+                conn.execute_batch(&format!(
+                    "INSERT INTO {table_name} BY NAME SELECT {columns} FROM {source_sql}{multi_order}"
+                ))?;
+            }
         }
 
         // Import files that need trace_id injection (one at a time to add trace_id)
         for (trace_id, path) in needs_injection {
             let escaped_path = path.replace('\'', "''");
             let escaped_trace_id = trace_id.replace('\'', "''");
+            let source_sql = format!("read_parquet('{escaped_path}')");
+            let Some(columns) = import_column_list(
+                &conn,
+                table_name,
+                &source_sql,
+                import_options,
+                &mut import_report,
+            )?
+            else {
+                continue;
+            };
             conn.execute_batch(&format!(
-                "INSERT INTO {table_name} BY NAME SELECT '{escaped_trace_id}' as trace_id, * FROM read_parquet('{escaped_path}'){order}"
+                "INSERT INTO {table_name} BY NAME SELECT '{escaped_trace_id}' as trace_id, {columns} FROM {source_sql}{order}"
             ))?;
         }
 
@@ -3806,7 +3842,15 @@ fn main() -> Result<()> {
             trace_id,
             recursive,
             verbose,
-        } => run_convert(inputs, output, trace_id, recursive, verbose),
+            strict_schema,
+        } => run_convert(
+            inputs,
+            output,
+            trace_id,
+            recursive,
+            verbose,
+            ImportOptions { strict_schema },
+        ),
         Commands::Validate {
             path,
             verbose,

--- a/src/bpf/systing_system.bpf.c
+++ b/src/bpf/systing_system.bpf.c
@@ -1082,9 +1082,15 @@ struct {
  *    that region (memory_vfio_inflight): the tracepoints are host-wide
  *    DMA-API paths, and every other iommu_map() costs one hash miss.
  *
- * Writers are classic tracepoint programs (task context; bpf_prog_active
- * is raised around them), never the perf_event sampler, so a plain
- * preallocated HASH is safe here.
+ * Writers are the iommu tracepoint programs, which run in whatever context
+ * calls the DMA API — the vfio ioctl path this histogram counts is task
+ * context, but a driver mapping under a softirq fires the same tracepoint
+ * (and is dropped at the memory_vfio_inflight miss). A plain preallocated
+ * HASH is safe from any of them: the bucket lock is a raw spinlock taken
+ * with interrupts disabled (htab_lock_bucket), so writers on one CPU cannot
+ * interleave, and the one context that could still re-enter a held bucket,
+ * an NMI, is the perf_event sampler's, which never writes this map (a
+ * re-entering update is refused with -EBUSY rather than deadlocking).
  */
 struct memory_iommu_key {
 	u32 tgid;
@@ -6354,7 +6360,14 @@ struct vfio_iommu_type1_dma_unmap_uapi {
  * kretprobe closes it. A window that cannot be opened (the inflight hash is
  * full: more than 1024 traced tasks inside a VFIO path at once) leaves
  * this path's runs uncounted — counted under memory_iommu_overflow so the
- * histogram reads as a floor rather than silently short. */
+ * histogram reads as a floor rather than silently short. The other way a
+ * window goes wrong is not counted: a kretprobe that misses its return
+ * (the kernel's per-probe pool of pending returns exhausted — an ioctl
+ * holds an instance for seconds, and the pool is sized per probe by the
+ * kernel) leaves the window open, so this task's later runs inside that
+ * range count until its next VFIO path re-opens the window or the capture
+ * ends; a perf-attached kretprobe's miss count is not exported, so the
+ * case is a documented bound rather than a counter. */
 static __always_inline void memory_vfio_open_window(u64 iova, u64 size)
 {
 	u64 tgidpid = bpf_get_current_pid_tgid();
@@ -6488,6 +6501,17 @@ int BPF_KRETPROBE(systing_vfio_detach_group_ret)
  * of the iommu events (the common 8-byte header, then the u64 fields in
  * TP_STRUCT__entry order — unchanged since the tracepoints were added). See
  * the memory_iommu_hist comment for why these count instead of emitting.
+ *
+ * What one event is, read at vfio_iommu_type1.c (v6.12): a map is pinned
+ * one physically contiguous run at a time and vfio_iommu_map() issues one
+ * iommu_map() per run PER DOMAIN in the container's domain_list, so a
+ * container whose devices sit in two IOMMU domains counts every map run
+ * twice; on unmap (vfio_unmap_unpin) only the first domain is unmapped run
+ * by run — each further domain gets ONE iommu_unmap() of the whole region,
+ * one event of the region's size. The order key is floor(log2(size)): a run
+ * that is not a power of two (three contiguous pages, 12 KiB) counts under
+ * the order below it (13, 8 KiB) with its exact size added to bytes, so
+ * bytes is exact per bucket and count-by-order is a floor histogram.
  */
 struct systing_iommu_map_args {
 	u64 common;
@@ -6590,8 +6614,13 @@ int systing_iommu_unmap(struct systing_iommu_unmap_args *ctx)
  * the folio split whose entry is split_huge_page_to_list (<= 6.8) or
  * split_huge_page_to_list_to_order (>= 6.9; at 6.18 the counter sits in its
  * static callee __folio_split); the entry's return value is the result: 0
- * split, -EBUSY/-EAGAIN failed. Userspace loads the programs whose symbols
- * the running kernel has and records the leg in sysinfo.memory_thp_leg.
+ * split, -EBUSY/-EAGAIN failed. On 6.9+ every large-folio split goes through
+ * that entry, file and shmem folios included, so its rows are a superset of
+ * the vmstat thp_split_page family; on 6.15+ the folio_split() path splits
+ * without passing it, so the vmstat delta stays the host-wide truth and the
+ * rows are the sampled, attributed subset. Userspace loads the programs
+ * whose symbols the running kernel has and records the leg in
+ * sysinfo.memory_thp_leg.
  * Splits run in task context (madvise, munmap, reclaim, migration), so the
  * memory ring is written as usual; the leg is 1:N sampled
  * (memory_thp_sample_rate, 0 = off) because reclaim storms can split

--- a/src/duckdb.rs
+++ b/src/duckdb.rs
@@ -832,6 +832,19 @@ pub fn create_schema(conn: &Connection) -> Result<()> {
 /// ).unwrap();
 /// ```
 pub fn parquet_to_duckdb(parquet_dir: &Path, db_path: &Path, trace_id: &str) -> Result<()> {
+    parquet_to_duckdb_with_options(parquet_dir, db_path, trace_id, ImportOptions::default())
+        .map(|_| ())
+}
+
+/// [`parquet_to_duckdb`] with the import options spelled out, returning what
+/// the import did about columns this systing's schema does not have (see
+/// [`ImportReport`]).
+pub fn parquet_to_duckdb_with_options(
+    parquet_dir: &Path,
+    db_path: &Path,
+    trace_id: &str,
+    options: ImportOptions,
+) -> Result<ImportReport> {
     // Remove existing database if present
     if db_path.exists() {
         std::fs::remove_file(db_path).with_context(|| {
@@ -866,9 +879,10 @@ pub fn parquet_to_duckdb(parquet_dir: &Path, db_path: &Path, trace_id: &str) -> 
 
     // Import each table from Parquet files
     let paths = ParquetPaths::new(parquet_dir);
-    import_tables(&conn, &paths, trace_id)?;
+    let mut report = ImportReport::default();
+    import_tables(&conn, &paths, trace_id, options, &mut report)?;
 
-    Ok(())
+    Ok(report)
 }
 
 /// Import a `stack.parquet` (which stores `frame_names VARCHAR[]`) into the
@@ -945,8 +959,118 @@ pub fn import_order_by(table_name: &str) -> Option<&'static str> {
     }
 }
 
+/// How a parquet→DuckDB import treats a source column this systing's schema
+/// does not have — a trace written by a newer systing than the one reading it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ImportOptions {
+    /// Refuse the import with a message naming the table, the unknown columns
+    /// and this systing's schema version, instead of importing the columns
+    /// this schema knows and leaving the rest out with a warning (the
+    /// default: a partial read of a newer trace serves every consumer better
+    /// than no read).
+    pub strict_schema: bool,
+}
+
+/// What a parquet→DuckDB import left out: per table, the source columns this
+/// systing's schema does not have. Empty when every table imported whole.
+/// The database's `_schema_version` names the schema the import produced,
+/// so a consumer reading the database sees a complete database of that
+/// schema; only the importing process learns, through this report and one
+/// warning line per table, that the trace carried more.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ImportReport {
+    pub dropped_columns: Vec<(String, Vec<String>)>,
+}
+
+/// The select list a table's import reads from its parquet source: `*` when
+/// every source column exists in the target table, else the known columns,
+/// quoted — or `None` when the source shares no column with the target (the
+/// table is skipped). `source_sql` is the `FROM` operand, a
+/// `read_parquet(...)` call.
+///
+/// DuckDB's `INSERT ... BY NAME` fills a target column the source lacks with
+/// NULL (an older trace read by a newer systing) but refuses the whole
+/// statement on a source column the target lacks (a newer trace read by an
+/// older systing) — a Binder error on the first unknown column. The columns
+/// are compared case-insensitively, as DuckDB binds them. Under
+/// [`ImportOptions::strict_schema`] the unknown columns are an error naming
+/// them; otherwise they are recorded on `report`, warned once per table and
+/// left out.
+pub fn import_column_list(
+    conn: &Connection,
+    table_name: &str,
+    source_sql: &str,
+    options: ImportOptions,
+    report: &mut ImportReport,
+) -> Result<Option<String>> {
+    let column_names = |sql: &str| -> Result<Vec<String>> {
+        let mut stmt = conn.prepare(sql)?;
+        let names = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(names)
+    };
+    let escaped_table_name = table_name.replace('\'', "''");
+    let target: HashSet<String> = column_names(&format!(
+        "SELECT column_name FROM duckdb_columns() \
+         WHERE database_name = current_database() AND schema_name = 'main' \
+         AND table_name = '{escaped_table_name}'"
+    ))
+    .with_context(|| format!("Failed to read the columns of table '{table_name}'"))?
+    .into_iter()
+    .map(|c| c.to_ascii_lowercase())
+    .collect();
+    if target.is_empty() {
+        anyhow::bail!("table '{table_name}' does not exist in the database being imported into");
+    }
+    let source = column_names(&format!("DESCRIBE SELECT * FROM {source_sql}"))
+        .with_context(|| format!("Failed to read the parquet columns for table '{table_name}'"))?;
+    let (known, unknown): (Vec<&String>, Vec<&String>) = source
+        .iter()
+        .partition(|c| target.contains(&c.to_ascii_lowercase()));
+    if unknown.is_empty() {
+        return Ok(Some("*".to_string()));
+    }
+    let unknown_list = unknown
+        .iter()
+        .map(|c| c.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if options.strict_schema {
+        anyhow::bail!(
+            "table '{table_name}' from {source_sql} has {} column(s) this systing (schema {SCHEMA_VERSION}) does not have: {unknown_list}; \
+             the trace was written by a newer systing — import it with a systing of that schema or later, or non-strictly to take the known columns only",
+            unknown.len()
+        );
+    }
+    eprintln!(
+        "warning: table '{table_name}' from {source_sql}: {} column(s) this systing (schema {SCHEMA_VERSION}) does not have were left out of the import: {unknown_list}",
+        unknown.len()
+    );
+    report.dropped_columns.push((
+        table_name.to_string(),
+        unknown.iter().map(|c| c.to_string()).collect(),
+    ));
+    if known.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(
+        known
+            .iter()
+            .map(|c| format!("\"{}\"", c.replace('"', "\"\"")))
+            .collect::<Vec<_>>()
+            .join(", "),
+    ))
+}
+
 /// Import all tables from Parquet files.
-fn import_tables(conn: &Connection, paths: &ParquetPaths, trace_id: &str) -> Result<()> {
+fn import_tables(
+    conn: &Connection,
+    paths: &ParquetPaths,
+    trace_id: &str,
+    options: ImportOptions,
+    report: &mut ImportReport,
+) -> Result<()> {
     let escaped_trace_id = trace_id.replace('\'', "''");
 
     // Helper to import a single table with trace_id injection.
@@ -955,20 +1079,25 @@ fn import_tables(conn: &Connection, paths: &ParquetPaths, trace_id: &str) -> Res
     // does not support parameterized queries. The escaping (replacing ' with '') is the
     // standard SQL escape for single quotes and is safe for the path and trace_id values
     // we're inserting. The table_name is always a literal from this code, not user input.
-    let import_table = |table_name: &str, path: &Path| -> Result<()> {
+    let mut import_table = |table_name: &str, path: &Path| -> Result<()> {
         if !path.exists() {
             return Ok(());
         }
 
         let escaped_path = path.to_string_lossy().replace('\'', "''");
+        let source_sql = format!("read_parquet('{escaped_path}')");
         let order = import_order_by(table_name)
             .map(|o| format!(" ORDER BY {o}"))
             .unwrap_or_default();
+        let Some(columns) = import_column_list(conn, table_name, &source_sql, options, report)?
+        else {
+            return Ok(());
+        };
 
         conn.execute_batch(&format!(
             "INSERT INTO {table_name} BY NAME \
-             SELECT '{escaped_trace_id}' as trace_id, * \
-             FROM read_parquet('{escaped_path}'){order}"
+             SELECT '{escaped_trace_id}' as trace_id, {columns} \
+             FROM {source_sql}{order}"
         ))
         .with_context(|| {
             format!(
@@ -1989,6 +2118,98 @@ mod tests {
         assert_eq!(info[1].trace_id, "trace_b");
         assert_eq!(info[1].source_path, "/path/to/b");
         assert_eq!(info[1].systing_version, "");
+    }
+
+    /// The import's column projection against a target table, over parquet
+    /// files DuckDB writes itself: every column known → `*`; an unknown
+    /// column → the known ones quoted and the unknown one reported (an error
+    /// naming it under strict_schema); no column known → the table skipped.
+    /// The multi-file source form the multi-trace importer uses binds the
+    /// same way.
+    #[test]
+    fn test_import_column_list_projects_unknown_columns() {
+        let temp_dir = TempDir::new().unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        create_schema(&conn).unwrap();
+        let parquet = |name: &str, select: &str| -> String {
+            let path = temp_dir.path().join(name).to_string_lossy().into_owned();
+            conn.execute_batch(&format!("COPY ({select}) TO '{path}' (FORMAT PARQUET)"))
+                .unwrap();
+            format!("read_parquet('{path}')")
+        };
+        let lax = ImportOptions::default();
+        let strict = ImportOptions {
+            strict_schema: true,
+        };
+
+        let known = parquet(
+            "known.parquet",
+            "SELECT 1::INTEGER AS cpu, 2::BIGINT AS max_freq_khz",
+        );
+        let mut report = ImportReport::default();
+        assert_eq!(
+            import_column_list(&conn, "cpu_info", &known, lax, &mut report).unwrap(),
+            Some("*".to_string())
+        );
+        assert_eq!(
+            import_column_list(&conn, "cpu_info", &known, strict, &mut report).unwrap(),
+            Some("*".to_string())
+        );
+        assert_eq!(report, ImportReport::default());
+
+        let newer = parquet(
+            "newer.parquet",
+            "SELECT 1::INTEGER AS cpu, 3::BIGINT AS min_freq_khz, 4::BIGINT AS turbo_khz",
+        );
+        assert_eq!(
+            import_column_list(&conn, "cpu_info", &newer, lax, &mut report).unwrap(),
+            Some("\"cpu\", \"min_freq_khz\"".to_string())
+        );
+        assert_eq!(
+            report.dropped_columns,
+            vec![("cpu_info".to_string(), vec!["turbo_khz".to_string()])]
+        );
+        let err = import_column_list(&conn, "cpu_info", &newer, strict, &mut report).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("turbo_khz"),
+            "the refusal names the unknown column: {err:#}"
+        );
+        // The projected statement is what the importers run.
+        conn.execute_batch(&format!(
+            "INSERT INTO cpu_info BY NAME SELECT 't' AS trace_id, \"cpu\", \"min_freq_khz\" FROM {newer}"
+        ))
+        .unwrap();
+        let row: (String, i32, Option<i64>, Option<i64>) = conn
+            .query_row(
+                "SELECT trace_id, cpu, min_freq_khz, max_freq_khz FROM cpu_info",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row, ("t".to_string(), 1, Some(3), None));
+
+        // A list source (the multi-trace importer's form) binds the same way.
+        let listed = format!(
+            "read_parquet(['{0}/newer.parquet', '{0}/newer.parquet'])",
+            temp_dir.path().to_string_lossy()
+        );
+        let mut report = ImportReport::default();
+        assert_eq!(
+            import_column_list(&conn, "cpu_info", &listed, lax, &mut report).unwrap(),
+            Some("\"cpu\", \"min_freq_khz\"".to_string())
+        );
+
+        let foreign = parquet("foreign.parquet", "SELECT 1 AS not_a_column");
+        let mut report = ImportReport::default();
+        assert_eq!(
+            import_column_list(&conn, "cpu_info", &foreign, lax, &mut report).unwrap(),
+            None,
+            "a source sharing no column with the target is skipped"
+        );
+        assert_eq!(
+            report.dropped_columns,
+            vec![("cpu_info".to_string(), vec!["not_a_column".to_string()])]
+        );
     }
 
     #[test]

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -3504,6 +3504,106 @@ mod tests {
         assert_eq!(row.2, None);
     }
 
+    /// The other face of schema skew: a sysinfo.parquet written by a NEWER
+    /// systing carries a column this schema does not have. DuckDB's BY NAME
+    /// import refuses the whole statement on it, so the importer projects
+    /// the unknown column away by default (the known columns import, the
+    /// drop is reported) and refuses only under `strict_schema`, naming it.
+    #[test]
+    fn test_sysinfo_duckdb_import_with_unknown_column() {
+        use crate::duckdb::{parquet_to_duckdb_with_options, ImportOptions, SCHEMA_VERSION};
+        use arrow::array::{Int64Array, StringArray};
+        use arrow::datatypes::{DataType, Field};
+        use duckdb::Connection;
+
+        let dir = TempDir::new().unwrap();
+        let newer_schema = Arc::new(Schema::new(vec![
+            Field::new("sysname", DataType::Utf8, false),
+            Field::new("release", DataType::Utf8, false),
+            Field::new("version", DataType::Utf8, false),
+            Field::new("machine", DataType::Utf8, false),
+            Field::new("sample_event", DataType::Utf8, true),
+            Field::new("sample_period", DataType::Int64, true),
+            Field::new("memory_fault_leg", DataType::Utf8, true),
+            Field::new("memory_future_leg", DataType::Utf8, true),
+            Field::new("memory_future_sample_rate", DataType::Int64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            newer_schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["Linux"])),
+                Arc::new(StringArray::from(vec!["6.12.0"])),
+                Arc::new(StringArray::from(vec!["#1 SMP"])),
+                Arc::new(StringArray::from(vec!["x86_64"])),
+                Arc::new(StringArray::from(vec![Some("cpu-clock")])),
+                Arc::new(Int64Array::from(vec![Some(1_000_000)])),
+                Arc::new(StringArray::from(vec![Some("tracepoint")])),
+                Arc::new(StringArray::from(vec![Some("on")])),
+                Arc::new(Int64Array::from(vec![Some(7)])),
+            ],
+        )
+        .unwrap();
+        let file = std::fs::File::create(dir.path().join("sysinfo.parquet")).unwrap();
+        let mut pw = ArrowWriter::try_new(file, newer_schema, None).unwrap();
+        pw.write(&batch).unwrap();
+        pw.close().unwrap();
+
+        let db_path = dir.path().join("test.duckdb");
+        let report = parquet_to_duckdb_with_options(
+            dir.path(),
+            &db_path,
+            "newer-trace",
+            ImportOptions::default(),
+        )
+        .expect("a sysinfo.parquet with a column this schema lacks must still import");
+        assert_eq!(
+            report.dropped_columns,
+            vec![(
+                "sysinfo".to_string(),
+                vec![
+                    "memory_future_leg".to_string(),
+                    "memory_future_sample_rate".to_string()
+                ]
+            )],
+            "the report names the table and the columns left out, in source order"
+        );
+
+        let conn = Connection::open(&db_path).unwrap();
+        let row: (String, String, Option<String>, Option<i64>) = conn
+            .query_row(
+                "SELECT trace_id, machine, memory_fault_leg, sample_period FROM sysinfo",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0, "newer-trace");
+        assert_eq!(row.1, "x86_64");
+        assert_eq!(row.2, Some("tracepoint".to_string()));
+        assert_eq!(row.3, Some(1_000_000));
+        let version: u32 = conn
+            .query_row("SELECT version FROM _schema_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(version, SCHEMA_VERSION, "the database is this schema's");
+        drop(conn);
+
+        let err = parquet_to_duckdb_with_options(
+            dir.path(),
+            &db_path,
+            "newer-trace",
+            ImportOptions {
+                strict_schema: true,
+            },
+        )
+        .expect_err("strict_schema refuses a column this schema lacks");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("table 'sysinfo'")
+                && msg.contains("memory_future_leg, memory_future_sample_rate")
+                && msg.contains(&format!("schema {SCHEMA_VERSION}")),
+            "the refusal names the table, the unknown columns and this schema: {msg}"
+        );
+    }
+
     #[test]
     fn test_cpu_info_duckdb_round_trip() {
         use crate::duckdb::parquet_to_duckdb;

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -922,8 +922,13 @@ pub struct MemoryKernelLegs {
     /// the rest of the memory recorder runs.
     pub syscall_off: Option<String>,
     /// Why the VFIO/IOMMU legs cannot run here (`nosym`: the
-    /// vfio_iommu_type1 module is not loaded; `notracepoint`: no iommu
-    /// tracepoints; `attach`: a probe failed to attach).
+    /// vfio_iommu_type1 module is not loaded, or its handlers are listed
+    /// only as `.isra` / `.constprop` clones the exact-name probe does not
+    /// match; `notracepoint`: no iommu tracepoints; `attach`: a probe failed
+    /// to attach). The legs instrument the vfio_iommu_type1 container path
+    /// only: a host whose devices are attached through iommufd (the cdev
+    /// path, `iommufd_ioas_map`) reads `on` with the module loaded beside it
+    /// and sees no VFIO region or IOMMU run at all.
     pub vfio_off: Option<String>,
     /// Why the teardown pair (container release, group detach) cannot run
     /// while the ioctl pair can (`nosym`, `attach`); the leg then reads

--- a/src/utid.rs
+++ b/src/utid.rs
@@ -82,6 +82,14 @@ impl UtidGenerator {
     ///
     /// If this is the first time seeing this tid, a new sequential utid is
     /// assigned and returned. Thread-safe via DashMap's internal sharded locking.
+    ///
+    /// The mapping is by tid alone and lives for the whole capture: a tid
+    /// the kernel reuses after its thread exits (long captures, a host near
+    /// its pid ceiling) resolves to the FIRST thread's utid, so rows
+    /// attributed after the reuse — an end-of-capture sample such as
+    /// `memory_rss`'s `anon_huge` member, a `memory_iommu` histogram row
+    /// drained at the end, any event the new thread produces — land on the
+    /// old thread. A known bound of the model, not detected here.
     pub fn get_or_create_utid(&self, tid: i32) -> i64 {
         // DashMap's entry API handles the get-or-insert atomically.
         // Relaxed ordering is sufficient - we only need uniqueness, not synchronization.


### PR DESCRIPTION
The parquet→DuckDB import is `INSERT INTO <table> BY NAME SELECT … FROM read_parquet(…)`, and DuckDB's `BY NAME` has two faces. A target column the parquet lacks — an older trace read by a newer systing — is NULL-filled (the case `test_sysinfo_duckdb_import_without_memory_columns` covers). A parquet column the target lacks — a newer trace read by an older systing — failed the WHOLE import with a binder error on the first unknown column, so a trace written after a schema bump was unreadable by every systing before it, and a reader that lags the writer by one release lost the trace rather than the new columns. This PR makes that face degrade instead of fail, and carries the remaining doc items from the second review of the VFIO/THP legs (#219 / #226).

## The import guard

- `duckdb::import_column_list` reads the target table's columns (`duckdb_columns()`, the form the DuckDB→DuckDB import already uses) and the parquet's (`DESCRIBE SELECT * FROM read_parquet(…)`, so the same source form works for one file or a list), compares them case-insensitively as DuckDB binds them, and returns the select list: `*` when every source column is known; the known columns quoted, with one `warning:` line naming the table, the unknown columns and this systing's `SCHEMA_VERSION`, otherwise; `None` — the table skipped — when the source shares no column with the target.
- `ImportOptions { strict_schema }` (default off) turns the projection into a refusal with the same names in the message; `ImportReport { dropped_columns }` carries what was left out, per table in source order.
- Both import sites use it: `duckdb::import_tables` (`parquet_to_duckdb` keeps its signature; `parquet_to_duckdb_with_options` takes the options and returns the report) and `systing-util convert`'s two statement shapes — the multi-file `read_parquet([…])` for inputs that already carry `trace_id` and the per-trace injection — which gains `--strict-schema`.
- The database an import produces is a complete database of the READER's schema: `_schema_version` names it, and a consumer of that database sees nothing amiss. Only the importing process learns, through the report and the warning line, that the trace carried more. Neither the parquet directory nor `_traces` records the writer's schema version (`_traces.systing_version` is the converting binary's — the v12 entry says so), so the recorder's version in the parquet directory stays the planned follow-up; this PR adds no column and no schema version.

## Tests

- `test_sysinfo_duckdb_import_with_unknown_column` (beside the forward-face test): a `sysinfo.parquet` carrying two columns this schema does not have imports on the default with the known values intact, the report naming the table and both columns, `_schema_version` at this schema; the same directory under `strict_schema` refuses with the table, the columns and the schema version in the message.
- `test_import_column_list_projects_unknown_columns`: over parquet files DuckDB writes itself — every column known → `*`; an unknown column → the quoted known list, the report, the strict refusal, and the projected `INSERT … BY NAME` that the importers run; the multi-file list form binds the same way; a source sharing no column is skipped.
- The whole lib suite and `clippy --all-targets -- -D warnings` clean; no BPF program, map or instruction changes (the `src/bpf/` hunks are comments), so no load-shape or guest run.

## The doc items

- The `memory_iommu_hist` comment said its writers are task-context tracepoint programs. They are not (a driver mapping under a softirq fires the same `iommu:map`); the map is safe from those contexts because the bucket lock is a raw spinlock taken with interrupts disabled (`htab_lock_bucket`, read at kernel/bpf/hashtab.c v6.12) and no NMI-context program writes it — the comment now says that.
- What one `iommu:map` / `iommu:unmap` event is, read at drivers/vfio/vfio_iommu_type1.c v6.12: `vfio_iommu_map` issues one `iommu_map` per pinned run PER DOMAIN in the container's domain list (a container with two domains counts every map run twice); on unmap only the first domain is unmapped run by run and each further domain gets one `iommu_unmap` of the whole region. `size_order` is floor(log2) of the run. Both at the leg's comment and in SCHEMA_CHANGES' `memory_iommu` entry.
- The folio-split kretprobe on 6.9+ (`split_huge_page_to_list_to_order`) sees every large-folio split, file and shmem folios included — a superset of the vmstat `thp_split_page` family — and 6.15+'s `folio_split()` bypasses it; at the THP comment.
- The VFIO/IOMMU legs instrument the vfio_iommu_type1 container path only: an iommufd host reads `on` with the module loaded and sees nothing, and `.isra` / `.constprop` clones of the handlers read `nosym` like a missing module; at `MemoryKernelLegs::vfio_off`.
- A tid the kernel reuses inside a capture resolves to the first thread's utid (no mapping is retired), so rows attributed after the reuse — the end-of-capture `anon_huge` sample, a drained `memory_iommu` row — land on the old thread; at `UtidGenerator::get_or_create_utid`.
- A kretprobe that misses its return leaves a VFIO window open (the task's later runs inside the range count until its next VFIO path or the capture's end); a perf-attached kretprobe's miss count is not exported, so it is a documented bound at `memory_vfio_open_window`. The window that cannot be opened was already counted in `memory_iommu_overflow`.
- Two release stamps in SCHEMA_CHANGES read from the tags: the classic-default restoration shipped in 1.17.4 (1.17.0–1.17.3 carried the trampoline default — the text said 1.17.2), and the `split_huge_pmd_locked` funnel tier shipped in 1.17.5.

Per-leg attach (`set_autoattach(false)` + `attach_program_set` per leg, `off:attach` recorded) was verified present from #226 — no change.
