### PR TITLE
pystacks: skip CPython 3.12+ entry frames instead of emitting "[Frame Error]"

### DIFF
--- a/src/pystacks/bpf/pystacks.bpf.c
+++ b/src/pystacks/bpf/pystacks.bpf.c
@@ -164,11 +164,29 @@ struct sample_state_t {
   uint64_t cur_cpu;
   void* frame_ptr;
   bool sync_use_shadow_frame;
+  /* The frame just visited by pystacks_get_frame_data was a CPython 3.12+
+   * entry ("shim") frame: nothing was read from it and no symbol is to be
+   * emitted for it. */
+  bool frame_skipped;
   char long_file_name[BPF_LIB_FILE_NAME_TRYGET];
   struct pystacks_symbol sym;
   struct pystacks_line_table linetable;
   int32_t lasti;
 };
+
+/*
+ * _PyInterpreterFrame.owner values whose frame carries no code object.
+ * CPython 3.12+ pushes an entry ("shim") frame onto the frame chain for every
+ * entry into _PyEval_EvalFrameDefault, i.e. at every C -> Python re-entry
+ * (PyObject_Call from C, a bound method's __call__, functools.partial, ...):
+ * owner = FRAME_OWNED_BY_CSTACK (3) and f_executable = None. 3.14 renames
+ * that value FRAME_OWNED_BY_INTERPRETER (3) and adds FRAME_OWNED_BY_CSTACK
+ * (4); both are non-Python frames. The values below it (THREAD 0,
+ * GENERATOR 1, FRAME_OBJECT 2) are real frames. Reading the (None) code
+ * object of a shim frame yields a "[Frame Error]" placeholder and spends a
+ * slot of the stack budget, so such frames are skipped instead.
+ */
+#define PYSTACKS_FIRST_NON_PYTHON_FRAME_OWNER 3
 
 struct {
   __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -678,10 +696,33 @@ __noinline bool pystacks_get_frame_data(int pid) {
     return false;
   }
 
-  void* code_ptr =
-      get_code_ptr(state->frame_ptr, offsets, use_shadow_frame, task);
+  /*
+   * CPython 3.12+ interleaves entry ("shim") frames with the real ones on
+   * the `previous` chain; they carry no code object (see
+   * PYSTACKS_FIRST_NON_PYTHON_FRAME_OWNER). Read the frame's owner first
+   * and step over such a frame without reading names for it.
+   */
+  state->frame_skipped = false;
+  if (!use_shadow_frame && offsets->PyVersion_major >= 3 &&
+      offsets->PyVersion_minor >= 12 &&
+      offsets->PyFrameObject_owner != BPF_LIB_DEFAULT_FIELD_OFFSET) {
+    uint8_t owner = 0;
+    if (bpf_probe_read_user_task(
+            &owner,
+            sizeof(owner),
+            state->frame_ptr + offsets->PyFrameObject_owner,
+            task) == 0 &&
+        owner >= PYSTACKS_FIRST_NON_PYTHON_FRAME_OWNER) {
+      state->frame_skipped = true;
+    }
+  }
 
-  get_names(state, state->frame_ptr, code_ptr, use_shadow_frame, task);
+  if (!state->frame_skipped) {
+    void* code_ptr =
+        get_code_ptr(state->frame_ptr, offsets, use_shadow_frame, task);
+
+    get_names(state, state->frame_ptr, code_ptr, use_shadow_frame, task);
+  }
 
   int ret_code = 0;
 
@@ -869,7 +910,9 @@ __hidden int walk_and_load_py_stack(
   for (; i < stack_max_len && i < BPF_LIB_MAX_STACK_DEPTH &&
        (last_frame_read = pystacks_get_frame_data(pid));
        ++i) {
-    add_symbol_to_buffer(py_msg);
+    if (!state->frame_skipped) {
+      add_symbol_to_buffer(py_msg);
+    }
   }
 
   set_py_stack_status(

--- a/src/pystacks/bpf/pystacks.bpf.c
+++ b/src/pystacks/bpf/pystacks.bpf.c
@@ -907,7 +907,15 @@ __hidden int walk_and_load_py_stack(
   bool last_frame_read = false;
   int pid = task ? BPF_CORE_READ(task, pid) : 0;
 
-  for (; i < stack_max_len && i < BPF_LIB_MAX_STACK_DEPTH &&
+  /*
+   * Bound the walk on emitted symbols rather than on visited frames, so a
+   * stack of N Python frames interleaved with shim frames still yields up
+   * to stack_max_len symbols. The visited-frame bound stays for the
+   * verifier; a shim frame never follows another shim frame on the chain
+   * (each hosts at least one real frame above it), so at most every other
+   * visited frame is skipped and twice the symbol budget covers the walk.
+   */
+  for (; i < 2 * BPF_LIB_MAX_STACK_DEPTH && py_msg->stack_len < stack_max_len &&
        (last_frame_read = pystacks_get_frame_data(pid));
        ++i) {
     if (!state->frame_skipped) {
@@ -919,7 +927,7 @@ __hidden int walk_and_load_py_stack(
       &py_msg->stack_status,
       (long)state->frame_ptr,
       last_frame_read,
-      (i == stack_max_len - 1) /* is_final_iteration */);
+      (py_msg->stack_len == stack_max_len - 1) /* is_final_iteration */);
 
   return py_msg->header.len;
 }


### PR DESCRIPTION
## Summary

Python stack walking on CPython 3.12+ emits a `[Frame Error]` placeholder
frame at every C → Python re-entry and spends a slot of the stack budget
on it. The placeholder is CPython's entry ("shim") frame; this PR makes
the walker step over those frames and bounds the walk on emitted symbols
so deep stacks get their depth back.

Measured on production Python 3.13 workloads (a 20-minute window of CPU
samples from two large production populations): 99 % of Python-bearing stacks carry
at least one `[Frame Error]` frame, typical stacks carry 5–11, deep ones
up to 126; the placeholder is 20–34 % of all Python frames recorded; and
1.5–4.6 % of Python stacks sit at the 127-frame budget with shim frames
inside, i.e. their real outer frames were truncated away. An example
stack (trimmed) shows where they land:

```
…
:tenacity.__init__:Retrying.__call__ (python) [__init__.py:473]
:[Frame Error] (python) [unknown]
:tenacity.__init__:BaseRetrying.wraps.<locals>.wrapped_f (python) [__init__.py:331]
…
:requests.sessions:Session.send (python) [sessions.py:706]
:[Frame Error] (python) [unknown]
:requests.sessions:Session.request (python) [sessions.py:592]
…
```

## The mechanism

Since 3.12, `_PyEval_EvalFrameDefault` pushes an entry frame onto the
`previous` chain each time it is entered — every call into Python from C
(`PyObject_Call`, a bound method's `__call__`, `functools.partial`,
decorators implemented in C, …). That frame is owned by the C stack —
`owner = FRAME_OWNED_BY_CSTACK` (3) in 3.12 and 3.13; 3.14 renames the
value `FRAME_OWNED_BY_INTERPRETER` and adds `FRAME_OWNED_BY_CSTACK` = 4 —
and its `f_executable` is `None` (`Include/internal/pycore_frame.h`,
`pycore_interpframe_structs.h`).

`pystacks_get_frame_data` walked every frame on the chain as a
code-bearing frame: the code pointer read yields `None`, the qualname
pointer read from it fails the address check, and `get_names` writes
`[Frame Error]` with an unknown file, after which `add_symbol_to_buffer`
spends one of the `stack_max_len` (127) slots. The `owner` offset was
already resolved per version (`PyFrameObject_owner` =
`PY_INTERP_FRAME_OWNER`: 70 / 70 / 74 for 3.12 / 3.13 / 3.14) but never
read by the BPF side.

## The fix

Two commits, one BPF file (`src/pystacks/bpf/pystacks.bpf.c`), no Rust,
no schema, no map, no new program:

1. **Skip shim frames.** For interpreter frames on 3.12+,
   `pystacks_get_frame_data` reads the frame's `owner` first and, when it
   is `FRAME_OWNED_BY_CSTACK` or above, marks the frame skipped: no code
   object or name reads, no symbol emitted, the walk follows `previous`
   as before. Frames owned by a thread, a generator or a frame object
   are real frames and unchanged; Python ≤ 3.11 (no shim frames on the
   chain) and the shadow-frame path are untouched.
2. **Bound the walk on emitted symbols.** The loop terminates on
   `py_msg->stack_len < stack_max_len` rather than on visited frames, so
   a stack of N real frames interleaved with shim frames still yields up
   to `stack_max_len` symbols; the visited-frame bound stays for the
   verifier at twice the symbol budget (a shim frame never follows
   another on the chain — each hosts at least one real frame above it —
   so at most every other visited frame is skipped).

## Validation

- **Compile**: the pystacks BPF object compiled with the build.rs recipe
  (`-g -O2 -target bpf -mcpu=v3 -fwrapv`, the pinned flags) for x86_64
  and aarch64 at the merge base and on this branch; the branch's
  `pystacks_get_frame_data` carries the one-byte owner read and the `< 3`
  compare feeding the skip, `walk_and_load_py_stack` the emitted-symbol
  test. `cargo fmt -- --check` clean (no Rust changed).
- **Load and runtime (VM, observed on this branch's bytes applied to the
  v1.17.7 source — the pystacks tree is identical at v1.17.8)**: an x86_64
  KVM guest on a 6.12.93 kernel with BTF. Load: `every_shape_loads` 34 of
  34 shapes loaded, no verifier refusal; the pystacks-on shape loaded in
  270.8 ms (the unpatched control in the same recipe: 431.3 ms on a
  different host — no cost signal from commit 2's doubled visited bound).
  Runtime: a python 3.13.13 workload (`spin.py`) under
  `systing --duration 3 --sw-event --collect-pystacks`, patched vs
  unpatched — samples carrying a `[Frame Error]` frame **0 of 3,129**
  (unpatched: 2,998 of 3,139, i.e. every Python-bearing sample); samples
  with a `.py` frame 3,004 of 3,129 (96.0 %) vs 2,998 of 3,139 (95.5 %);
  the hot function `spin_hot_loop_m4` in 3,004 samples with both source
  lines vs 2,998; `with_pystack=3004 without_pystack=125 unknown=0`
  vs `2998 / 141 / 0`; the walker's per-event `stack_len` 2 vs 3 (the
  shim slot gone); distinct Python frames 3 vs 4 (the placeholder entry
  gone; the native frame counts differ by run noise only).
- **aarch64 (observed)**: the same patch on top of the aarch64 pystacks
  TLS fix (a separate PR; without it aarch64 yields no Python frames at
  all), in an emulated aarch64 guest on the same 6.12.93 kernel with BTF:
  `every_shape_loads` 34 of 34, no verifier refusal, the pystacks-on
  shape in 15.1 s under emulation (17.3 s with the TLS fix alone); the
  python 3.13.13 workload — samples carrying a `[Frame Error]` frame
  **0 of 2,691** (TLS fix alone: 2,637 of 2,905, every Python-bearing
  sample); `.py` frames 2,377 of 2,691 (88.3 %) vs 2,637 of 2,905
  (90.8 %); `spin_hot_loop_m4` in 2,377 samples with both lines vs 2,637;
  `stack_len` 2 vs 3 per event; distinct Python frames 3 vs 4. The
  Python-bearing share moves +0.5 pt on x86_64 and −2.5 pt on emulated
  aarch64 between runs of different length — run noise in both
  directions; the one real reclassification is a sample caught mid-entry
  whose chain holds only a shim frame, which now reads as no Python
  stack instead of a lone `[Frame Error]`.
- **First contact after release**: the `[Frame Error]` share of Python
  frames on the populations above goes to 0 and the at-budget share
  drops.

Note: the `[Frame Error]` text stays for the case it was written for — a
frame whose code object genuinely cannot be read.
