### PR TITLE
network-packets: take the parquet encode and the fan-in channel off the packet consumer

### DIFF
--- a/src/network_recorder.rs
+++ b/src/network_recorder.rs
@@ -296,6 +296,44 @@ impl SocketMetadata {
     }
 }
 
+/// A consumer's batch of packet events prepared OUTSIDE the recorder lock
+/// ([`NetworkRecorder::prepare_packet_batch`]): the parquet records with
+/// their `id` unassigned, and beside each the socket sighting the recorder
+/// needs to emit the socket record on first sight. Appended under the lock
+/// by [`NetworkRecorder::append_packet_batch`].
+pub struct PreparedBatch {
+    records: Vec<NetworkPacketRecord>,
+    sockets: Vec<SocketSighting>,
+}
+
+impl PreparedBatch {
+    /// Packet records in the batch (events without a socket id or of an
+    /// unknown type were dropped at preparation).
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+/// What a packet event says about its socket: the tuple the socket record
+/// carries, whether it is complete (see [`socket_tuple_is_complete`]), the
+/// namespace and the sighting time.
+struct SocketSighting {
+    socket_id: SocketId,
+    protocol: u32,
+    af: u32,
+    src_addr: [u8; 16],
+    src_port: u16,
+    dest_addr: [u8; 16],
+    dest_port: u16,
+    complete: bool,
+    netns_inum: u64,
+    ts: u64,
+}
+
 pub struct NetworkRecorder {
     pub ringbuf: RingBuffer<network_event>,
 
@@ -325,7 +363,7 @@ pub struct NetworkRecorder {
     /// arrives with the complete tuple, ONE upgraded record is emitted
     /// so the trace carries the real endpoints. Readers keep one row
     /// per socket by preferring the complete row.
-    seen_sockets: HashMap<SocketId, bool>,
+    seen_sockets: SeenSockets,
     /// Collector for streaming records during recording
     streaming_collector: Option<Box<dyn RecordCollector + Send>>,
     /// Next record ID counters for streaming
@@ -355,6 +393,34 @@ fn socket_tuple_is_complete(af: u32, src_port: u16, dest_addr: &[u8; 16], dest_p
     src_port != 0 && !(dest_port == 0 && parse_ip_addr(af, dest_addr).is_unspecified())
 }
 
+/// The seen-socket map, probed once per packet event under the recorder
+/// lock: a `u64` socket id hashed by one multiplication (Fibonacci hashing)
+/// instead of SipHash. The ids are BPF-assigned counters, so the identity
+/// would cluster hashbrown's tag bits; the multiply spreads them.
+type SeenSockets = HashMap<SocketId, bool, std::hash::BuildHasherDefault<SocketIdHasher>>;
+
+#[derive(Default)]
+struct SocketIdHasher(u64);
+
+impl std::hash::Hasher for SocketIdHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        // Only `u64` keys reach this hasher; anything else would be a bug
+        // in how the map is keyed, and is hashed byte-wise so it still
+        // works.
+        for &b in bytes {
+            self.0 = (self.0 ^ u64::from(b)).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        }
+    }
+
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    }
+}
+
 /// Decide whether a NetworkSocketRecord should be emitted for this
 /// sighting of `socket_id`, updating the seen-map. True on first sight,
 /// and ONCE more as an upgrade when the first record was emitted from a
