### PR TITLE
symbolize: never hand a gVisor pool-memfd address to the process source

### DIFF
--- a/src/sandbox_maps.rs
+++ b/src/sandbox_maps.rs
@@ -227,6 +227,30 @@ impl ProcessMaps {
         self.gvisor_exe || self.gvisor_memfd
     }
 
+    /// Whether `addr` lies in a mapping of one of gVisor's memory pools
+    /// (`runsc-memory`, `systrap-memory` — [`GVISOR_MEMFDS`]).
+    ///
+    /// Such an address must never be handed to a symbolizer as a live
+    /// process address: the mapping's `map_files` link opens the pool memfd
+    /// itself — for `runsc-memory` the sandbox's entire MemoryFile, every
+    /// guest page of every process in it, gigabytes — which is not an ELF.
+    /// A symbolizer that resolves the address through the process's maps
+    /// opens that file and parses it from byte 0; whenever the pool's first
+    /// page happens to hold an ELF header (guest images live in the same
+    /// pool), the "symbol tables" it builds are read out of guest memory,
+    /// bounded only by the pool's size. An island's identity comes from its
+    /// file-backed neighbors ([`Self::bridge_for`]) or the guest's own maps
+    /// instead, so skipping the process source loses nothing.
+    ///
+    /// Only the pools count. The sandbox binary that runsc re-execs from a
+    /// memfd (`/memfd:runsc (deleted)`) is a real ELF and keeps the ordinary
+    /// path — the test is the memfd's name, never `memfd:` as a class.
+    pub fn is_pool_backed(&self, addr: u64) -> bool {
+        self.entry_for(addr).is_some_and(|e| {
+            matches!(&e.backing, Backing::Memfd(name) if GVISOR_MEMFDS.contains(&name.as_str()))
+        })
+    }
+
     /// Executable file-backed ranges of this process — for a systrap stub,
     /// the fragments of guest text it maps directly. Used as the
     /// fingerprint for correlating a stub to the guest process it mirrors
@@ -616,6 +640,76 @@ mod tests {
             "foo",
         );
         assert!(!pm_plain.is_gvisor());
+    }
+
+    /// The pool test keys on the memfd's NAME: islands of `runsc-memory`
+    /// and pages of `systrap-memory` are pool-backed; the sandbox binary
+    /// runsc re-execs from a memfd named `runsc` is a real ELF and is not;
+    /// file-backed, anonymous, special and unmapped addresses are not.
+    #[test]
+    fn test_is_pool_backed_names_the_pools_only() {
+        // The Sentry's own text — `/proc/self/exe` re-exec'd from a memfd —
+        // beside a stub's islands, in one maps text.
+        let maps = "\
+64000-69000 r-xs 3ff26000 00:01 4                          /memfd:runsc-memory (deleted)
+400000-4c2000 r-xs 00000000 00:13 426                      /root/bin/guestbox
+4c2000-4c3000 r-xs 3ff1f000 00:01 4                        /memfd:runsc-memory (deleted)
+4c3000-4cd000 r-xs 000c3000 00:13 426                      /root/bin/guestbox
+711000-714000 rw-s 3fe00000 00:01 4                        /memfd:runsc-memory (deleted)
+5600000-8a00000 r-xp 00000000 00:01 9                      /memfd:runsc (deleted)
+7fa398efc000-7fa398eff000 r-xp 00000000 00:00 0
+7fee63d08000-7fee63d09000 r--s 3fffe000 00:01 3            /memfd:systrap-memory (deleted)
+7ffd1c000000-7ffd1c021000 rw-p 00000000 00:00 0                          [stack]";
+        let pm = ProcessMaps::parse(510, maps, "exe");
+        assert!(pm.is_gvisor());
+
+        // Pool islands and pages, executable or not.
+        assert!(
+            pm.is_pool_backed(0x64000),
+            "usertrap trampolines below the image"
+        );
+        assert!(
+            pm.is_pool_backed(0x4c2800),
+            "a patched-syscall island inside guest text"
+        );
+        assert!(pm.is_pool_backed(0x711000), "a writable pool mapping");
+        assert!(
+            pm.is_pool_backed(0x7fee63d08010),
+            "a sysmsg page of systrap-memory"
+        );
+
+        // Everything else keeps the ordinary path.
+        assert!(!pm.is_pool_backed(0x401000), "file-backed guest text");
+        assert!(
+            !pm.is_pool_backed(0x4c3000),
+            "the file fragment right after an island"
+        );
+        assert!(
+            !pm.is_pool_backed(0x5600100),
+            "the runsc binary's own memfd is a real ELF, never a pool"
+        );
+        assert!(!pm.is_pool_backed(0x7fa398efc000), "anonymous");
+        assert!(!pm.is_pool_backed(0x7ffd1c000100), "[stack]");
+        assert!(!pm.is_pool_backed(0x4c3000 + 0x20000), "unmapped");
+        assert!(
+            !pm.is_pool_backed(0x4c2000 - 1),
+            "the byte before an island is guest text"
+        );
+        assert!(
+            pm.is_pool_backed(0x4c3000 - 1),
+            "an island's last byte is pool"
+        );
+
+        // A non-gVisor process with an unrelated exec memfd (a JIT's code
+        // file) is untouched: only the two gVisor pool names count.
+        let jit = ProcessMaps::parse(
+            7,
+            "400000-500000 r-xp 00000000 08:01 42 /usr/bin/node\n\
+             7f0000000000-7f0000100000 r-xp 00000000 00:01 11 /memfd:jit-code (deleted)",
+            "node",
+        );
+        assert!(!jit.is_gvisor());
+        assert!(!jit.is_pool_backed(0x7f0000000800));
     }
 
     #[test]

