### PR TITLE
Fix pystacks on aarch64: TLS derivation and the user-space address bound

### DIFF
--- a/src/pystacks/bpf/include/common.h
+++ b/src/pystacks/bpf/include/common.h
@@ -19,8 +19,17 @@
 // https://www.kernel.org/doc/Documentation/x86/x86_64/mm.txt
 #define BPF_LIB_MAX_USER_SPACE_ADDRESS ((uintptr_t)0x00ffffffffffffff)
 #elif defined(__aarch64__)
-// https://www.kernel.org/doc/Documentation/arm64/memory.txt
-#define BPF_LIB_MAX_USER_SPACE_ADDRESS ((uintptr_t)0x0000007fffffffff)
+// https://www.kernel.org/doc/Documentation/arch/arm64/memory.rst
+// arm64 distribution kernels give user space 48 bits (4KB pages + 4
+// levels: 0x0000000000000000 - 0x0000ffffffffffff), and up to 52 bits with
+// CONFIG_ARM64_VA_BITS_52 (0x000fffffffffffff); the smaller 39- and 42-bit
+// configurations fit under the same bound, so it is the 52-bit maximum.
+// Kernel addresses always sit at 0xfff0000000000000 and above, so nothing
+// kernel-side passes this check. The previous value, 0x0000007fffffffff,
+// was the 39-bit (4KB pages + 3 levels) layout, under which every pointer
+// in the mmap region (0x0000ffff........) and every PIE executable
+// (0x0000aaaa........) of a 48-bit process read as invalid.
+#define BPF_LIB_MAX_USER_SPACE_ADDRESS ((uintptr_t)0x000fffffffffffff)
 #elif defined(__riscv64__)
 // https://www.kernel.org/doc/Documentation/riscv/vm-layout.rst
 #define BPF_LIB_MAX_USER_SPACE_ADDRESS ((uintptr_t)0x00ffffffffffffff)

--- a/src/pystacks/bpf/include/pthread_helpers.bpf.c
+++ b/src/pystacks/bpf/include/pthread_helpers.bpf.c
@@ -5,9 +5,23 @@
 #include "bpf_read_helpers.bpf.h"
 #include "task_helpers.bpf.h"
 
