### PR TITLE
test: allow the TIME_WAIT programs unselected only where the kernel lacks a hooked function

### DIFF
--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -342,7 +342,7 @@ const NETWORK_TW_KPROBE_PROGRAMS: &[&str] = &[
 /// (b334b924c9b7) — a 6.6-series kernel lacks it, and before this gate a
 /// network capture on such a node failed its every attach (the whole
 /// capture, CPU lane included) rather than running without the leg.
-const NETWORK_TW_SYMBOLS: &[&str] = &[
+pub const NETWORK_TW_SYMBOLS: &[&str] = &[
     "tcp_time_wait",
     "inet_twsk_hashdance_schedule",
     "inet_twsk_deschedule_put",
@@ -1145,7 +1145,7 @@ fn probe_memory_kernel_legs(opts: &Config, kernel: &KernelSymbols) -> MemoryKern
 /// Which of `names` /proc/kallsyms lists as text symbols (`t`/`T`). An
 /// unreadable kallsyms reads as "none present", which turns the legs off
 /// rather than failing the capture.
-fn kallsyms_has_funcs(names: &[&str]) -> HashSet<String> {
+pub fn kallsyms_has_funcs(names: &[&str]) -> HashSet<String> {
     let mut found = HashSet::new();
     let Ok(contents) = fs::read_to_string("/proc/kallsyms") else {
         return found;

--- a/tests/bpf_load_shapes.rs
+++ b/tests/bpf_load_shapes.rs
@@ -30,7 +30,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use systing::bpf_load_shapes::{coverage_gaps, ranges, shape_table, LoadReport};
-use systing::systing_core::bpf_load_probe;
+use systing::systing_core::{bpf_load_probe, kallsyms_has_funcs, NETWORK_TW_SYMBOLS};
 
 /// Instructions known to be unreachable at every shipping shape, with the
 /// reason. Add a row only with the reason; the entry is `(program, ranges)`
@@ -60,6 +60,22 @@ const SELECTED_ELSEWHERE: &[(&str, &str)] = &[
         "systing_rss_stat_btf",
         "loads only on a kernel whose BTF carries the rss_stat tracepoint; the classic twin loads elsewhere",
     ),
+];
+
+/// Programs of a kernel leg the recorder itself switches off on a kernel that
+/// lacks one of the leg's hooked functions (`tw_off = nosym`): the network
+/// shapes select them wherever the functions exist and no shape selects them
+/// where one is missing. They are allowed unselected ONLY on a kernel that
+/// lacks one of the functions; on a kernel that has them all, an unselected
+/// program here is a real finding. `inet_twsk_hashdance_schedule` exists from
+/// 6.11 (b334b924c9b7), so the 6.6 series takes this branch.
+const SELECTED_WHEN_KERNEL_HAS: &[(&str, &[&str])] = &[
+    ("tcp_time_wait_fentry", NETWORK_TW_SYMBOLS),
+    ("tcp_time_wait_entry", NETWORK_TW_SYMBOLS),
+    ("inet_twsk_hashdance_schedule_fentry", NETWORK_TW_SYMBOLS),
+    ("inet_twsk_hashdance_schedule_entry", NETWORK_TW_SYMBOLS),
+    ("inet_twsk_deschedule_put_fentry", NETWORK_TW_SYMBOLS),
+    ("inet_twsk_deschedule_put_entry", NETWORK_TW_SYMBOLS),
 ];
 
 fn allowed(program: &str) -> Option<(&'static str, &'static str)> {
@@ -127,10 +143,30 @@ fn selection_findings(reports: &[(String, LoadReport)]) -> Vec<String> {
             if selected_somewhere {
                 continue;
             }
-            match SELECTED_ELSEWHERE.iter().find(|(name, _)| *name == p.name) {
-                Some((_, why)) => eprintln!("[selection] {} selected by no shape ({why})", p.name),
-                None => never_selected.push(p.name.clone()),
+            if let Some((_, why)) = SELECTED_ELSEWHERE.iter().find(|(name, _)| *name == p.name) {
+                eprintln!("[selection] {} selected by no shape ({why})", p.name);
+                continue;
             }
+            if let Some((_, symbols)) = SELECTED_WHEN_KERNEL_HAS
+                .iter()
+                .find(|(name, _)| *name == p.name)
+            {
+                let present = kallsyms_has_funcs(symbols);
+                let missing: Vec<&str> = symbols
+                    .iter()
+                    .copied()
+                    .filter(|s| !present.contains(*s))
+                    .collect();
+                if !missing.is_empty() {
+                    eprintln!(
+                        "[selection] {} selected by no shape (this kernel lacks {}, so the recorder keeps the leg off)",
+                        p.name,
+                        missing.join(", ")
+                    );
+                    continue;
+                }
+            }
+            never_selected.push(p.name.clone());
         }
     }
     if never_selected.is_empty() {


### PR DESCRIPTION
## Summary

The load-shape gate `every_shape_loads` requires every program in the object to be selected by some shape, or documented in `SELECTED_ELSEWHERE`. On a 6.6-series kernel it failed naming six programs — the network recorder's TIME_WAIT leg (`tcp_time_wait`, `inet_twsk_hashdance_schedule`, `inet_twsk_deschedule_put`, each as a kprobe and as its fentry twin) — although every selected program loaded: the recorder switches that leg off on a kernel that lacks one of the three hooked functions (`inet_twsk_hashdance_schedule` exists from 6.11, b334b924c9b7), so no shape selects the six there.

This change teaches the gate the recorder's own rule instead of a blanket exemption.

## What changes

- `src/systing_core.rs`: `NETWORK_TW_SYMBOLS` and `kallsyms_has_funcs` become `pub` (a `const` slice and a read-only `/proc/kallsyms` reader; no runtime behaviour changes).
- `tests/bpf_load_shapes.rs`: a new `SELECTED_WHEN_KERNEL_HAS` list names the six programs with the symbols the leg needs. A program in it that no shape selected is allowed — reported under `[selection]` with the missing function named — only when the running kernel lacks one of those functions. On a kernel that has all three, an unselected TIME_WAIT program remains a finding, as before.

A static `SELECTED_ELSEWHERE` row would have reported the six on every kernel and let a regression that dropped the leg where it must load pass silently; the kernel-conditional form keeps that regression visible.

## Verified

- In a guest on a 6.6.97 kernel: 34/34 shapes loaded, 0 verifier rejections, the six programs reported `[selection] … (this kernel lacks inet_twsk_hashdance_schedule, so the recorder keeps the leg off)`, `test result: ok`.
- In a guest on a 6.12.85 kernel: 34/34 shapes loaded, every program selected, the new allowance never consulted, `test result: ok`.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and the lib tests (590 passed) clean.

Before this change the same 6.6.97 guest run loaded 34/34 shapes and failed only on the six unselected programs.

## Notes

- The reader's failure mode is shared with the recorder by construction: an unreadable `/proc/kallsyms` reads as "no symbol present" on both sides (the leg off; the six allowed unselected).
- The change is test-only in effect; it needs no schema or version bump.