--- a/src/stack_recorder.rs
+++ b/src/stack_recorder.rs
@@ -1820,12 +1820,21 @@ impl StackRecorder {
         ctx: &UserSymbolizeCtx<'_>,
         addr: u64,
     ) -> String {
-        if let Some(sym) = symbolizer
-            .symbolize_single(ctx.proc_src, Input::AbsAddr(addr))
-            .ok()
-            .and_then(|s| s.into_sym())
-        {
-            return format_symbolized_frame(&sym, addr, "unknown", self.elide_generics);
+        // A pool-backed address (a `runsc-memory` island, a `systrap-memory`
+        // page) never goes through the process source: blazesym would open
+        // the pool memfd — the sandbox's whole memory file, never an ELF —
+        // and parse it, costing time and symbol-cache memory for no name.
+        // Such an address resolves through the bridge and the guest view
+        // below; see `ProcessMaps::is_pool_backed` for the discriminator.
+        let pool_backed = ctx.maps.is_some_and(|m| m.is_pool_backed(addr));
+        if !pool_backed {
+            if let Some(sym) = symbolizer
+                .symbolize_single(ctx.proc_src, Input::AbsAddr(addr))
+                .ok()
+                .and_then(|s| s.into_sym())
+            {
+                return format_symbolized_frame(&sym, addr, "unknown", self.elide_generics);
+            }
         }
 
         if let Some(bridge) = ctx.maps.and_then(|m| m.bridge_for(addr)) {
@@ -2639,6 +2648,12 @@ mod tests {
         assert!(guest.virt_candidates_for_file_offset(0x3ff1f500).is_empty());
         assert_eq!(guest.pool_candidates_for_offset(0x3ff1f500), vec![0x4c2500]);
         assert!(guest.bridge_for(0x4c2500).is_some());
+        // The island address `symbolize_user_addr` routes past the process
+        // source is exactly the one the bridge resolves; its file-backed
+        // neighbors keep the process source.
+        assert!(guest.is_pool_backed(0x4c2500));
+        assert!(!guest.is_pool_backed(0x4c1500));
+        assert!(!guest.is_pool_backed(0x4c3500));
         assert_eq!(
             reconstruct_build_id_addr(Some(&guest), &[1; 20], 0x3ff1f500),
             None


### PR DESCRIPTION
## Summary

On hosts running gVisor sandboxes, `symbolize_user_addr` handed every
user address to blazesym's process source first — pool-memfd addresses
included. For an address inside one of the Sentry's memory pools
(`runsc-memory` islands inside guest text, `systrap-memory` sysmsg
pages) that call resolves the mapping through `/proc/<pid>/maps`, opens
the mapping's `map_files` link — the pool memfd itself, for
`runsc-memory` the sandbox's whole MemoryFile — and parses that file
from byte 0 as if it were the ELF the address belongs to. A pool is
never an ELF image, so the call costs time and symbol-cache memory and
can never name the address; the bridge (`bridge_for`) and the guest's
own maps, which run right after it, are where such addresses resolve.

This PR routes pool-backed addresses past the process source.

## The cost, as observed

On a gVisor-based Kubernetes cluster, continuous captures of 1–5 K stack
rows that sampled sandbox processes spent 60–192 s in `symbolize and
write parquet` while the fast captures on the same hosts took 0.5–16 s,
with the tracer's anon RSS at the symbolizer's memory-budget valve
(`memory.max / 2`). The slow captures were exactly the ones whose samples
landed in `memfd:runsc` processes, and their time tracked the number of
pool addresses that ended as `[gvisor:*]` labels — roughly 4–13 s per
such address — i.e. a per-address cost sitting on the addresses that go
through `handle_elf_addr` on the island's link before `bridge_for` and
come out unresolved.

## The change

- `ProcessMaps::is_pool_backed(addr)` (new): true iff the maps entry
  containing `addr` is a memfd named `runsc-memory` or `systrap-memory`
  — the `GVISOR_MEMFDS` set the sandbox classification (`is_gvisor`)
  already keys on. The test is the memfd's NAME, never `memfd:` as a
  class: the sandbox binary runsc re-execs from a memfd named `runsc`
  is a real ELF and keeps the ordinary path, and so does any other
  runtime's exec memfd (a JIT's code file).
- `symbolize_user_addr`: for a pool-backed address the
  `symbolize_single(Process, AbsAddr)` call is skipped; the address goes
  straight to the bridge, then the guest view, then the host-side label
  — the path it took after the failed call before.

## What does not change

No frame string changes for any class: bridged islands still render as
the original binary's symbol, guest-view misses as `[gvisor:*]` /
`[jit:*]` / `<module>:unknown`, file-backed and runsc-binary frames
exactly as today. Only the time and memory of the pool parse go away.

## Tests

- `sandbox_maps::tests::test_is_pool_backed_names_the_pools_only`: a
  maps fixture with the usertrap trampolines below the image, a
  patched-syscall island inside guest text, a writable pool mapping, a
  `systrap-memory` page, the runsc binary's own `/memfd:runsc
  (deleted)` mapping, file-backed text, an anon exec page and `[stack]`
  — pool-backed only for the four pool addresses (an island's last byte
  included); plus a non-gVisor process with a `/memfd:jit-code` exec
  mapping, untouched.
- `stack_recorder`'s existing guest fixture test now also asserts that
  the island address `bridge_for` resolves is the pool-backed one and
  its file-backed neighbors are not.

Not covered by a unit test: the skip inside `symbolize_user_addr` itself
needs a symbolizer over a live process; a runsc guest capture in the VM
suite is the end-to-end proof (a before/after on the symbolizer's
`Note: symbolizer caches rebuilt` count and its `symbolization done:
anon RSS` line).

## Runtime evidence

`cargo fmt --check` passes. `cargo clippy` and `cargo test` did not run
before the push (the authoring machine has no offline crate cache for
this lockfile), so this is a draft until the repository's Clippy and
Test Suite rows are green at the head; the runtime effect on a host
running gVisor sandboxes is measured after the change ships, on a
capture that sampled sandbox processes, against the two lines named
above.