-#if __riscv64__
-/* glibc registers &pthread->tid as the kernel clear-child-tid pointer. */
-static __always_inline void* get_riscv_pthread_descriptor(
+#if __aarch64__ || __riscv64__
+/*
+ * On TLS-variant-1 architectures (aarch64, riscv64) the thread pointer
+ * addresses the 16-byte TCB, not struct pthread: the descriptor sits at
+ * tp - sizeof(struct pthread), and that distance is tail-anchored — it
+ * changes when glibc grows or shrinks struct pthread (e.g. 1856 bytes in
+ * glibc 2.36 vs 1824 in 2.41 on aarch64). Head-anchored offsets are
+ * stable across those same versions, so instead of the thread pointer we
+ * derive the descriptor from pointers glibc registers with the kernel,
+ * which point into the descriptor head.
+ *
+ * glibc registers &pthread->tid as the kernel clear-child-tid pointer
+ * (set_tid_address is called for the main thread too). 0xd0 is
+ * offsetof(struct pthread, tid) for the generic-nptl layout both
+ * architectures share: 24-pointer header padding (192) + list_head (16).
+ */
+static __always_inline void* get_glibc_pthread_descriptor(
     const struct task_struct* cur_task) {
   const uint32_t offsetof_tid = 0xd0;
   void* clear_child_tid = (void*)BPF_PROBE_READ(cur_task, clear_child_tid);
@@ -21,7 +35,7 @@ static __always_inline void* get_riscv_pthread_descriptor(
  * specific_1stblock is 0x30 bytes after robust_head in both of glibc's
  * robust-mutex layouts.
  */
-static __always_inline void* get_riscv_specific1stblock(
+static __always_inline void* get_glibc_specific1stblock(
     const struct task_struct* cur_task) {
   void* robust_list = (void*)BPF_PROBE_READ(cur_task, robust_list);
   return IS_VALID_USER_SPACE_ADDRESS(robust_list)
@@ -44,11 +58,8 @@ __hidden int probe_read_pthread_tls_slot(
 #if __x86_64__
   void* tls_base = (void*)BPF_PROBE_READ(cur_task, thread.fsbase);
   void* specific1stblock = (char*)tls_base + 0x310;
-#elif __aarch64__
-  void* tls_base = (void*)BPF_PROBE_READ(cur_task, thread.uw.tp_value);
-  void* specific1stblock = (char*)tls_base + 0x310;
-#elif __riscv64__
-  void* specific1stblock = get_riscv_specific1stblock(cur_task);
+#elif __aarch64__ || __riscv64__
+  void* specific1stblock = get_glibc_specific1stblock(cur_task);
   if (!specific1stblock) {
     *value = 0;
     return -1;
@@ -70,8 +81,9 @@ __hidden int probe_read_pthread_tls_slot(
   //   pthread->specific[key / 32][key % 32].data
   //
   // 'struct pthread' is not in the public API.
-  // - x86-64 and AArch64 use fixed offset above.
-  // - RISC-V derives the block from the kernel's glibc robust-list pointer.
+  // - x86-64 uses the fixed offset above (fsbase is the descriptor itself).
+  // - AArch64 and RISC-V derive the block from the kernel's glibc
+  //   robust-list pointer.
   //   (https://codebrowser.dev/glibc/glibc/sysdeps/nptl/dl-tls_init_tp.c.html#92)
   const uint32_t specific1stblock_count = 32;
   const uint32_t sizeof_pthread_key_data = 16;

--- a/src/pystacks/bpf/pystacks.bpf.c
+++ b/src/pystacks/bpf/pystacks.bpf.c
@@ -990,8 +990,13 @@ get_pthread_id_match(void* thread_state, void* tls_base, PyPidData* pid_data) {
     return PYSTACKS_PTHREAD_ID_NULL;
   }
 
-#if __riscv64__
-  /* tls_base is the pthread descriptor derived from clear_child_tid. */
+#if __aarch64__ || __riscv64__
+  /*
+   * tls_base is the pthread descriptor derived from clear_child_tid;
+   * compare it directly. struct pthread has no header.self on these
+   * architectures (the header union is plain padding), so there is
+   * nothing to read.
+   */
   pthread_self = (uint64_t)tls_base;
 #else
   // 0x10 = offsetof(struct pthread, header.self)
@@ -1119,10 +1124,8 @@ __hidden int pystacks_read_stacks_task(
 
 #if __x86_64__
   void* tls_base = (void*)BPF_PROBE_READ(cur_task, thread.fsbase);
-#elif __aarch64__
-  void* tls_base = (void*)BPF_PROBE_READ(cur_task, thread.uw.tp_value);
-#elif __riscv64__
-  void* tls_base = get_riscv_pthread_descriptor(cur_task);
+#elif __aarch64__ || __riscv64__
+  void* tls_base = get_glibc_pthread_descriptor(cur_task);
 #else
 #error "Unsupported platform"
 #endif


### PR DESCRIPTION
## Summary

Python stack resolution on aarch64 has been silently broken since the
pure-Rust pystacks port, for two independent reasons — either one alone
produces zero Python frames on every current arm64 kernel:

1. the aarch64 path reuses x86-shaped TLS constants that are invalid
   under aarch64's TLS layout — fixed by extending the existing riscv64
   derivation (clear_child_tid / robust_list, both head-anchored) to
   aarch64, which shares glibc's generic-nptl `struct pthread` layout;
2. the aarch64 user-space address bound (`BPF_LIB_MAX_USER_SPACE_ADDRESS`)
   is the 39-bit value of an old memory-layout table, so
   `IS_VALID_USER_SPACE_ADDRESS()` rejects every pointer of a 48-bit-VA
   process — fixed by raising it to the 52-bit architectural maximum.

Observed in production on hosts of both architectures running the same
systing build and kernel version (6.18) with `--collect-pystacks`:
python3.13 processes on the aarch64 hosts produced 0 Python frames over
more than a billion CPU samples in a 30-minute window, while the x86_64
hosts resolved a Python frame in 30–50 % of their python samples.

## Bug 1: the TLS derivation

On TLS-variant-1 architectures (aarch64, riscv64) the thread pointer
addresses the 16-byte TCB, not `struct pthread`: the descriptor lives at
`tp - sizeof(struct pthread)`, and static TLS starts at `tp + 16`. The
aarch64 path read:

- `tp_value + 0x310` for `specific_1stblock` — actually 784 bytes into
  some module's static TLS. The pages are mapped, so
  `bpf_probe_read_user` succeeds and garbage flows into the TLS-slot
  lookup.
- `tp_value + 0x10` for `header.self` — a field that does not exist on
  aarch64 (`struct pthread` has no `header.self` there; the header union
  is plain padding). The pthread-id match therefore ~never fires and
  thread-state association fails.

Both failures are silent: no errors, just no Python frames (the sanity
checks downstream reject the garbage), which is exactly the production
signature above.

Offsets from glibc DWARF (Debian `libc6-dbg`, read with `gdb ptype /o`;
x86-64 read first as a negative control — it reproduces the exact
constants the x86 path uses, 0x310 and 0x10, before trusting any
aarch64 numbers), plus a live probe on glibc 2.42:

| | x86_64 glibc 2.36 | aarch64 2.36 | aarch64 2.41 | aarch64 2.42 (probe) |
|---|---|---|---|---|
| `sizeof(struct pthread)` | 2368 | 1856 | **1824 (drifts)** | 1824 |
| `specific_1stblock` | 784 = 0x310 | 272 | 272 (stable) | 272 |
| `tid` | 720 | 208 = 0xd0 | 208 (stable) | 208 |
| `robust_head` | 736 | 224 | 224 (stable) | 224 |
| `header.self` | 16 = 0x10 | absent | absent | absent |

The 2.42 column is a small C program run on an aarch64 host: it creates
a pthread key, then scans `struct pthread` for the key slot, the tid and
`robust_head` from the main thread and from a created thread — the
patch's arithmetic (`robust_head + 0x30`, tid slot − 0xd0) holds for
both, and the old `tp + 0x310` sits 1,824 bytes above the descriptor.

"Accidentally works" is ruled out arithmetically: the wanted-vs-read
delta is a fixed `-sizeof(struct pthread)` bytes, so no aliasing is
possible, and the id-match would require static-TLS content to
systematically equal the thread's own descriptor address.

### The fix

Derive the descriptor from pointers glibc registers with the kernel —
these are head-anchored and stable across glibc versions, unlike
tp-anchoring, which shifts whenever `sizeof(struct pthread)` changes
(1856 in 2.36 vs 1824 in 2.41, per the table):

- descriptor base = `task->clear_child_tid - 0xd0`: glibc registers
  `&self->tid` via `set_tid_address`, including for the main thread
- `specific_1stblock` = `task->robust_list + 0x30`: glibc registers
  `&self->robust_head`, and `specific_1stblock` sits 0x30 past it in
  both robust-mutex layouts
- the pthread-id match compares the derived descriptor base directly
  against the recorded thread id; there is no `header.self` to read on
  these architectures (and on glibc, `pthread_t` is the descriptor
  address)

This is the same mechanism the riscv64 port already uses; the riscv64
helpers are renamed `get_riscv_*` → `get_glibc_*` and now serve both
architectures.

## Bug 2: the user-space address bound

`src/pystacks/bpf/include/common.h` set the aarch64
`BPF_LIB_MAX_USER_SPACE_ADDRESS` to `0x0000007fffffffff` — the 39-bit
(4KB pages + 3 levels) row of the old arm64 memory-layout table — while
x86_64 and riscv64 get `0x00ffffffffffffff`. arm64 distribution kernels
give user space 48 bits (`0x0000ffffffffffff`; up to 52 with
`CONFIG_ARM64_VA_BITS_52`), with the mmap region near `0x0000ffff…` and
PIE executables near `0x0000aaaa…`, so `IS_VALID_USER_SPACE_ADDRESS()`
rejected every pointer of a normal process. It gates four reads in the
pystacks path: the two descriptor anchors that bug 1's fix introduces
(`clear_child_tid`, `robust_list` — a rejected anchor means "no thread
state", so no walk at all) and the `qualname` / `filename` string
pointers of every frame (a rejected pointer reads as `[Frame Error]`).

Measured on the affected hosts (the same production population as the
Summary, a 20-minute window): every raw address in the unsymbolized
user frames of Python processes on the aarch64 hosts sits in the 48-bit
regions — 23,053 frames on 12 hosts between `0xabe8e2886cf0` and
`0xfffffa01dbf8`, none at or below 2^39 — while the x86_64 hosts'
addresses sit at `0x56c3…`–`0x642f…` (their PIE region). The
fix raises the bound to `0x000fffffffffffff`, which every arm64 VA
configuration fits under; arm64 kernel addresses start at
`0xfff0000000000000`, so nothing kernel-side passes.

This bug was found by the VM run of bug 1's fix alone (below): with the
descriptor derived correctly, the walk still produced zero frames,
because the very first pointer it validated failed the 39-bit bound.

The x86_64 path is unchanged by either fix (fsbase already points at the
descriptor, so the fixed offsets are correct there, and the x86 bound is
untouched). Three BPF source files change; no Rust, no schema, no map,
no new program.

## Validation

- **x86_64 regression**: the pystacks BPF object compiled with the
  build.rs recipe (`-g -O2 -target bpf -mcpu=v3 -fwrapv`, the pinned
  flags) at the merge base and on this branch is instruction-identical
  (`llvm-objdump -d` diff is empty, 2,283 lines each) — every change is
  inside non-x86 `#if` arms or comments; the objects differ only in
  debug line info.
- **aarch64 compile check**: `pystacks.bpf.c` compiled with the same
  recipe plus `-D__aarch64__ -D__TARGET_ARCH_arm64` against
  `vmlinux_aarch64.h`. The object carries the new derivation (`-0xd0`
  from `clear_child_tid` feeding the direct id-compare, `+= 0x30` from
  `robust_list` for the specific-block path; CO-RE relocations against
  `clear_child_tid` and `robust_list`) and no read of `thread.uw.tp_value`
  on the pystacks path; a preprocessing read of `common.h` under aarch64
  flags shows the bound at `0x0000007fffffffff` on the merge base and
  `0x000fffffffffffff` here.
- **aarch64 load check (verifier)**: systing built natively for
  aarch64-linux at the merge base and with bug 1's fix applied to the
  pinned source (the BPF object embedded in the test binary is the one
  shipped in `bin/systing`), and the `bpf_load_shapes` test
  (`every_shape_loads`, 34 recorder shapes, the three `--collect-pystacks`
  shapes among them) run as root in an aarch64 VM (QEMU TCG, kernel
  6.12.93 with BTF): **34/34 shapes load in both builds**, no libbpf or
  verifier complaint — the pystacks code is statically linked into the
  main object and the pystacks path is walked only in the pystacks-on
  shapes, so those loads are the verifier's verdict on the new arms. The
  same check on the final bytes (both fixes applied): **34/34 shapes
  load** (`continuous-pystacks` 17.3 s, `all-recorders` 109.7 s, the
  whole test 298 s under TCG), no libbpf or verifier complaint.
- **aarch64 runtime**: a python 3.13 workload under
  `systing --duration 3 --sw-event --collect-pystacks` in the same
  aarch64 VM (QEMU TCG, kernel 6.12.93, nixpkgs python 3.13.13 whose
  libpython exports `_PyRuntime`). With bug 1's fix alone: **0 Python
  frames** (0 of 2,787 samples; unpatched: 0 of 2,909) while the native
  control was healthy in both (`_PyEval_EvalFrameDefault` in 2,504 /
  2,632 samples; discovery attached the interpreter;
  `with_pystack=0 … initialized=true`) — the run that exposed bug 2. The
  same workload on x86_64 under KVM with the unpatched build resolved
  Python frames in 2,998 of 3,139 samples (95 %), so the test setup is
  sound and the aarch64 zero is aarch64-specific. **With both fixes
  (the final bytes of this PR): Python frames in 2,637 of 2,905 samples
  (91 %)** — the workload's hot loop `spin_hot_loop_m4` named in 2,637
  samples with both of its source lines resolved (`spin.py:5` 1,727,
  `spin.py:6` 910) under `<module>` at `spin.py:12`; systing's stats
  line `with_pystack=2637 without_pystack=268 symbol_loads=3
  symbolized=504 unknown=0 initialized=true` — the x86_64 control's
  shape, in the guest recipe that gave 0 an hour earlier with only bug
  1's fix, the v2 patch the only change. The x86_64 path is
  byte-for-byte unchanged, so the only risk this PR carries is on
  architectures where pystacks yields nothing today.

Note: CI currently has no arm64 coverage (which is how this survived
since the port — nothing exercises arm64 pystacks). build.rs already
supports cross-compilation; a follow-up could add an aarch64
cross-compile check job (needs `libc6-dev-arm64-cross` in the runner).