@@ -365,7 +431,7 @@ fn socket_tuple_is_complete(af: u32, src_port: u16, dest_addr: &[u8; 16], dest_p
 /// only ever shows degraded tuples (a real listener, an unconnected UDP
 /// socket) emits exactly one record.
 fn should_emit_socket_record(
-    seen_sockets: &mut HashMap<SocketId, bool>,
+    seen_sockets: &mut SeenSockets,
     socket_id: SocketId,
     complete: bool,
 ) -> bool {
@@ -387,7 +453,7 @@ impl NetworkRecorder {
             hostname_cache: HashMap::new(),
             resolve_addresses,
             min_ts: None,
-            seen_sockets: HashMap::new(),
+            seen_sockets: SeenSockets::default(),
             streaming_collector: None,
             next_syscall_id: 1,
             next_packet_id: 1,
@@ -410,23 +476,13 @@ impl NetworkRecorder {
     /// or ONCE more as an upgrade when the first record was emitted from a
     /// degraded sighting (port-less or peer-less tuple) and this event
     /// carries the complete tuple. Returns true if a record was emitted.
-    #[allow(clippy::too_many_arguments)]
-    fn maybe_emit_socket_record(
-        &mut self,
-        socket_id: SocketId,
-        protocol: u32,
-        af: u32,
-        src_addr: &[u8; 16],
-        src_port: u16,
-        dest_addr: &[u8; 16],
-        dest_port: u16,
-        netns_inum: u64,
-        ts: i64,
-    ) -> Result<bool> {
+    fn maybe_emit_socket_record(&mut self, sighting: &SocketSighting) -> Result<bool> {
         use crate::systing_core::types::{network_address_family, network_protocol};
 
-        let complete = socket_tuple_is_complete(af, src_port, dest_addr, dest_port);
-        if !should_emit_socket_record(&mut self.seen_sockets, socket_id, complete) {
+        let socket_id = sighting.socket_id;
+        let protocol = sighting.protocol;
+        let af = sighting.af;
+        if !should_emit_socket_record(&mut self.seen_sockets, socket_id, sighting.complete) {
             return Ok(false);
         }
 
@@ -456,24 +512,46 @@ impl NetworkRecorder {
         .to_string();
 
         // Convert addresses to strings
-        let src_ip = parse_ip_addr(af, src_addr).to_string();
-        let dest_ip = parse_ip_addr(af, dest_addr).to_string();
+        let src_ip = parse_ip_addr(af, &sighting.src_addr).to_string();
+        let dest_ip = parse_ip_addr(af, &sighting.dest_addr).to_string();
 
         // Emit NetworkSocketRecord
         collector.add_network_socket(NetworkSocketRecord {
             socket_id: socket_id as i64,
-            netns_inum: netns_inum as i64,
+            netns_inum: sighting.netns_inum as i64,
             protocol: protocol_str,
             address_family: af_str,
             src_ip,
-            src_port: src_port as i32,
+            src_port: sighting.src_port as i32,
             dest_ip,
-            dest_port: dest_port as i32,
-            first_seen_ts: Some(ts),
-            last_seen_ts: Some(ts),
+            dest_port: sighting.dest_port as i32,
+            first_seen_ts: Some(sighting.ts as i64),
+            last_seen_ts: Some(sighting.ts as i64),
         })?;
 
         Ok(true)
+    }
+
+    /// A syscall event's socket sighting (its tuple completeness computed
+    /// here; a packet event's is computed off the lock at preparation).
+    fn syscall_sighting(event: &network_event) -> SocketSighting {
+        SocketSighting {
+            socket_id: event.socket_id,
+            protocol: event.protocol.0,
+            af: event.af.0,
+            src_addr: event.src_addr,
+            src_port: event.src_port,
+            dest_addr: event.dest_addr,
+            dest_port: event.dest_port,
+            complete: socket_tuple_is_complete(
+                event.af.0,
+                event.src_port,
+                &event.dest_addr,
+                event.dest_port,
+            ),
+            netns_inum: event.netns_inum,
+            ts: event.start_ts,
+        }
     }
 
     /// Helper function to convert kernel jiffies to microseconds for streaming.
@@ -499,17 +577,7 @@ impl NetworkRecorder {
         let ResolvedTask { utid, .. } = self.utid_generator.resolve_task(&event.task);
 
         // Emit NetworkSocketRecord if first time seeing this socket
-        self.maybe_emit_socket_record(
-            socket_id,
-            event.protocol.0,
-            event.af.0,
-            &event.src_addr,
-            event.src_port,
-            &event.dest_addr,
-            event.dest_port,
-            event.netns_inum,
-            ts,
-        )?;
+        self.maybe_emit_socket_record(&Self::syscall_sighting(event))?;
 
         // Get collector
         let collector = self.streaming_collector.as_mut().ok_or_else(|| {
@@ -576,42 +644,19 @@ impl NetworkRecorder {
         Ok(())
     }
 
-    /// Stream a packet event - emit NetworkPacketRecord immediately.
-    /// Also emits NetworkSocketRecord if this is the first event for this socket.
-    fn stream_packet_event(
-        &mut self,
+    /// The packet record's fields from the event — no recorder state, the
+    /// `id` left 0 for [`Self::append_packet_batch`]; the socket record for
+    /// a first sighting is emitted there too.
+    fn packet_record(
         event: &crate::systing_core::types::packet_event,
         event_name: &'static str,
-    ) -> Result<()> {
+    ) -> NetworkPacketRecord {
         let socket_id = event.socket_id;
         let ts = event.ts as i64;
 
-        // Emit NetworkSocketRecord if first time seeing this socket
-        self.maybe_emit_socket_record(
-            socket_id,
-            event.protocol.0,
-            event.af.0,
-            &event.src_addr,
-            event.src_port,
-            &event.dest_addr,
-            event.dest_port,
-            event.netns_inum,
-            ts,
-        )?;
-
-        // Get collector
-        let collector = self
-            .streaming_collector
-            .as_mut()
-            .ok_or_else(|| anyhow::anyhow!("Streaming collector not set in stream_packet_event"))?;
-
-        // Get ID and increment
-        let id = self.next_packet_id;
-        self.next_packet_id += 1;
-
         // Build packet record
         let mut record = NetworkPacketRecord {
-            id,
+            id: 0,
             ts,
             socket_id: socket_id as i64,
             event_type: event_name,
@@ -780,9 +825,7 @@ impl NetworkRecorder {
             record.sndbuf_fill_pct = Some(fill_pct);
         }
 
-        // Emit the record
-        collector.add_network_packet(record)?;
-        Ok(())
+        record
     }
 
     /// Stream a poll event - emit NetworkPollRecord immediately.
@@ -966,14 +1009,57 @@ impl NetworkRecorder {
             "streaming_collector must be set before handling events"
         );
 
+        let batch = Self::prepare_packet_batch(std::slice::from_ref(&event));
+        if let Err(e) = self.append_packet_batch(batch) {
+            eprintln!("Warning: Failed to stream network packet event: {e}");
+        }
+    }
+
+    /// The parquet records for a consumer's batch of packet events, built
+    /// with no recorder state so the consumer does it outside the recorder
+    /// lock. Events without a socket id or of an unknown type are dropped
+    /// here; the records' `id`s stay 0 until [`Self::append_packet_batch`]
+    /// assigns them.
+    pub fn prepare_packet_batch(
+        events: &[crate::systing_core::types::packet_event],
+    ) -> PreparedBatch {
+        let mut records = Vec::with_capacity(events.len());
+        let mut sockets = Vec::with_capacity(events.len());
+        for event in events {
+            let Some(event_name) = Self::packet_event_name(event) else {
+                continue;
+            };
+            records.push(Self::packet_record(event, event_name));
+            sockets.push(SocketSighting {
+                socket_id: event.socket_id,
+                protocol: event.protocol.0,
+                af: event.af.0,
+                src_addr: event.src_addr,
+                src_port: event.src_port,
+                dest_addr: event.dest_addr,
+                dest_port: event.dest_port,
+                complete: socket_tuple_is_complete(
+                    event.af.0,
+                    event.src_port,
+                    &event.dest_addr,
+                    event.dest_port,
+                ),
+                netns_inum: event.netns_inum,
+                ts: event.ts,
+            });
+        }
+        PreparedBatch { records, sockets }
+    }
+
+    /// The `event_type` column's name for a packet event; `None` for an
+    /// event the recorder skips (no socket id, an unknown type).
+    fn packet_event_name(event: &crate::systing_core::types::packet_event) -> Option<&'static str> {
         use crate::systing_core::types::packet_event_type;
 
         // Skip events without socket_id (shouldn't happen in normal operation)
         if event.socket_id == 0 {
-            return;
+            return None;
         }
-
-        self.track_min_ts(event.ts);
 
         let event_name = match event.event_type.0 {
             // TCP packet events
@@ -1001,12 +1087,37 @@ impl NetworkRecorder {
             // TCP state change events
             x if x == packet_event_type::PACKET_TCP_STATE_CHANGE.0 => "TCP state_change",
             // Unknown event type - skip
-            _ => return,
+            _ => return None,
         };
+        Some(event_name)
+    }
 
-        if let Err(e) = self.stream_packet_event(&event, event_name) {
-            eprintln!("Warning: Failed to stream network packet event: {e}");
+    /// Append a consumer's prepared batch under the recorder lock — the
+    /// part of the packet path that needs the recorder: the socket record
+    /// on a socket's first sighting, the packet ids in arrival order, the
+    /// trace's minimum timestamp, then ONE collector call for the whole
+    /// batch (one collector lock, one buffer extend).
+    pub fn append_packet_batch(&mut self, batch: PreparedBatch) -> Result<()> {
+        let PreparedBatch {
+            mut records,
+            sockets,
+        } = batch;
+        if records.is_empty() {
+            return Ok(());
         }
+        if let Some(min_ts) = sockets.iter().map(|s| s.ts).min() {
+            self.track_min_ts(min_ts);
+        }
+        for (record, socket) in records.iter_mut().zip(&sockets) {
+            self.maybe_emit_socket_record(socket)?;
+            record.id = self.next_packet_id;
+            self.next_packet_id += 1;
+        }
+        let collector = self
+            .streaming_collector
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("Streaming collector not set in append_packet_batch"))?;
+        collector.add_network_packet_batch(records)
     }
 
     pub fn handle_epoll_event(&mut self, event: crate::systing_core::types::epoll_event_bpf) {
@@ -1235,7 +1346,7 @@ mod socket_record_emission_tests {
     /// nothing after that re-emits.
     #[test]
     fn upgrade_emits_once_after_portless_first_sight() {
-        let mut seen = HashMap::new();
+        let mut seen = SeenSockets::default();
         // First sight, pre-bind (connect-start): emit the port-less record.
         assert!(should_emit_socket_record(&mut seen, 42, portless()));
         // More pre-bind sightings: no re-emit.
@@ -1255,7 +1366,7 @@ mod socket_record_emission_tests {
     /// after that (ESTABLISHED→CLOSE_WAIT, →CLOSE) re-emits.
     #[test]
     fn upgrade_emits_once_after_peerless_first_sight() {
-        let mut seen = HashMap::new();
+        let mut seen = SeenSockets::default();
         assert!(should_emit_socket_record(&mut seen, 9, peerless()));
         assert!(!should_emit_socket_record(&mut seen, 9, peerless()));
         assert!(should_emit_socket_record(&mut seen, 9, full()));
@@ -1269,7 +1380,7 @@ mod socket_record_emission_tests {
     /// socket — emits exactly one record and never an upgrade.
     #[test]
     fn degraded_only_lifecycle_is_single_emission() {
-        let mut seen = HashMap::new();
+        let mut seen = SeenSockets::default();
         assert!(should_emit_socket_record(&mut seen, 11, peerless()));
         assert!(!should_emit_socket_record(&mut seen, 11, peerless()));
         assert!(!should_emit_socket_record(&mut seen, 11, portless()));
@@ -1281,7 +1392,7 @@ mod socket_record_emission_tests {
     /// sighting (a terminal transition) never re-emits.
     #[test]
     fn complete_first_sight_is_single_emission() {
-        let mut seen = HashMap::new();
+        let mut seen = SeenSockets::default();
         assert!(should_emit_socket_record(&mut seen, 7, full()));
         assert!(!should_emit_socket_record(&mut seen, 7, full()));
         assert!(!should_emit_socket_record(&mut seen, 7, portless()));
@@ -1292,7 +1403,7 @@ mod socket_record_emission_tests {
     /// Distinct sockets track independently.
     #[test]
     fn sockets_are_independent() {
-        let mut seen = HashMap::new();
+        let mut seen = SeenSockets::default();
         assert!(should_emit_socket_record(&mut seen, 1, portless()));
         assert!(should_emit_socket_record(&mut seen, 2, full()));
         assert!(should_emit_socket_record(&mut seen, 3, peerless()));
@@ -1300,5 +1411,423 @@ mod socket_record_emission_tests {
         assert!(!should_emit_socket_record(&mut seen, 2, portless()));
         assert!(should_emit_socket_record(&mut seen, 3, full()));
         assert!(!should_emit_socket_record(&mut seen, 3, full()));
+    }
+}
+
+/// Consumer-path benchmarks for the packets tier. Ignored by default: they
+/// measure, they do not assert. Run in release mode with `--nocapture`:
+///
+/// ```text
+/// cargo test --release --lib packet_consumer_bench -- --ignored --nocapture
+/// ```
+///
+/// The three legs split the userspace cost of one `packet_event`: the
+/// record build under the recorder (into a collector that only keeps the
+/// rows), the same path into the production `SharedCollector` +
+/// `StreamingParquetWriter` (the amortized encode plus the 200K-row flush
+/// stall), and the fan-in channel every ring's poller sends into.
+#[cfg(test)]
+mod packet_consumer_bench {
+    use super::*;
+    use crate::parquet::StreamingParquetWriter;
+    use crate::record::{InMemoryCollector, SharedCollector};
+    use crate::systing_core::types::{
+        network_address_family, network_protocol, packet_event, packet_event_type,
+    };
+    use std::sync::mpsc::sync_channel;
+    use std::time::{Duration, Instant};
+
+    /// A TX packet's four data-path events on a live socket pool: the shape
+    /// a busy host's capture records (every stage of every skb).
+    fn synth_event(i: u64) -> packet_event {
+        let mut e = packet_event::default();
+        let socket = 1 + (i / 4) % 4096;
+        e.ts = 1_000_000_000 + i * 700;
+        e.socket_id = socket;
+        e.netns_inum = 4_026_531_840;
+        e.event_type = match i % 4 {
+            0 => packet_event_type::PACKET_ENQUEUE,
+            1 => packet_event_type::PACKET_QDISC_ENQUEUE,
+            2 => packet_event_type::PACKET_QDISC_DEQUEUE,
+            _ => packet_event_type::PACKET_SEND,
+        };
+        e.protocol = network_protocol::NETWORK_TCP;
+        e.af = network_address_family::NETWORK_AF_INET;
+        e.src_addr[..4].copy_from_slice(&[10, 0, 0, 1]);
+        e.src_port = (33_000 + socket % 4096) as _;
+        e.dest_addr[..4].copy_from_slice(&[10, 0, 0, 2]);
+        e.dest_port = 443;
+        e.seq = ((i / 4) * 1448) as _;
+        e.length = 1448;
+        e.tcp_flags = 0x10;
+        e.cpu = (i % 192) as _;
+        e.sndbuf_used = 120_000;
+        e.sndbuf_limit = 4_194_304;
+        e.srtt_us = 210;
+        e.rttvar_us = 40;
+        e.snd_wnd = 65_535;
+        e.rcv_wnd = 65_535;
+        e.sk_wmem_alloc = 3_000;
+        e.tsq_limit = 1_048_576;
+        e.qdisc_backlog = 12;
+        e.qdisc_latency_us = 7;
+        e.skb_addr = 0xffff_9000_0000_0000 + i;
+        e
+    }
+
+    fn recorder_with(collector: Box<dyn RecordCollector + Send>) -> NetworkRecorder {
+        let mut rec = NetworkRecorder::new(Arc::new(UtidGenerator::new()), false);
+        rec.set_streaming_collector(collector);
+        rec
+    }
+
+    fn report(leg: &str, n: u64, took: Duration) {
+        let ns = took.as_nanos() as f64 / n as f64;
+        eprintln!(
+            "BENCH {leg}: {n} events in {:.3} s = {ns:.0} ns/event = {:.2} M events/s",
+            took.as_secs_f64(),
+            1e3 / ns
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn sizes() {
+        eprintln!(
+            "BENCH sizes: packet_event {} B, NetworkPacketRecord {} B",
+            std::mem::size_of::<packet_event>(),
+            std::mem::size_of::<NetworkPacketRecord>()
+        );
+    }
+
+    /// Leg 1: the record build under the recorder, rows kept in memory.
+    #[test]
+    #[ignore]
+    fn record_build_in_memory() {
+        const N: u64 = 1_000_000;
+        let mut rec = recorder_with(Box::new(InMemoryCollector::new()));
+        let events: Vec<packet_event> = (0..N).map(synth_event).collect();
+        let start = Instant::now();
+        for e in events {
+            rec.handle_packet_event(e);
+        }
+        report("record build -> InMemoryCollector", N, start.elapsed());
+        assert_eq!(rec.next_packet_id - 1, N as i64);
+    }
+
+    /// Leg 2: the production path — the shared collector's lock per record
+    /// and the parquet writer's 200K-row flushes (arrow batch build + ZSTD
+    /// encode) on the consumer's own thread. Prints the slowest single
+    /// `handle_packet_event` call, which is the flush stall.
+    #[test]
+    #[ignore]
+    fn record_build_to_parquet() {
+        const N: u64 = 2_000_000;
+        let dir = tempfile::TempDir::new().unwrap();
+        let writer = StreamingParquetWriter::new(dir.path()).unwrap();
+        let mut rec = recorder_with(Box::new(SharedCollector::new(Box::new(writer))));
+        let events: Vec<packet_event> = (0..N).map(synth_event).collect();
+        let mut worst = Duration::ZERO;
+        let mut stalls: Vec<Duration> = Vec::new();
+        let start = Instant::now();
+        for e in events {
+            let t = Instant::now();
+            rec.handle_packet_event(e);
+            let d = t.elapsed();
+            if d > Duration::from_millis(1) {
+                stalls.push(d);
+            }
+            worst = worst.max(d);
+        }
+        let took = start.elapsed();
+        report(
+            "record build -> SharedCollector(StreamingParquetWriter)",
+            N,
+            took,
+        );
+        eprintln!(
+            "BENCH consumer-side stalls: {} calls over 1 ms, worst {:.1} ms, sum {:.1} ms of {:.1} ms total",
+            stalls.len(),
+            worst.as_secs_f64() * 1e3,
+            stalls.iter().sum::<Duration>().as_secs_f64() * 1e3,
+            took.as_secs_f64() * 1e3
+        );
+        assert_eq!(rec.next_packet_id - 1, N as i64);
+        // Dropping the recorder finishes its collector: the encode lane
+        // drains what the consumer ran ahead of it and closes the file.
+        let start = Instant::now();
+        drop(rec);
+        let drained = start.elapsed();
+        eprintln!(
+            "BENCH lane drain + close after the last event: {:.1} ms; end-to-end {} events in {:.3} s = {:.2} M events/s",
+            drained.as_secs_f64() * 1e3,
+            N,
+            (took + drained).as_secs_f64(),
+            N as f64 / (took + drained).as_secs_f64() / 1e6
+        );
+    }
+
+    /// Leg 2b: the consumer shape the per-ring consumers run — the record
+    /// build with no lock, then one `append_packet_batch` per 4096 events
+    /// under the recorder (the socket-record probe, the ids, one collector
+    /// call), the parquet encode on the table's lane.
+    #[test]
+    #[ignore]
+    fn batch_path_to_parquet() {
+        const N: u64 = 2_000_000;
+        const BATCH: usize = 4096;
+        let dir = tempfile::TempDir::new().unwrap();
+        let writer = StreamingParquetWriter::new(dir.path()).unwrap();
+        let mut rec = recorder_with(Box::new(SharedCollector::new(Box::new(writer))));
+        let events: Vec<packet_event> = (0..N).map(synth_event).collect();
+        let mut build_time = Duration::ZERO;
+        let mut append_time = Duration::ZERO;
+        let mut worst_append = Duration::ZERO;
+        let start = Instant::now();
+        for chunk in events.chunks(BATCH) {
+            let t = Instant::now();
+            let prepared = NetworkRecorder::prepare_packet_batch(chunk);
+            build_time += t.elapsed();
+            let t = Instant::now();
+            rec.append_packet_batch(prepared).unwrap();
+            let d = t.elapsed();
+            append_time += d;
+            worst_append = worst_append.max(d);
+        }
+        let took = start.elapsed();
+        report(
+            "batch path: lock-free build + per-batch append -> lane",
+            N,
+            took,
+        );
+        eprintln!(
+            "BENCH batch split: build {:.0} ns/event (no lock), append {:.0} ns/event (under lock), worst append {:.1} ms",
+            build_time.as_nanos() as f64 / N as f64,
+            append_time.as_nanos() as f64 / N as f64,
+            worst_append.as_secs_f64() * 1e3
+        );
+        assert_eq!(rec.next_packet_id - 1, N as i64);
+        let start = Instant::now();
+        drop(rec);
+        let drained = start.elapsed();
+        eprintln!(
+            "BENCH lane drain + close after the last event: {:.1} ms; end-to-end {} events in {:.3} s = {:.2} M events/s",
+            drained.as_secs_f64() * 1e3,
+            N,
+            (took + drained).as_secs_f64(),
+            N as f64 / (took + drained).as_secs_f64() / 1e6
+        );
+    }
+
+    /// Leg 3: the fan-in channel as the pollers use it — one bounded
+    /// `sync_channel(100_000)` with P blocking producers and one consumer
+    /// draining `recv` + `try_iter().take(4096)` batches.
+    fn channel_leg(producers: u64, per_producer: u64) {
+        const CAPACITY: usize = 100_000;
+        const BATCH: usize = 4096;
+        let (tx, rx) = sync_channel::<packet_event>(CAPACITY);
+        let start = Instant::now();
+        let mut handles = Vec::new();
+        for p in 0..producers {
+            let tx = tx.clone();
+            handles.push(std::thread::spawn(move || {
+                for i in 0..per_producer {
+                    let e = synth_event(p * per_producer + i);
+                    if tx.send(e).is_err() {
+                        return;
+                    }
+                }
+            }));
+        }
+        drop(tx);
+        let consumer = std::thread::spawn(move || {
+            let mut n = 0u64;
+            let mut batch: Vec<packet_event> = Vec::with_capacity(BATCH);
+            while let Ok(first) = rx.recv() {
+                batch.push(first);
+                batch.extend(rx.try_iter().take(BATCH - 1));
+                n += batch.len() as u64;
+                batch.clear();
+            }
+            n
+        });
+        for h in handles {
+            h.join().unwrap();
+        }
+        let n = consumer.join().unwrap();
+        report(
+            &format!("sync_channel(100_000) {producers} producers -> 1 consumer"),
+            n,
+            start.elapsed(),
+        );
+        assert_eq!(n, producers * per_producer);
+    }
+
+    #[test]
+    #[ignore]
+    fn channel_fan_in_1_producer() {
+        channel_leg(1, 4_000_000);
+    }
+
+    #[test]
+    #[ignore]
+    fn channel_fan_in_8_producers() {
+        channel_leg(8, 500_000);
+    }
+
+    #[test]
+    #[ignore]
+    fn channel_fan_in_64_producers() {
+        channel_leg(64, 62_500);
+    }
+}
+
+#[cfg(test)]
+mod packet_batch_tests {
+    use super::*;
+    use crate::record::InMemoryCollector;
+    use crate::systing_core::types::{
+        network_address_family, network_protocol, packet_event, packet_event_type,
+    };
+    use crate::trace::{NetworkPacketRecord, NetworkSocketRecord};
+
+    fn event(
+        socket_id: u64,
+        event_type: packet_event_type,
+        src_port: u16,
+        ts: u64,
+    ) -> packet_event {
+        let mut src_addr = [0u8; 16];
+        src_addr[..4].copy_from_slice(&[10, 0, 0, 1]);
+        let mut dest_addr = [0u8; 16];
+        dest_addr[..4].copy_from_slice(&[10, 0, 0, 2]);
+        packet_event {
+            ts,
+            socket_id,
+            event_type,
+            protocol: network_protocol::NETWORK_TCP,
+            af: network_address_family::NETWORK_AF_INET,
+            src_addr,
+            src_port,
+            dest_addr,
+            dest_port: 443,
+            seq: 1000,
+            length: 1448,
+            tcp_flags: 0x18,
+            sndbuf_used: 4096,
+            sndbuf_limit: 65536,
+            srtt_us: 2500,
+            netns_inum: 4_026_531_840,
+            ..packet_event::default()
+        }
+    }
+
+    /// The mixed batch every test feeds: three sockets, one of them first
+    /// seen port-less (connect-start) and upgraded by its next event, an
+    /// event with no socket id and one of an unknown type in the middle.
+    fn mixed_events() -> Vec<packet_event> {
+        vec![
+            event(7, packet_event_type::PACKET_ENQUEUE, 0, 100),
+            event(7, packet_event_type::PACKET_SEND, 40_001, 110),
+            event(8, packet_event_type::PACKET_RCV_ESTABLISHED, 40_002, 120),
+            event(0, packet_event_type::PACKET_SEND, 40_003, 130),
+            event(9, packet_event_type(0xffff), 40_004, 140),
+            event(9, packet_event_type::PACKET_QDISC_ENQUEUE, 40_004, 150),
+            event(7, packet_event_type::PACKET_QDISC_DEQUEUE, 40_001, 160),
+        ]
+    }
+
+    fn collect(
+        feed: impl FnOnce(&mut NetworkRecorder, &[packet_event]),
+    ) -> (
+        Vec<NetworkPacketRecord>,
+        Vec<NetworkSocketRecord>,
+        Option<u64>,
+    ) {
+        let mut rec = NetworkRecorder::new(Arc::new(UtidGenerator::new()), false);
+        let collector = Box::new(InMemoryCollector::new());
+        rec.set_streaming_collector(collector);
+        let events = mixed_events();
+        feed(&mut rec, &events);
+        let min_ts = rec.min_timestamp();
+        let mut boxed = rec.streaming_collector.take().unwrap();
+        let data = boxed
+            .as_any_mut()
+            .and_then(|c| c.downcast_mut::<InMemoryCollector>())
+            .expect("the test collector is the in-memory one")
+            .data();
+        (
+            data.network_packets.clone(),
+            data.network_sockets.clone(),
+            min_ts,
+        )
+    }
+
+    /// The batch path (prepare with no lock, append under it) produces the
+    /// same packet rows, socket rows and minimum timestamp as feeding the
+    /// same events one at a time.
+    #[test]
+    fn batch_path_matches_single_event_path() {
+        let (single_packets, single_sockets, single_min) = collect(|rec, events| {
+            for e in events {
+                rec.handle_packet_event(*e);
+            }
+        });
+        let (batch_packets, batch_sockets, batch_min) = collect(|rec, events| {
+            let prepared = NetworkRecorder::prepare_packet_batch(events);
+            assert_eq!(prepared.len(), 5, "two events are dropped at preparation");
+            rec.append_packet_batch(prepared).unwrap();
+        });
+        assert_eq!(single_packets.len(), 5);
+        assert_eq!(batch_packets, single_packets);
+        assert_eq!(batch_sockets, single_sockets);
+        assert_eq!(batch_min, single_min);
+        assert_eq!(batch_min, Some(100));
+    }
+
+    /// Ids are assigned in arrival order and stay contiguous across
+    /// batches; the socket record is emitted once per socket plus the one
+    /// upgrade when a port-less first sighting is followed by a full one.
+    #[test]
+    fn ids_are_contiguous_across_batches_and_sockets_emit_once() {
+        let (packets, sockets, _) = collect(|rec, events| {
+            let (first, second) = events.split_at(3);
+            rec.append_packet_batch(NetworkRecorder::prepare_packet_batch(first))
+                .unwrap();
+            rec.append_packet_batch(NetworkRecorder::prepare_packet_batch(second))
+                .unwrap();
+        });
+        let ids: Vec<i64> = packets.iter().map(|p| p.id).collect();
+        assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+        let names: Vec<&str> = packets.iter().map(|p| p.event_type).collect();
+        assert_eq!(
+            names,
+            vec![
+                "TCP packet_enqueue",
+                "TCP packet_send",
+                "TCP packet_rcv_established",
+                "qdisc_enqueue",
+                "qdisc_dequeue"
+            ]
+        );
+        // Socket 7: the port-less record, then its upgrade; 8 and 9 once.
+        let by_socket: Vec<(i64, i32)> =
+            sockets.iter().map(|s| (s.socket_id, s.src_port)).collect();
+        assert_eq!(
+            by_socket,
+            vec![(7, 0), (7, 40_001), (8, 40_002), (9, 40_004)]
+        );
+    }
+
+    /// An empty batch is a no-op under the lock.
+    #[test]
+    fn empty_batch_is_a_no_op() {
+        let (packets, sockets, min_ts) = collect(|rec, _| {
+            rec.append_packet_batch(NetworkRecorder::prepare_packet_batch(&[]))
+                .unwrap();
+        });
+        assert!(packets.is_empty());
+        assert!(sockets.is_empty());
+        assert_eq!(min_ts, None);
     }
 }

--- a/src/parquet/lane.rs
+++ b/src/parquet/lane.rs
@@ -1,0 +1,512 @@
+//! An encode lane: the parquet encode of one table, off the thread that
+//! produces its rows.
+//!
+//! A `StreamingParquetWriter` flush used to build the arrow batch and run
+//! `ArrowWriter::write` — definition levels, the column encodings and the
+//! compression of every column — inline on the thread that called
+//! `add_*`. For the `network_packet` table that thread is the packet
+//! consumer: a 200,000-row flush cost it ≈140 ms during which every ring
+//! poller sat blocked on a full channel, and those flushes were 83 % of
+//! the consumer's time on a saturated host (the measurements are on the
+//! PR that introduced this module). The lane moves the whole flush: the
+//! producing thread hands the `Vec` of rows over a bounded channel and
+//! returns; the lane thread builds the arrow batch in parallel slices and
+//! fans the leaf columns out to a fixed set of column-encoder threads
+//! through parquet's parallel column-writer API, closing a row group every
+//! `row_group_rows` rows exactly where `ArrowWriter` closed one. The file
+//! that results carries the same schema, encodings, compression, row-group
+//! bounds and `ARROW:schema` metadata as the inline writer produced, so
+//! every reader is unchanged.
+//!
+//! Errors surface on the next `push` after the lane thread stopped and on
+//! `finish`, which also returns the first error any encoder hit.
+
+use std::io::Write;
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+use anyhow::{anyhow, Context, Result};
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use parquet::arrow::arrow_writer::{
+    compute_leaves, get_column_writers, ArrowColumnChunk, ArrowColumnWriter, ArrowLeafColumn,
+};
+use parquet::arrow::{add_encoded_arrow_schema_to_metadata, ArrowSchemaConverter};
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::types::SchemaDescriptor;
+
+/// Builds the arrow batch for a slice of rows.
+pub type BatchBuilder<R> = fn(&[R], &SchemaRef) -> Result<RecordBatch>;
+
+/// Flushed row batches the producing thread may run ahead of the lane by
+/// before its `push` blocks. Two 200,000-row batches of the widest record
+/// are under 200 MB; the backpressure is the point — a lane that cannot
+/// keep up shows as missed events in the trace, never as unbounded memory.
+const LANE_QUEUE: usize = 2;
+
+/// Leaf columns queued to one encoder thread before the lane thread blocks.
+const LEAF_QUEUE: usize = 64;
+
+/// Column-encoder threads for one lane on this host: one per sixteen CPUs,
+/// two at least, eight at most (a table has a few dozen columns; past eight
+/// encoders the batch build is the longer half).
+pub fn encode_workers() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| (n.get() / 16).clamp(2, 8))
+        .unwrap_or(2)
+}
+
+/// One table's encode lane. Created on the table's first flush, finished
+/// (or dropped, which finishes it) when the writer closes.
+pub struct EncodeLane<R: Send + Sync + 'static> {
+    table: String,
+    tx: Option<SyncSender<Vec<R>>>,
+    thread: Option<JoinHandle<Result<()>>>,
+    /// The lane thread's outcome once joined: `finish` and a `push` after
+    /// the lane stopped both report it.
+    outcome: Option<Result<(), String>>,
+}
+
+impl<R: Send + Sync + 'static> EncodeLane<R> {
+    /// Start the lane: the file writer, the arrow-to-parquet schema and the
+    /// `ARROW:schema` metadata are set up on the lane thread exactly as
+    /// `ArrowWriter::try_new` does.
+    pub fn start(
+        table: &str,
+        out: Box<dyn Write + Send>,
+        schema: SchemaRef,
+        props: WriterProperties,
+        build: BatchBuilder<R>,
+        workers: usize,
+        row_group_rows: usize,
+    ) -> Result<Self> {
+        let (tx, rx) = sync_channel::<Vec<R>>(LANE_QUEUE);
+        let name = format!("pq_{}", &table[..table.len().min(12)]);
+        let table_name = table.to_string();
+        let thread = std::thread::Builder::new()
+            .name(name)
+            .spawn(move || {
+                run_lane(
+                    &table_name,
+                    rx,
+                    out,
+                    schema,
+                    props,
+                    build,
+                    workers.max(1),
+                    row_group_rows.max(1),
+                )
+            })
+            .with_context(|| format!("spawning the encode lane for table {table}"))?;
+        Ok(Self {
+            table: table.to_string(),
+            tx: Some(tx),
+            thread: Some(thread),
+            outcome: None,
+        })
+    }
+
+    /// Hand a flushed batch to the lane. Blocks while `LANE_QUEUE` batches
+    /// are already queued; fails once the lane thread has stopped, with the
+    /// error that stopped it.
+    pub fn push(&mut self, rows: Vec<R>) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let sent = match &self.tx {
+            Some(tx) => tx.send(rows).is_ok(),
+            None => false,
+        };
+        if sent {
+            return Ok(());
+        }
+        // The receiver is gone: the lane thread exited. Its result says why.
+        self.tx = None;
+        match self.join() {
+            Ok(()) => Err(anyhow!(
+                "encode lane for table {} stopped before the writer finished",
+                self.table
+            )),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Close the lane: every queued batch is encoded, the row groups and the
+    /// file are closed. Returns the first error the lane or an encoder hit.
+    pub fn finish(mut self) -> Result<()> {
+        self.tx = None;
+        self.join()
+    }
+
+    /// Join the lane thread once; every later call repeats its outcome.
+    fn join(&mut self) -> Result<()> {
+        if let Some(thread) = self.thread.take() {
+            let outcome = match thread.join() {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(e)) => Err(format!("{e:#}")),
+                Err(_) => Err("the lane thread panicked".to_string()),
+            };
+            self.outcome = Some(outcome);
+        }
+        match &self.outcome {
+            Some(Ok(())) | None => Ok(()),
+            Some(Err(text)) => Err(anyhow!("encode lane for table {}: {text}", self.table)),
+        }
+    }
+}
+
+impl<R: Send + Sync + 'static> Drop for EncodeLane<R> {
+    fn drop(&mut self) {
+        if self.thread.is_some() {
+            self.tx = None;
+            if let Err(e) = self.join() {
+                eprintln!(
+                    "Error finishing the encode lane for table {}: {e}",
+                    self.table
+                );
+            }
+        }
+    }
+}
+
+/// The lane thread: batches in, one parquet file out.
+#[allow(clippy::too_many_arguments)]
+fn run_lane<R: Send + Sync + 'static>(
+    table: &str,
+    rx: Receiver<Vec<R>>,
+    out: Box<dyn Write + Send>,
+    schema: SchemaRef,
+    mut props: WriterProperties,
+    build: BatchBuilder<R>,
+    workers: usize,
+    row_group_rows: usize,
+) -> Result<()> {
+    add_encoded_arrow_schema_to_metadata(&schema, &mut props);
+    let props = Arc::new(props);
+    let parquet_schema = ArrowSchemaConverter::new()
+        .with_coerce_types(props.coerce_types())
+        .convert(&schema)
+        .with_context(|| format!("converting the arrow schema of table {table}"))?;
+    let mut file = SerializedFileWriter::new(out, parquet_schema.root_schema_ptr(), props.clone())
+        .with_context(|| format!("opening the parquet file of table {table}"))?;
+
+    let mut group: Option<RowGroup> = None;
+    for rows in rx {
+        if rows.is_empty() {
+            continue;
+        }
+        let batches = build_parallel(&rows, &schema, build, workers)?;
+        drop(rows);
+        if group.is_none() {
+            group = Some(RowGroup::open(
+                table,
+                &parquet_schema,
+                &props,
+                &schema,
+                workers,
+            )?);
+        }
+        let current = group.as_mut().expect("row group opened above");
+        let write_error = batches
+            .iter()
+            .find_map(|batch| current.write(&schema, batch).err());
+        let rows = current.rows;
+        if let Some(e) = write_error {
+            // A closed encoder channel means an encoder failed: its own
+            // error is the one to report, not the send that found it.
+            let failed = group.take().expect("row group open");
+            return Err(failed.abort().unwrap_or(e));
+        }
+        if rows >= row_group_rows {
+            let closing = group.take().expect("row group open");
+            closing.close_into(&mut file)?;
+        }
+    }
+    if let Some(closing) = group.take() {
+        closing.close_into(&mut file)?;
+    }
+    file.close()
+        .with_context(|| format!("closing the parquet file of table {table}"))?;
+    Ok(())
+}
+
+/// Build the arrow batches for `rows` in `workers` slices at once.
+fn build_parallel<R: Send + Sync>(
+    rows: &[R],
+    schema: &SchemaRef,
+    build: BatchBuilder<R>,
+    workers: usize,
+) -> Result<Vec<RecordBatch>> {
+    let chunk = rows.len().div_ceil(workers).max(1);
+    if rows.len() <= chunk {
+        return Ok(vec![build(rows, schema)?]);
+    }
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = rows
+            .chunks(chunk)
+            .map(|slice| scope.spawn(move || build(slice, schema)))
+            .collect();
+        handles
+            .into_iter()
+            .map(|h| h.join().map_err(|_| anyhow!("a batch builder panicked"))?)
+            .collect()
+    })
+}
+
+/// A column chunk tagged with its leaf index.
+type IndexedChunk = (usize, ArrowColumnChunk);
+
+/// One open row group: its leaf columns spread over the encoder threads.
+/// Leaf `i` belongs to encoder `i % n`, which holds its writers in leaf
+/// order, so the encoder finds it at `i / n`.
+struct RowGroup {
+    senders: Vec<SyncSender<(usize, ArrowLeafColumn)>>,
+    handles: Vec<JoinHandle<Result<Vec<IndexedChunk>>>>,
+    rows: usize,
+}
+
+impl RowGroup {
+    fn open(
+        table: &str,
+        parquet_schema: &SchemaDescriptor,
+        props: &Arc<WriterProperties>,
+        schema: &SchemaRef,
+        workers: usize,
+    ) -> Result<Self> {
+        let column_writers = get_column_writers(parquet_schema, props, schema)?;
+        let n = workers.clamp(1, column_writers.len().max(1));
+        let mut per_worker: Vec<Vec<ArrowColumnWriter>> = (0..n).map(|_| Vec::new()).collect();
+        for (i, writer) in column_writers.into_iter().enumerate() {
+            per_worker[i % n].push(writer);
+        }
+        let mut senders = Vec::with_capacity(n);
+        let mut handles = Vec::with_capacity(n);
+        for (k, writers) in per_worker.into_iter().enumerate() {
+            let (tx, rx) = sync_channel::<(usize, ArrowLeafColumn)>(LEAF_QUEUE);
+            let name = format!("pqc_{}_{k}", &table[..table.len().min(7)]);
+            let handle = std::thread::Builder::new()
+                .name(name)
+                .spawn(move || encode_columns(writers, k, n, rx))
+                .with_context(|| format!("spawning a column encoder for table {table}"))?;
+            senders.push(tx);
+            handles.push(handle);
+        }
+        Ok(Self {
+            senders,
+            handles,
+            rows: 0,
+        })
+    }
+
+    fn write(&mut self, schema: &SchemaRef, batch: &RecordBatch) -> Result<()> {
+        let n = self.senders.len();
+        let mut leaf = 0usize;
+        for (field, column) in schema.fields().iter().zip(batch.columns()) {
+            for levels in compute_leaves(field.as_ref(), column)? {
+                self.senders[leaf % n]
+                    .send((leaf, levels))
+                    .map_err(|_| anyhow!("a column encoder stopped"))?;
+                leaf += 1;
+            }
+        }
+        self.rows += batch.num_rows();
+        Ok(())
+    }
+
+    fn close_into<W: Write + Send>(self, file: &mut SerializedFileWriter<W>) -> Result<()> {
+        drop(self.senders);
+        let mut chunks: Vec<IndexedChunk> = Vec::new();
+        for handle in self.handles {
+            chunks.extend(
+                handle
+                    .join()
+                    .map_err(|_| anyhow!("a column encoder panicked"))??,
+            );
+        }
+        chunks.sort_by_key(|(i, _)| *i);
+        let mut row_group = file.next_row_group()?;
+        for (_, chunk) in chunks {
+            chunk.append_to_row_group(&mut row_group)?;
+        }
+        row_group.close()?;
+        Ok(())
+    }
+
+    /// Stop the encoders without writing the group: the first error one of
+    /// them stopped on, if any.
+    fn abort(self) -> Option<anyhow::Error> {
+        drop(self.senders);
+        self.handles
+            .into_iter()
+            .filter_map(|handle| match handle.join() {
+                Ok(Ok(_)) => None,
+                Ok(Err(e)) => Some(e),
+                Err(_) => Some(anyhow!("a column encoder panicked")),
+            })
+            .next()
+    }
+}
+
+/// One encoder thread (the `k`-th of `workers`): writes the leaves it is
+/// sent into its column writers, then closes them into column chunks
+/// tagged with their leaf index so the row group can append them in
+/// schema order.
+fn encode_columns(
+    mut writers: Vec<ArrowColumnWriter>,
+    k: usize,
+    workers: usize,
+    rx: Receiver<(usize, ArrowLeafColumn)>,
+) -> Result<Vec<IndexedChunk>> {
+    for (leaf, levels) in rx {
+        let slot = (leaf - k) / workers;
+        let writer = writers
+            .get_mut(slot)
+            .ok_or_else(|| anyhow!("no column writer for leaf {leaf}"))?;
+        writer.write(&levels)?;
+    }
+    writers
+        .into_iter()
+        .enumerate()
+        .map(|(slot, writer)| Ok((k + slot * workers, writer.close()?)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
+    use tempfile::TempDir;
+
+    #[derive(Clone)]
+    struct Row {
+        id: i64,
+        name: &'static str,
+    }
+
+    fn schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+        ]))
+    }
+
+    fn build(rows: &[Row], schema: &SchemaRef) -> Result<RecordBatch> {
+        let ids = Int64Array::from_iter_values(rows.iter().map(|r| r.id));
+        let names = StringArray::from_iter(rows.iter().map(|r| Some(r.name)));
+        Ok(RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(ids), Arc::new(names)],
+        )?)
+    }
+
+    fn read_back(path: &std::path::Path) -> (usize, Vec<i64>, usize) {
+        let file = File::open(path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let groups = builder.metadata().num_row_groups();
+        let reader = builder.build().unwrap();
+        let mut ids = Vec::new();
+        for batch in reader {
+            let batch = batch.unwrap();
+            let col = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .unwrap();
+            ids.extend(col.iter().map(|v| v.unwrap()));
+        }
+        (ids.len(), ids, groups)
+    }
+
+    /// Rows pushed in several batches come back whole, in order, with the
+    /// row groups closed at the configured bound and the arrow schema
+    /// carried in the file's metadata.
+    #[test]
+    fn round_trip_in_order_with_row_groups() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.parquet");
+        let out: Box<dyn Write + Send> = Box::new(File::create(&path).unwrap());
+        let props = WriterProperties::builder()
+            .set_max_row_group_size(250)
+            .build();
+        let mut lane = EncodeLane::start("t", out, schema(), props, build, 3, 250).unwrap();
+        for b in 0..7 {
+            let rows: Vec<Row> = (0..100)
+                .map(|i| Row {
+                    id: b * 100 + i,
+                    name: if i % 2 == 0 { "even" } else { "odd" },
+                })
+                .collect();
+            lane.push(rows).unwrap();
+        }
+        lane.push(Vec::new()).unwrap();
+        lane.finish().unwrap();
+
+        let (n, ids, groups) = read_back(&path);
+        assert_eq!(n, 700);
+        assert_eq!(ids, (0..700).collect::<Vec<i64>>());
+        // 700 rows in 100-row batches with a 250-row bound: groups close
+        // after the batch that reaches the bound — 300, 300, 100.
+        assert_eq!(groups, 3);
+        let file = File::open(&path).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        assert_eq!(builder.schema().as_ref(), schema().as_ref());
+    }
+
+    /// An empty lane still produces a well-formed file with no rows.
+    #[test]
+    fn empty_lane_writes_an_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("e.parquet");
+        let out: Box<dyn Write + Send> = Box::new(File::create(&path).unwrap());
+        let lane = EncodeLane::start(
+            "e",
+            out,
+            schema(),
+            WriterProperties::default(),
+            build,
+            2,
+            1000,
+        )
+        .unwrap();
+        lane.finish().unwrap();
+        let (n, _, groups) = read_back(&path);
+        assert_eq!(n, 0);
+        assert_eq!(groups, 0);
+    }
+
+    /// A sink that fails is reported by `finish`, not swallowed.
+    #[test]
+    fn a_failing_sink_surfaces_at_finish() {
+        struct Broken;
+        impl Write for Broken {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("disk gone"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        let out: Box<dyn Write + Send> = Box::new(Broken);
+        let mut lane = EncodeLane::start(
+            "b",
+            out,
+            schema(),
+            WriterProperties::default(),
+            build,
+            2,
+            10,
+        )
+        .unwrap();
+        let rows: Vec<Row> = (0..50).map(|i| Row { id: i, name: "x" }).collect();
+        // The first push may be accepted (the write happens on the lane);
+        // finish must fail either way.
+        let _ = lane.push(rows);
+        let err = lane.finish().unwrap_err();
+        assert!(format!("{err:#}").contains("disk gone"), "{err:#}");
+    }
+}

--- a/src/parquet/mod.rs
+++ b/src/parquet/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides functionality for reading and writing trace data
 //! in Parquet format.
 
+pub mod lane;
 pub mod sink;
 pub mod writer;
 

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -24,6 +24,7 @@ use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::schema::types::ColumnPath;
 
 use crate::network_recorder::{drop_reason_str, format_tcp_flags, tcp_state_name};
+use crate::parquet::lane::{encode_workers, EncodeLane};
 use crate::parquet::ParquetSink;
 use crate::record::RecordCollector;
 use crate::trace::{
@@ -165,7 +166,9 @@ pub struct StreamingParquetWriter {
     network_interface_writer: Option<TableWriter>,
     socket_connection_writer: Option<TableWriter>,
     network_syscall_writer: Option<TableWriter>,
-    network_packet_writer: Option<TableWriter>,
+    /// The network_packet table encodes off the flushing thread: see
+    /// [`EncodeLane`]. Started on the first flush, finished with the others.
+    network_packet_lane: Option<EncodeLane<NetworkPacketRecord>>,
     network_socket_writer: Option<TableWriter>,
     network_poll_writer: Option<TableWriter>,
     network_dns_writer: Option<TableWriter>,
@@ -288,7 +291,7 @@ impl StreamingParquetWriter {
             network_interface_writer: None,
             socket_connection_writer: None,
             network_syscall_writer: None,
-            network_packet_writer: None,
+            network_packet_lane: None,
             network_socket_writer: None,
             network_poll_writer: None,
             network_dns_writer: None,
@@ -864,25 +867,38 @@ impl StreamingParquetWriter {
         Ok(())
     }
 
-    // Flush network_packets buffer
+    // Flush network_packets buffer: the rows go whole to the table's encode
+    // lane (started here on the first flush) and this thread returns with a
+    // fresh buffer; the arrow build and the parquet encode run on the lane.
     fn flush_network_packets(&mut self) -> Result<()> {
         if self.network_packets.is_empty() {
             return Ok(());
         }
 
-        let schema = trace::network_packet_schema();
-        let writer = Self::get_or_create_writer(
-            &mut self.network_packet_writer,
-            &self.sink,
-            "network_packet",
-            schema.clone(),
-            &self.writer_props,
-        )?;
-
-        let batch = build_network_packet_batch(&self.network_packets, &schema)?;
-        writer.write(&batch)?;
-        self.network_packets.clear();
-        Ok(())
+        if self.network_packet_lane.is_none() {
+            let out = self
+                .sink
+                .open("network_packet")
+                .context("Failed to open parquet sink for table network_packet")?;
+            let lane = EncodeLane::start(
+                "network_packet",
+                out,
+                trace::network_packet_schema(),
+                self.writer_props.clone(),
+                build_network_packet_batch,
+                encode_workers(),
+                self.writer_props.max_row_group_size(),
+            )?;
+            self.network_packet_lane = Some(lane);
+        }
+        let rows = std::mem::replace(
+            &mut self.network_packets,
+            Vec::with_capacity(self.batch_size),
+        );
+        self.network_packet_lane
+            .as_mut()
+            .expect("lane started above")
+            .push(rows)
     }
 
     // Flush network_sockets buffer
@@ -1193,7 +1209,13 @@ impl StreamingParquetWriter {
         close_writer!(self.network_interface_writer);
         close_writer!(self.socket_connection_writer);
         close_writer!(self.network_syscall_writer);
-        close_writer!(self.network_packet_writer);
+        if let Some(lane) = self.network_packet_lane.take() {
+            if let Err(e) = lane.finish() {
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
         close_writer!(self.network_socket_writer);
         close_writer!(self.network_poll_writer);
         close_writer!(self.network_dns_writer);
@@ -1243,7 +1265,7 @@ impl Drop for StreamingParquetWriter {
             || self.network_interface_writer.is_some()
             || self.socket_connection_writer.is_some()
             || self.network_syscall_writer.is_some()
-            || self.network_packet_writer.is_some()
+            || self.network_packet_lane.is_some()
             || self.network_socket_writer.is_some()
             || self.network_poll_writer.is_some()
             || self.network_dns_writer.is_some()
@@ -1482,6 +1504,16 @@ impl RecordCollector for StreamingParquetWriter {
         Self::reserve_if_empty(&mut self.network_packets, self.batch_size);
         self.network_packets.push(record);
         self.total_records += 1;
+        if Self::should_flush(&self.network_packets, self.batch_size) {
+            self.flush_network_packets()?;
+        }
+        Ok(())
+    }
+
+    fn add_network_packet_batch(&mut self, records: Vec<NetworkPacketRecord>) -> Result<()> {
+        Self::reserve_if_empty(&mut self.network_packets, self.batch_size);
+        self.total_records += records.len();
+        self.network_packets.extend(records);
         if Self::should_flush(&self.network_packets, self.batch_size) {
             self.flush_network_packets()?;
         }
@@ -3688,5 +3720,152 @@ mod tests {
         assert!((samples[1].1 - 2_400.0).abs() < f64::EPSILON);
         assert_eq!(samples[2].0, 2);
         assert!((samples[2].1 - 2_500.0).abs() < f64::EPSILON);
+    }
+}
+
+/// Encode-side benchmark for the network_packet table: what one 200K-row flush
+/// costs on the thread that runs it, split into the arrow batch build and the
+/// parquet write (encode + compression). Ignored by default; run in release
+/// mode with `--nocapture`:
+///
+/// ```text
+/// cargo test --release --lib packet_encode_bench -- --ignored --nocapture
+/// ```
+#[cfg(test)]
+mod packet_encode_bench {
+    use super::*;
+    use std::time::Instant;
+    use tempfile::TempDir;
+
+    /// The record shape `NetworkRecorder::stream_packet_event` builds for a
+    /// TX data-path event (the send-buffer, RTT and TSQ fields set, the
+    /// diagnostic fields None), on a 4096-socket pool.
+    fn synth_record(i: i64) -> NetworkPacketRecord {
+        let socket = 1 + (i / 4) % 4096;
+        NetworkPacketRecord {
+            id: i + 1,
+            ts: 1_000_000_000 + i * 700,
+            socket_id: socket,
+            event_type: match i % 4 {
+                0 => "TCP packet_enqueue",
+                1 => "qdisc_enqueue",
+                2 => "qdisc_dequeue",
+                _ => "TCP packet_send",
+            },
+            seq: Some((i / 4) * 1448),
+            length: 1448,
+            tcp_flags: Some(0x10),
+            sndbuf_used: Some(120_000),
+            sndbuf_limit: Some(4_194_304),
+            sndbuf_fill_pct: Some(2),
+            is_retransmit: false,
+            retransmit_count: None,
+            rto_ms: None,
+            srtt_ms: Some(0),
+            rttvar_us: Some(40),
+            backoff: None,
+            is_zero_window_probe: false,
+            is_zero_window_ack: false,
+            probe_count: None,
+            snd_wnd: Some(65_535),
+            rcv_wnd: Some(65_535),
+            rcv_buf_used: None,
+            rcv_buf_limit: None,
+            window_clamp: None,
+            rcv_wscale: None,
+            icsk_pending: None,
+            icsk_timeout: None,
+            drop_reason: None,
+            drop_location: None,
+            qlen: None,
+            qlen_limit: None,
+            sk_wmem_alloc: Some(3_000),
+            tsq_limit: Some(1_048_576),
+            txq_state: None,
+            qdisc_state: None,
+            qdisc_backlog: Some(12),
+            skb_addr: Some(0x7fff_0000_0000 + i),
+            qdisc_latency_us: Some(7),
+            old_state: None,
+            new_state: None,
+        }
+    }
+
+    fn write_with(
+        props: WriterProperties,
+        batches: &[RecordBatch],
+        schema: &Arc<Schema>,
+        label: &str,
+    ) {
+        let dir = TempDir::new().unwrap();
+        let file = std::fs::File::create(dir.path().join("network_packet.parquet")).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props)).unwrap();
+        let rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        let start = Instant::now();
+        for b in batches {
+            writer.write(b).unwrap();
+        }
+        let wrote = start.elapsed();
+        let start = Instant::now();
+        writer.close().unwrap();
+        let closed = start.elapsed();
+        let bytes = std::fs::metadata(dir.path().join("network_packet.parquet"))
+            .unwrap()
+            .len();
+        eprintln!(
+            "BENCH write[{label}]: {rows} rows in {:.1} ms write + {:.1} ms close = {:.0} ns/row, {:.1} MB on disk",
+            wrote.as_secs_f64() * 1e3,
+            closed.as_secs_f64() * 1e3,
+            (wrote + closed).as_nanos() as f64 / rows as f64,
+            bytes as f64 / 1e6
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn flush_split() {
+        const ROWS: i64 = 200_000;
+        const BATCHES: usize = 5;
+        let records: Vec<NetworkPacketRecord> = (0..ROWS).map(synth_record).collect();
+        let schema = trace::network_packet_schema();
+
+        // The arrow batch build, on the flushing thread today.
+        let start = Instant::now();
+        let batch = build_network_packet_batch(&records, &schema).unwrap();
+        let built = start.elapsed();
+        eprintln!(
+            "BENCH build_network_packet_batch: {ROWS} rows in {:.1} ms = {:.0} ns/row",
+            built.as_secs_f64() * 1e3,
+            built.as_nanos() as f64 / ROWS as f64
+        );
+
+        let batches: Vec<RecordBatch> = (0..BATCHES).map(|_| batch.clone()).collect();
+
+        // The production properties (ZSTD-3, DELTA_BINARY_PACKED on the
+        // integer columns, 1M-row row groups).
+        write_with(
+            build_writer_properties(),
+            &batches,
+            &schema,
+            "production ZSTD-3",
+        );
+        // The same encodings at ZSTD-1.
+        let zstd1 = WriterProperties::builder()
+            .set_compression(Compression::ZSTD(ZstdLevel::try_new(1).unwrap()))
+            .set_max_row_group_size(1_000_000)
+            .build();
+        write_with(zstd1, &batches, &schema, "ZSTD-1 default encodings");
+        // LZ4_RAW: the codec floor.
+        let lz4 = WriterProperties::builder()
+            .set_compression(Compression::LZ4_RAW)
+            .set_max_row_group_size(1_000_000)
+            .build();
+        write_with(lz4, &batches, &schema, "LZ4_RAW default encodings");
+        // No compression: the encode alone.
+        let none = WriterProperties::builder()
+            .set_compression(Compression::UNCOMPRESSED)
+            .set_max_row_group_size(1_000_000)
+            .build();
+        write_with(none, &batches, &schema, "UNCOMPRESSED default encodings");
     }
 }

--- a/src/record/collector.rs
+++ b/src/record/collector.rs
@@ -105,6 +105,24 @@ pub trait RecordCollector {
     /// Add a network packet record.
     fn add_network_packet(&mut self, record: NetworkPacketRecord) -> Result<()>;
 
+    /// Add a consumer's whole batch of network packet records. The default
+    /// adds them one by one; a collector that pays a lock per call
+    /// ([`SharedCollector`]) or buffers toward a flush overrides it so a
+    /// packet consumer's 4096-event batch costs one call.
+    fn add_network_packet_batch(&mut self, records: Vec<NetworkPacketRecord>) -> Result<()> {
+        for record in records {
+            self.add_network_packet(record)?;
+        }
+        Ok(())
+    }
+
+    /// The collector as `Any`, so a test that handed an [`InMemoryCollector`]
+    /// to a recorder can read its rows back out of the trait object; the
+    /// writing collectors return `None`.
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        None
+    }
+
     /// Add a network socket record.
     fn add_network_socket(&mut self, record: NetworkSocketRecord) -> Result<()>;
 
@@ -377,6 +395,11 @@ impl RecordCollector for SharedCollector {
         self.lock().add_sched_batch(batch)
     }
 
+    fn add_network_packet_batch(&mut self, records: Vec<NetworkPacketRecord>) -> Result<()> {
+        // One acquisition per consumer batch, not one per packet.
+        self.lock().add_network_packet_batch(records)
+    }
+
     fn flush(&mut self) -> Result<()> {
         self.lock().flush()
     }
@@ -532,6 +555,15 @@ impl RecordCollector for InMemoryCollector {
     fn add_network_packet(&mut self, record: NetworkPacketRecord) -> Result<()> {
         self.data.network_packets.push(record);
         Ok(())
+    }
+
+    fn add_network_packet_batch(&mut self, records: Vec<NetworkPacketRecord>) -> Result<()> {
+        self.data.network_packets.extend(records);
+        Ok(())
+    }
+
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
     }
 
     fn add_network_socket(&mut self, record: NetworkSocketRecord) -> Result<()> {

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -1997,7 +1997,11 @@ struct RecorderChannels {
     cache_rx: Receiver<perf_counter_event>,
     probe_rx: Receiver<probe_event>,
     network_rx: Receiver<network_event>,
-    packet_rx: Receiver<packet_event>,
+    /// One receiver per `packet_ringbufs` ring, SPSC like the sched rings:
+    /// a shared channel with 64 producers was a ceiling of its own (≈1.5 M
+    /// events/s from send-side contention alone), and one consumer thread
+    /// behind it another; each ring's poller feeds its own consumer.
+    packet_rxs: Vec<Receiver<packet_event>>,
     epoll_rx: Receiver<epoll_event_bpf>,
     memory_rx: Receiver<memory_event>,
     marker_rx: Receiver<marker_event>,
@@ -2022,7 +2026,7 @@ fn spawn_recorder_threads(
         cache_rx,
         probe_rx,
         network_rx,
-        packet_rx,
+        packet_rxs,
         epoll_rx,
         memory_rx,
         marker_rx,
@@ -2123,32 +2127,36 @@ fn spawn_recorder_threads(
                 })?,
         );
 
-        // Packet recorder: processes packet events into network_recorder
-        let session_recorder = recorder.clone();
-        threads.push(
-            thread::Builder::new()
-                .name("packet_recorder".to_string())
-                .spawn(move || {
-                    let mut seen_tasks = TaskSightings::new();
-                    let mut batch: Vec<packet_event> = Vec::with_capacity(CONSUME_BATCH);
-                    while let Ok(first) = packet_rx.recv() {
-                        batch.push(first);
-                        batch.extend(packet_rx.try_iter().take(CONSUME_BATCH - 1));
-                        for event in &batch {
-                            if let Some(task_info) = event.next_task_info() {
-                                if seen_tasks.observe(task_info) {
-                                    session_recorder.maybe_record_task(task_info);
-                                }
+        // Packet consumers: one per packet ring. Each builds its batch's
+        // records OUTSIDE the recorder lock (the record build is the bulk of
+        // the per-event work) and takes the lock once per batch to append
+        // them — the socket records, the ids and one collector call. The
+        // parquet encode itself runs on the table's encode lane, never here.
+        for (i, packet_rx) in packet_rxs.into_iter().enumerate() {
+            let session_recorder = recorder.clone();
+            threads.push(
+                thread::Builder::new()
+                    .name(format!("packet_rec_{i}"))
+                    .spawn(move || {
+                        let mut batch: Vec<packet_event> = Vec::with_capacity(CONSUME_BATCH);
+                        while let Ok(first) = packet_rx.recv() {
+                            batch.push(first);
+                            batch.extend(packet_rx.try_iter().take(CONSUME_BATCH - 1));
+                            let prepared =
+                                network_recorder::NetworkRecorder::prepare_packet_batch(&batch);
+                            batch.clear();
+                            if prepared.is_empty() {
+                                continue;
+                            }
+                            let mut rec = session_recorder.network_recorder.lock().unwrap();
+                            if let Err(e) = rec.append_packet_batch(prepared) {
+                                eprintln!("Warning: Failed to stream network packet events: {e}");
                             }
                         }
-                        let mut rec = session_recorder.network_recorder.lock().unwrap();
-                        for event in batch.drain(..) {
-                            rec.handle_packet_event(event);
-                        }
-                    }
-                    0
-                })?,
-        );
+                        0
+                    })?,
+            );
+        }
 
         // Epoll recorder thread
         let session_recorder = recorder.clone();
@@ -3100,6 +3108,13 @@ fn setup_ringbuffers<'a>(
     // events and increments the missed-events counter, which is the intended
     // behaviour under sustained overload.
     const CHANNEL_CAPACITY: usize = 100_000;
+    // The packet rings get a channel each (below), so their capacity is per
+    // ring: a bounded channel initialises every slot when it is created, and
+    // 64 rings at CHANNEL_CAPACITY would commit ~1.4 GB of 216-byte slots at
+    // capture start. Two consume batches per ring (~1.8 MB) cover the
+    // consumer's lock waits; a longer stall means the lane is behind and
+    // missed events are the honest outcome.
+    const PACKET_CHANNEL_CAPACITY: usize = 2 * CONSUME_BATCH;
 
     let mut rings = Vec::new();
     // The sched/IRQ event stream gets one SPSC channel per ring instead of a
@@ -3113,7 +3128,8 @@ fn setup_ringbuffers<'a>(
     let (cache_tx, cache_rx) = sync_channel(CHANNEL_CAPACITY);
     let (probe_tx, probe_rx) = sync_channel(CHANNEL_CAPACITY);
     let (network_tx, network_rx) = sync_channel(CHANNEL_CAPACITY);
-    let (packet_tx, packet_rx) = sync_channel(CHANNEL_CAPACITY);
+    // Packet rings get one SPSC channel each too (see RecorderChannels).
+    let mut packet_rxs = Vec::new();
     let (epoll_tx, epoll_rx) = sync_channel(CHANNEL_CAPACITY);
     let (memory_tx, memory_rx) = sync_channel(CHANNEL_CAPACITY);
     let (marker_tx, marker_rx) = sync_channel(CHANNEL_CAPACITY);
@@ -3156,7 +3172,9 @@ fn setup_ringbuffers<'a>(
                     rings.push((poller, ring));
                 }
                 "packet_ringbufs" => {
-                    let ring = create_ring::<packet_event>(inner, packet_tx.clone())?;
+                    let (packet_tx, packet_rx) = sync_channel(PACKET_CHANNEL_CAPACITY);
+                    let ring = create_ring::<packet_event>(inner, packet_tx)?;
+                    packet_rxs.push(packet_rx);
                     rings.push((poller, ring));
                 }
                 "epoll_ringbufs" => {
@@ -3223,7 +3241,7 @@ fn setup_ringbuffers<'a>(
         probe_rx,
         memory_rx,
         network_rx,
-        packet_rx,
+        packet_rxs,
         epoll_rx,
         marker_rx,
         exec_event_rx,


### PR DESCRIPTION
## Summary

On a busy host the `network-packets` recorder loses most of its events to its own userspace consumer, not to the kernel ring buffers. Two 90-second captures on 192-vCPU hosts (`--only-recorder network --only-recorder network-packets --ringbuf-size-mib 256`, i.e. 64 rings × 32 MiB per family) reported `Missed packet events` of 81 M and 93 M while `Missed network events` on the same runs was 0. A ring-size step cannot help: at 216 B per event the 2 GiB budget is ≈10 s of that deficit.

This PR removes the two structural ceilings on the consumer side. No schema change; the parquet file that comes out has the same schema, encodings, compression, row-group bounds and metadata as before, so every reader is unchanged.

## What was measured

The ignored benchmarks added here (`network_recorder::packet_consumer_bench`, `parquet::writer::packet_encode_bench`; run with `cargo test --release --lib <name> -- --ignored --nocapture`) split the per-event cost on one 64-core host. The absolute numbers are that host's; the split is the finding.

Before:

- building one packet record: **177 ns/event** (5.6 M/s on one thread) — not the ceiling;
- the production path (record build → `SharedCollector` → `StreamingParquetWriter`): **865 ns/event = 1.16 M/s**, of which the ten inline `flush_network_packets` calls over 2 M events took 1,434 ms of 1,729 ms — **83 %** of the consumer's time was building the arrow batch and running the parquet encode for 200,000 rows on the consumer thread, under both the recorder mutex and the collector mutex, while every ring poller sat blocked on the channel (worst single stall 229 ms);
- the encode itself: `build_network_packet_batch` 267 ns/row + `ArrowWriter::write` 447 ns/row across ~45 columns on one thread, and the codec is not the cost (UNCOMPRESSED 395, LZ4_RAW 426, ZSTD-1 462, ZSTD-3 447 ns/row — ZSTD-3 with the existing encodings is both the fastest compressed form and the smallest file, so the writer properties stay as they are);
- the single `sync_channel(100_000)` that all 64 ring pollers sent into: 11 M events/s with one producer, 2.5 M/s with 8, **1.5 M/s with 64** — a ceiling from send-side contention alone.

## What changed

1. **One channel and one consumer thread per packet ring** (`packet_rec_{i}`), the shape the sched rings already use. No shared channel, no contention. Each ring's channel holds 8,192 events (two consume batches, ≈1.8 MB per ring): the single channel held 100,000, and the same capacity per ring would commit ≈1.4 GB at capture start on a 64-ring host, because the bounded channel initialises every slot when it is created.
2. **The record build runs with no lock.** `NetworkRecorder::prepare_packet_batch` turns a consumer's batch of events into packet records (id unassigned) plus the socket sightings they need; the consumer then takes the recorder once per batch for `append_packet_batch` — the first-sight socket records, the ids in arrival order, the minimum timestamp — and hands the whole batch to the collector through a new `RecordCollector::add_network_packet_batch` (one collector lock per batch instead of one per record; the default implementation loops, `SharedCollector` and the parquet writer override it). `handle_packet_event` is the same two calls with a batch of one, so the row-level behaviour is unchanged, and a test feeds the same mixed batch through both paths and compares the packet rows, socket rows and minimum timestamp.
3. **The parquet encode moves off the consumer into an encode lane** (`src/parquet/lane.rs`). `flush_network_packets` hands the flushed `Vec` of rows over a bounded channel and returns with a fresh buffer; the lane thread builds the arrow batch in parallel slices and fans the leaf columns out to a fixed set of column-encoder threads through parquet's parallel column-writer API (`get_column_writers` / `compute_leaves` / `ArrowColumnWriter`), closing a row group at the writer's `max_row_group_size` exactly where `ArrowWriter` closed one and writing the same `ARROW:schema` metadata. The lane's queue is bounded to two batches on purpose: a lane that cannot keep up shows as missed events in the trace, never as unbounded memory. A consumer that finds that queue full waits on it while holding the recorder lock, so the other consumers and the syscall path wait behind it exactly as they waited behind the inline flush — no new lock class, only a shorter and rarer wait. Errors surface on the next flush and at `finish`.

After, on the same host: the single-event path costs **267 ns/event** with **no consumer-side stall over 1 ms** (worst 0.3 ms), and the per-ring batch path **195 ns/event per consumer thread** (47 ns lock-free, 148 ns under the recorder lock), with the lane draining in ~15 ms after the last event.

## Tests

- `parquet::lane::tests`: rows pushed in several batches come back whole and in order with the row groups closed at the configured bound and the arrow schema in the file's metadata; an empty lane writes a well-formed empty file; a failing sink is reported at `finish`.
- `network_recorder::packet_batch_tests`: the batch path produces the same packet rows, socket rows and minimum timestamp as the single-event path on a mixed batch (three sockets, one port-less first sighting that is upgraded, an event with no socket id, an event of an unknown type); ids stay contiguous across batches; the socket record is emitted once per socket plus the one upgrade; an empty batch is a no-op.
- The existing socket-record emission tests and the full lib suite pass unchanged (596 passed, 8 ignored = the benchmarks); `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.
- Two integration targets run in a VM on the repo's 6.12 test kernel: `analyze_commands` (records a 3-second trace with the packets recorder on, validates the DuckDB, and runs every `systing-analyze` subcommand — `network socket-pairs` asserts a non-empty pair list, so packet rows went through the per-ring consumers, the encode lane and the parquet import) and `trace_validation`'s `test_e2e_network_suite` (the state tier on the shared recorder), both PASS. The VM cannot generate a packet rate that stresses the consumers; the before/after under real load is measured on the hosts that showed the loss.

## Open choices for the reader

- The lane is adopted for `network_packet` only. `sched_slice`, `thread_state` and `stack_sample` flush the same way and would take the same lane with a one-line change each; left for a follow-up so this change stays on the packets path.
- The remaining serialized cost per event is the recorder lock (the socket probe, the id, the buffer extend); reusing the flushed buffer's allocation instead of a fresh `Vec` per flush is the next trim if a host still runs ahead of it.
- Kernel-side work (a leaner per-packet event, folding the same-CPU stage pairs) is a separate change with reader implications and is not in this PR.
