### PR TITLE
sched: take the sched_slice and thread_state parquet encode off the shard consumers

### DIFF
--- a/src/parquet/lane.rs
+++ b/src/parquet/lane.rs
@@ -40,6 +40,11 @@ use parquet::schema::types::SchemaDescriptor;
 /// Builds the arrow batch for a slice of rows.
 pub type BatchBuilder<R> = fn(&[R], &SchemaRef) -> Result<RecordBatch>;
 
+/// Rewrites a flushed batch on the lane thread before it is built — the
+/// per-batch sort a table wants for its delta encodings, which the inline
+/// writer ran on the producing thread.
+pub type BatchPrepare<R> = fn(&mut [R]);
+
 /// Flushed row batches the producing thread may run ahead of the lane by
 /// before its `push` blocks. Two 200,000-row batches of the widest record
 /// are under 200 MB; the backpressure is the point — a lane that cannot
@@ -72,12 +77,15 @@ pub struct EncodeLane<R: Send + Sync + 'static> {
 impl<R: Send + Sync + 'static> EncodeLane<R> {
     /// Start the lane: the file writer, the arrow-to-parquet schema and the
     /// `ARROW:schema` metadata are set up on the lane thread exactly as
-    /// `ArrowWriter::try_new` does.
+    /// `ArrowWriter::try_new` does. `prepare`, when given, runs over every
+    /// batch on the lane thread before `build` sees it.
+    #[allow(clippy::too_many_arguments)]
     pub fn start(
         table: &str,
         out: Box<dyn Write + Send>,
         schema: SchemaRef,
         props: WriterProperties,
+        prepare: Option<BatchPrepare<R>>,
         build: BatchBuilder<R>,
         workers: usize,
         row_group_rows: usize,
@@ -94,6 +102,7 @@ impl<R: Send + Sync + 'static> EncodeLane<R> {
                     out,
                     schema,
                     props,
+                    prepare,
                     build,
                     workers.max(1),
                     row_group_rows.max(1),
@@ -179,6 +188,7 @@ fn run_lane<R: Send + Sync + 'static>(
     out: Box<dyn Write + Send>,
     schema: SchemaRef,
     mut props: WriterProperties,
+    prepare: Option<BatchPrepare<R>>,
     build: BatchBuilder<R>,
     workers: usize,
     row_group_rows: usize,
@@ -193,9 +203,12 @@ fn run_lane<R: Send + Sync + 'static>(
         .with_context(|| format!("opening the parquet file of table {table}"))?;
 
     let mut group: Option<RowGroup> = None;
-    for rows in rx {
+    for mut rows in rx {
         if rows.is_empty() {
             continue;
+        }
+        if let Some(prepare) = prepare {
+            prepare(&mut rows);
         }
         let batches = build_parallel(&rows, &schema, build, workers)?;
         drop(rows);
@@ -433,7 +446,7 @@ mod tests {
         let props = WriterProperties::builder()
             .set_max_row_group_size(250)
             .build();
-        let mut lane = EncodeLane::start("t", out, schema(), props, build, 3, 250).unwrap();
+        let mut lane = EncodeLane::start("t", out, schema(), props, None, build, 3, 250).unwrap();
         for b in 0..7 {
             let rows: Vec<Row> = (0..100)
                 .map(|i| Row {
@@ -468,6 +481,7 @@ mod tests {
             out,
             schema(),
             WriterProperties::default(),
+            None,
             build,
             2,
             1000,
@@ -497,6 +511,7 @@ mod tests {
             out,
             schema(),
             WriterProperties::default(),
+            None,
             build,
             2,
             10,
@@ -508,5 +523,42 @@ mod tests {
         let _ = lane.push(rows);
         let err = lane.finish().unwrap_err();
         assert!(format!("{err:#}").contains("disk gone"), "{err:#}");
+    }
+
+    /// `prepare` runs on the lane thread over each batch before the build:
+    /// rows pushed in reverse come out sorted, batch by batch.
+    #[test]
+    fn prepare_rewrites_each_batch_before_the_build() {
+        fn sort_rows(rows: &mut [Row]) {
+            rows.sort_unstable_by_key(|r| r.id);
+        }
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("p.parquet");
+        let out: Box<dyn Write + Send> = Box::new(File::create(&path).unwrap());
+        let mut lane = EncodeLane::start(
+            "p",
+            out,
+            schema(),
+            WriterProperties::default(),
+            Some(sort_rows),
+            build,
+            2,
+            1000,
+        )
+        .unwrap();
+        for b in 0..3 {
+            let rows: Vec<Row> = (0..100)
+                .rev()
+                .map(|i| Row {
+                    id: b * 100 + i,
+                    name: "r",
+                })
+                .collect();
+            lane.push(rows).unwrap();
+        }
+        lane.finish().unwrap();
+        let (n, ids, _) = read_back(&path);
+        assert_eq!(n, 300);
+        assert_eq!(ids, (0..300).collect::<Vec<i64>>());
     }
 }

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -24,7 +24,7 @@ use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::schema::types::ColumnPath;
 
 use crate::network_recorder::{drop_reason_str, format_tcp_flags, tcp_state_name};
-use crate::parquet::lane::{encode_workers, EncodeLane};
+use crate::parquet::lane::{encode_workers, BatchBuilder, BatchPrepare, EncodeLane};
 use crate::parquet::ParquetSink;
 use crate::record::RecordCollector;
 use crate::trace::{
@@ -147,8 +147,13 @@ pub struct StreamingParquetWriter {
     // Persistent writers (created lazily on first flush, kept alive until finish)
     process_writer: Option<TableWriter>,
     thread_writer: Option<TableWriter>,
-    sched_slice_writer: Option<TableWriter>,
-    thread_state_writer: Option<TableWriter>,
+    /// The two hot sched tables encode off the flushing thread, like
+    /// `network_packet`: with one sched consumer per ring all flushing into
+    /// this writer under one lock, an inline 200,000-row encode held the
+    /// lock while every other shard queued on it and its ring overflowed.
+    /// Each lane's batch is sorted on the lane thread (the `prepare` hook).
+    sched_slice_lane: Option<EncodeLane<SchedSliceRecord>>,
+    thread_state_lane: Option<EncodeLane<ThreadStateRecord>>,
     irq_slice_writer: Option<TableWriter>,
     softirq_slice_writer: Option<TableWriter>,
     wakeup_new_writer: Option<TableWriter>,
@@ -272,8 +277,8 @@ impl StreamingParquetWriter {
             // Writers start as None, created lazily
             process_writer: None,
             thread_writer: None,
-            sched_slice_writer: None,
-            thread_state_writer: None,
+            sched_slice_lane: None,
+            thread_state_lane: None,
             irq_slice_writer: None,
             softirq_slice_writer: None,
             wakeup_new_writer: None,
@@ -353,6 +358,40 @@ impl StreamingParquetWriter {
         Ok(writer_opt.as_mut().unwrap())
     }
 
+    /// Hand a table's flushed rows to its encode lane, starting the lane on
+    /// the first flush. The caller has already swapped a fresh buffer in;
+    /// the sort (`prepare`), the arrow build and the parquet encode run on
+    /// the lane thread, so what this thread does under the writer's lock is
+    /// the hand-off alone.
+    #[allow(clippy::too_many_arguments)]
+    fn push_to_lane<R: Send + Sync + 'static>(
+        lane: &mut Option<EncodeLane<R>>,
+        sink: &ParquetSink,
+        props: &WriterProperties,
+        table: &str,
+        schema: Arc<Schema>,
+        prepare: Option<BatchPrepare<R>>,
+        build: BatchBuilder<R>,
+        rows: Vec<R>,
+    ) -> Result<()> {
+        if lane.is_none() {
+            let out = sink
+                .open(table)
+                .with_context(|| format!("Failed to open parquet sink for table {table}"))?;
+            *lane = Some(EncodeLane::start(
+                table,
+                out,
+                schema,
+                props.clone(),
+                prepare,
+                build,
+                encode_workers(),
+                props.max_row_group_size(),
+            )?);
+        }
+        lane.as_mut().expect("lane started above").push(rows)
+    }
+
     // Flush processes buffer
     fn flush_processes(&mut self) -> Result<()> {
         if self.processes.is_empty() {
@@ -395,52 +434,43 @@ impl StreamingParquetWriter {
         Ok(())
     }
 
-    // Flush sched_slices buffer
+    // Flush sched_slices buffer: the rows go whole to the table's encode
+    // lane and this thread returns with a fresh buffer. The sched consumers
+    // all flush through one shared writer lock, so what happens here is
+    // what every shard waits on.
     fn flush_sched_slices(&mut self) -> Result<()> {
         if self.sched_slices.is_empty() {
             return Ok(());
         }
-
-        let schema = trace::sched_slice_schema();
-        let writer = Self::get_or_create_writer(
-            &mut self.sched_slice_writer,
+        let rows = std::mem::replace(&mut self.sched_slices, Vec::with_capacity(self.batch_size));
+        Self::push_to_lane(
+            &mut self.sched_slice_lane,
             &self.sink,
-            "sched_slice",
-            schema.clone(),
             &self.writer_props,
-        )?;
-
-        // Sorting each batch by (cpu, ts) groups runs of nearby timestamps so
-        // delta encoding + ZSTD can exploit the locality. Per-batch sort is
-        // nearly as effective as a global sort because each 200k-row batch
-        // already covers a narrow time window.
-        self.sched_slices.sort_unstable_by_key(|r| (r.cpu, r.ts));
-        let batch = build_sched_slice_batch(&self.sched_slices, &schema)?;
-        writer.write(&batch)?;
-        self.sched_slices.clear();
-        Ok(())
+            "sched_slice",
+            trace::sched_slice_schema(),
+            Some(sort_sched_slice_batch),
+            build_sched_slice_batch,
+            rows,
+        )
     }
 
-    // Flush thread_states buffer
+    // Flush thread_states buffer: the same lane shape as sched_slices.
     fn flush_thread_states(&mut self) -> Result<()> {
         if self.thread_states.is_empty() {
             return Ok(());
         }
-
-        let schema = trace::thread_state_schema();
-        let writer = Self::get_or_create_writer(
-            &mut self.thread_state_writer,
+        let rows = std::mem::replace(&mut self.thread_states, Vec::with_capacity(self.batch_size));
+        Self::push_to_lane(
+            &mut self.thread_state_lane,
             &self.sink,
-            "thread_state",
-            schema.clone(),
             &self.writer_props,
-        )?;
-
-        self.thread_states.sort_unstable_by_key(|r| (r.utid, r.ts));
-        let batch = build_thread_state_batch(&self.thread_states, &schema)?;
-        writer.write(&batch)?;
-        self.thread_states.clear();
-        Ok(())
+            "thread_state",
+            trace::thread_state_schema(),
+            Some(sort_thread_state_batch),
+            build_thread_state_batch,
+            rows,
+        )
     }
 
     // Flush irq_slices buffer
@@ -868,37 +898,26 @@ impl StreamingParquetWriter {
     }
 
     // Flush network_packets buffer: the rows go whole to the table's encode
-    // lane (started here on the first flush) and this thread returns with a
-    // fresh buffer; the arrow build and the parquet encode run on the lane.
+    // lane and this thread returns with a fresh buffer; the arrow build and
+    // the parquet encode run on the lane.
     fn flush_network_packets(&mut self) -> Result<()> {
         if self.network_packets.is_empty() {
             return Ok(());
-        }
-
-        if self.network_packet_lane.is_none() {
-            let out = self
-                .sink
-                .open("network_packet")
-                .context("Failed to open parquet sink for table network_packet")?;
-            let lane = EncodeLane::start(
-                "network_packet",
-                out,
-                trace::network_packet_schema(),
-                self.writer_props.clone(),
-                build_network_packet_batch,
-                encode_workers(),
-                self.writer_props.max_row_group_size(),
-            )?;
-            self.network_packet_lane = Some(lane);
         }
         let rows = std::mem::replace(
             &mut self.network_packets,
             Vec::with_capacity(self.batch_size),
         );
-        self.network_packet_lane
-            .as_mut()
-            .expect("lane started above")
-            .push(rows)
+        Self::push_to_lane(
+            &mut self.network_packet_lane,
+            &self.sink,
+            &self.writer_props,
+            "network_packet",
+            trace::network_packet_schema(),
+            None,
+            build_network_packet_batch,
+            rows,
+        )
     }
 
     // Flush network_sockets buffer
@@ -1190,8 +1209,21 @@ impl StreamingParquetWriter {
 
         close_writer!(self.process_writer);
         close_writer!(self.thread_writer);
-        close_writer!(self.sched_slice_writer);
-        close_writer!(self.thread_state_writer);
+        // A lane finishes on the writer's thread: every queued batch is
+        // encoded, the row groups and the file closed.
+        macro_rules! finish_lane {
+            ($lane:expr) => {
+                if let Some(lane) = $lane.take() {
+                    if let Err(e) = lane.finish() {
+                        if first_error.is_none() {
+                            first_error = Some(e);
+                        }
+                    }
+                }
+            };
+        }
+        finish_lane!(self.sched_slice_lane);
+        finish_lane!(self.thread_state_lane);
         close_writer!(self.irq_slice_writer);
         close_writer!(self.softirq_slice_writer);
         close_writer!(self.wakeup_new_writer);
@@ -1209,13 +1241,7 @@ impl StreamingParquetWriter {
         close_writer!(self.network_interface_writer);
         close_writer!(self.socket_connection_writer);
         close_writer!(self.network_syscall_writer);
-        if let Some(lane) = self.network_packet_lane.take() {
-            if let Err(e) = lane.finish() {
-                if first_error.is_none() {
-                    first_error = Some(e);
-                }
-            }
-        }
+        finish_lane!(self.network_packet_lane);
         close_writer!(self.network_socket_writer);
         close_writer!(self.network_poll_writer);
         close_writer!(self.network_dns_writer);
@@ -1246,8 +1272,8 @@ impl Drop for StreamingParquetWriter {
         // Check if any writers are still open (finish() was not called)
         let has_open_writers = self.process_writer.is_some()
             || self.thread_writer.is_some()
-            || self.sched_slice_writer.is_some()
-            || self.thread_state_writer.is_some()
+            || self.sched_slice_lane.is_some()
+            || self.thread_state_lane.is_some()
             || self.irq_slice_writer.is_some()
             || self.softirq_slice_writer.is_some()
             || self.wakeup_new_writer.is_some()
@@ -1327,6 +1353,64 @@ impl RecordCollector for StreamingParquetWriter {
             self.flush_thread_states()?;
         }
         Ok(())
+    }
+
+    /// A sched shard's flush: the two hot tables take their rows as whole
+    /// `Vec` appends (one flush check each) instead of a push per record —
+    /// this runs under the shared writer lock every other shard waits on —
+    /// and the five small tables go through the per-record adds as before.
+    fn add_sched_batch(&mut self, batch: crate::record::SchedRecordBatch<'_>) -> usize {
+        let mut failed = 0usize;
+        let mut warn = |what: &str, e: anyhow::Error| {
+            eprintln!("Warning: Failed to stream {what}: {e}");
+            failed += 1;
+        };
+        if !batch.slices.is_empty() {
+            Self::reserve_if_empty(&mut self.sched_slices, self.batch_size);
+            self.total_records += batch.slices.len();
+            self.sched_slices.append(batch.slices);
+            if Self::should_flush(&self.sched_slices, self.batch_size) {
+                if let Err(e) = self.flush_sched_slices() {
+                    warn("sched slice batch", e);
+                }
+            }
+        }
+        if !batch.thread_states.is_empty() {
+            Self::reserve_if_empty(&mut self.thread_states, self.batch_size);
+            self.total_records += batch.thread_states.len();
+            self.thread_states.append(batch.thread_states);
+            if Self::should_flush(&self.thread_states, self.batch_size) {
+                if let Err(e) = self.flush_thread_states() {
+                    warn("thread state batch", e);
+                }
+            }
+        }
+        for record in batch.irq_slices.drain(..) {
+            if let Err(e) = self.add_irq_slice(record) {
+                warn("IRQ slice", e);
+            }
+        }
+        for record in batch.softirq_slices.drain(..) {
+            if let Err(e) = self.add_softirq_slice(record) {
+                warn("softirq slice", e);
+            }
+        }
+        for record in batch.wakeup_news.drain(..) {
+            if let Err(e) = self.add_wakeup_new(record) {
+                warn("wakeup_new", e);
+            }
+        }
+        for record in batch.sched_migrates.drain(..) {
+            if let Err(e) = self.add_sched_migrate(record) {
+                warn("sched_migrate", e);
+            }
+        }
+        for record in batch.process_exits.drain(..) {
+            if let Err(e) = self.add_process_exit(record) {
+                warn("process_exit", e);
+            }
+        }
+        failed
     }
 
     fn add_irq_slice(&mut self, record: IrqSliceRecord) -> Result<()> {
@@ -1794,6 +1878,20 @@ fn build_thread_batch(records: &[ThreadRecord], schema: &Arc<Schema>) -> Result<
             Arc::new(upid_builder.finish()),
         ],
     )?)
+}
+
+/// Sort a sched_slice batch by (cpu, ts) before it is built: runs of nearby
+/// timestamps let delta encoding + ZSTD exploit the locality. A per-batch
+/// sort is nearly as effective as a global one because each 200k-row batch
+/// already covers a narrow time window. Runs on the table's encode lane.
+fn sort_sched_slice_batch(rows: &mut [SchedSliceRecord]) {
+    rows.sort_unstable_by_key(|r| (r.cpu, r.ts));
+}
+
+/// Sort a thread_state batch by (utid, ts) before it is built, on the
+/// table's encode lane; the same locality argument as sched_slice.
+fn sort_thread_state_batch(rows: &mut [ThreadStateRecord]) {
+    rows.sort_unstable_by_key(|r| (r.utid, r.ts));
 }
 
 fn build_sched_slice_batch(
@@ -3975,5 +4073,175 @@ mod packet_encode_bench {
             .set_max_row_group_size(1_000_000)
             .build();
         write_with(none, &batches, &schema, "UNCOMPRESSED default encodings");
+    }
+}
+
+/// The two sched encode lanes against the inline writer's contract: every
+/// row a shard hands over lands once, each flushed batch sorted by the
+/// table's key on the lane, in a file whose columns the readers expect.
+#[cfg(test)]
+mod sched_lane_tests {
+    use super::*;
+    use crate::parquet::ParquetSink;
+    use crate::record::SchedRecordBatch;
+    use arrow::array::{Int32Array, Int64Array};
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
+    use tempfile::TempDir;
+
+    /// An integer column (Int64 or Int32) widened to i64.
+    fn col_i64(batch: &RecordBatch, idx: usize) -> Vec<i64> {
+        let col = batch.column(idx);
+        if let Some(v) = col.as_any().downcast_ref::<Int64Array>() {
+            (0..batch.num_rows()).map(|i| v.value(i)).collect()
+        } else if let Some(v) = col.as_any().downcast_ref::<Int32Array>() {
+            (0..batch.num_rows()).map(|i| v.value(i) as i64).collect()
+        } else {
+            panic!("column {idx} is not an integer column");
+        }
+    }
+
+    /// The table's rows as (column `a`, column `b`) pairs, both widened to
+    /// i64, in file order, plus the column names.
+    fn read_rows(
+        dir: &std::path::Path,
+        table: &str,
+        a: usize,
+        b: usize,
+    ) -> (Vec<(i64, i64)>, Vec<String>) {
+        let file = File::open(dir.join(format!("{table}.parquet"))).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let names: Vec<String> = builder
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        let mut rows = Vec::new();
+        for batch in builder.build().unwrap() {
+            let batch = batch.unwrap();
+            let av = col_i64(&batch, a);
+            let bv = col_i64(&batch, b);
+            rows.extend(av.into_iter().zip(bv));
+        }
+        (rows, names)
+    }
+
+    /// Two shards hand over unsorted rows in 10-slice / 6-state batches to a
+    /// writer that flushes a table to its lane at 25 rows: 60 slices and 36
+    /// thread states come back whole, and each lane batch is sorted by the
+    /// table's key.
+    #[test]
+    fn sched_rows_through_the_lanes_match_the_inline_contract() {
+        let dir = TempDir::new().unwrap();
+        let sink = ParquetSink::directory(dir.path()).unwrap();
+        let mut writer = StreamingParquetWriter::with_sink(sink, 25);
+
+        let mut expected_slices: Vec<(i64, i64)> = Vec::new();
+        let mut expected_states: Vec<(i64, i64)> = Vec::new();
+        for shard in 0..2i64 {
+            for batch in 0..3i64 {
+                // Descending timestamps within a batch, two CPUs interleaved.
+                let mut slices: Vec<SchedSliceRecord> = (0..10)
+                    .map(|i| SchedSliceRecord {
+                        ts: 1_000 * (shard * 3 + batch) + (10 - i),
+                        dur: 5,
+                        cpu: (i % 2) as i32,
+                        utid: 100 + shard,
+                        end_state: if i % 3 == 0 { Some(2) } else { None },
+                        priority: 120,
+                    })
+                    .collect();
+                let mut states: Vec<ThreadStateRecord> = (0..6)
+                    .map(|i| ThreadStateRecord {
+                        ts: 1_000 * (shard * 3 + batch) + (6 - i),
+                        dur: 0,
+                        utid: 200 + (i % 2),
+                        state: 0,
+                        cpu: Some(3),
+                    })
+                    .collect();
+                expected_slices.extend(slices.iter().map(|r| (r.ts, r.cpu as i64)));
+                expected_states.extend(states.iter().map(|r| (r.ts, r.utid)));
+                let (mut irq, mut softirq, mut wake, mut mig, mut exits) =
+                    (Vec::new(), Vec::new(), Vec::new(), Vec::new(), Vec::new());
+                let failed = writer.add_sched_batch(SchedRecordBatch {
+                    slices: &mut slices,
+                    thread_states: &mut states,
+                    irq_slices: &mut irq,
+                    softirq_slices: &mut softirq,
+                    wakeup_news: &mut wake,
+                    sched_migrates: &mut mig,
+                    process_exits: &mut exits,
+                });
+                assert_eq!(failed, 0);
+                assert!(
+                    slices.is_empty() && states.is_empty(),
+                    "the batch is taken whole"
+                );
+            }
+        }
+        writer.finish().unwrap();
+
+        let (slices, names) = read_rows(dir.path(), "sched_slice", 0, 2);
+        assert_eq!(names, ["ts", "dur", "cpu", "utid", "end_state", "priority"]);
+        assert_eq!(slices.len(), 60);
+        let mut want = expected_slices.clone();
+        want.sort_unstable();
+        let mut got = slices.clone();
+        got.sort_unstable();
+        assert_eq!(got, want, "every slice lands exactly once");
+        // The lane sorts each flushed batch by (cpu, ts). The first flush
+        // carries shard 0's 30 slices (the buffer crossed 25 on its third
+        // batch), so the file's first 30 rows are one sorted lane batch.
+        let first: Vec<(i64, i64)> = slices[..30].iter().map(|&(ts, cpu)| (cpu, ts)).collect();
+        let mut sorted = first.clone();
+        sorted.sort_unstable();
+        assert_eq!(first, sorted, "a lane batch is sorted by (cpu, ts)");
+
+        let (states, names) = read_rows(dir.path(), "thread_state", 0, 2);
+        assert_eq!(names, ["ts", "dur", "utid", "state", "cpu"]);
+        assert_eq!(states.len(), 36);
+        let mut want: Vec<(i64, i64)> = expected_states;
+        want.sort_unstable();
+        let mut got = states.clone();
+        got.sort_unstable();
+        assert_eq!(got, want, "every thread state lands exactly once");
+        // The first thread_state flush carries 30 rows too (shard 0's 18 plus
+        // shard 1's first 12 crossed 25 on shard 1's second batch).
+        let first: Vec<(i64, i64)> = states[..30].iter().map(|&(ts, utid)| (utid, ts)).collect();
+        let mut sorted = first.clone();
+        sorted.sort_unstable();
+        assert_eq!(first, sorted, "a lane batch is sorted by (utid, ts)");
+    }
+
+    /// An empty batch is a no-op: no lane, no file.
+    #[test]
+    fn an_empty_sched_batch_writes_nothing() {
+        let dir = TempDir::new().unwrap();
+        let sink = ParquetSink::directory(dir.path()).unwrap();
+        let mut writer = StreamingParquetWriter::with_sink(sink, 25);
+        let (mut a, mut b, mut c, mut d, mut e, mut f, mut g) = (
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let failed = writer.add_sched_batch(SchedRecordBatch {
+            slices: &mut a,
+            thread_states: &mut b,
+            irq_slices: &mut c,
+            softirq_slices: &mut d,
+            wakeup_news: &mut e,
+            sched_migrates: &mut f,
+            process_exits: &mut g,
+        });
+        assert_eq!(failed, 0);
+        writer.finish().unwrap();
+        assert!(!dir.path().join("sched_slice.parquet").exists());
+        assert!(!dir.path().join("thread_state.parquet").exists());
     }
 }

--- a/src/sched.rs
+++ b/src/sched.rs
@@ -830,3 +830,298 @@ mod tests {
         assert_eq!(runnable.state, 0);
     }
 }
+
+/// Release-mode benchmark legs for the sched consumer path — the userspace
+/// ceiling behind `Missed sched/IRQ events` on many-CPU hosts. Ignored by
+/// default; run one with
+/// `cargo test --release --lib sched_consumer_bench::<leg> -- --ignored --nocapture`.
+///
+/// Every leg drives N shard threads the way the `sched_rec_{i}` consumers
+/// run: each shard owns one `SchedEventRecorder` behind its own mutex and
+/// feeds it 4,096-event batches under that lock; the shards share only what
+/// production shares — the utid generator's DashMap and, in the legs that
+/// have one, the collector. Three collector shapes separate the candidate
+/// ceilings: a private `InMemoryCollector` per shard (the record cost plus
+/// the DashMap), one `SharedCollector(InMemoryCollector)` (adds the shared
+/// lock without an encode) and the production
+/// `SharedCollector(StreamingParquetWriter)` (adds the parquet flushes).
+/// A batch under the lock that takes longer than a few milliseconds is a
+/// stall — a flush of the shared writer, or a wait on the shard that is
+/// flushing — and each leg reports how many, the worst, and their share.
+#[cfg(test)]
+mod sched_consumer_bench {
+    use super::*;
+    use crate::parquet::StreamingParquetWriter;
+    use crate::record::{InMemoryCollector, SharedCollector};
+    use crate::systing_core::types::event_type;
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    /// The host shape the finding came from: 144 CPUs, ~29K threads.
+    const CPUS: u64 = 144;
+    const TIDS: u64 = 29_000;
+    /// Events handed to the recorder per lock acquisition, as `consume_loop`.
+    const BATCH: usize = 4096;
+    /// A batch under the lock slower than this is counted as a stall.
+    const STALL: Duration = Duration::from_millis(5);
+
+    /// One CPU's stream, as the kernel emits it: a WAKING of the next task
+    /// (targeting this CPU), then the SWITCH to it. Every other switch puts
+    /// the previous task to sleep (prev_state 2), which also emits a
+    /// thread_state row, so the model is 2.5 rows per 2 events.
+    fn synth_event(shard: u64, shards: u64, i: u64) -> task_event {
+        let cpus_here = (CPUS / shards).max(1);
+        let cpu = shard + shards * ((i / 2) % cpus_here);
+        let pair = i / 2;
+        let tid = 1000 + (pair * 7919 + shard * 104_729) % TIDS;
+        let prev_tid = 1000 + (pair * 7919 + shard * 104_729 + 7919 * cpus_here) % TIDS;
+        let mut e = task_event {
+            ts: 1_000_000_000 + i * 2_000 + shard,
+            cpu: cpu as u32,
+            ..Default::default()
+        };
+        if i.is_multiple_of(2) {
+            e.r#type = event_type::SCHED_WAKING;
+            e.target_cpu = cpu as u32;
+            e.next.tgidpid = (tid << 32) | tid;
+        } else {
+            e.r#type = event_type::SCHED_SWITCH;
+            e.prev.tgidpid = (prev_tid << 32) | prev_tid;
+            e.next.tgidpid = (tid << 32) | tid;
+            e.next_prio = 120;
+            e.prev_state = if pair.is_multiple_of(2) { 0 } else { 2 };
+        }
+        e
+    }
+
+    struct ShardStats {
+        events: u64,
+        stalls: u64,
+        stall_time: Duration,
+        worst: Duration,
+    }
+
+    /// Run N shards concurrently, `per_shard` events each; `make` builds
+    /// each shard's collector. Returns the wall (join of the slowest shard)
+    /// and every shard's stats.
+    fn run_shards(
+        shards: usize,
+        per_shard: u64,
+        utid: Arc<UtidGenerator>,
+        make: impl Fn(usize) -> Box<dyn RecordCollector + Send>,
+    ) -> (Duration, Vec<ShardStats>, Vec<SchedEventRecorder>) {
+        let recorders: Vec<Arc<Mutex<SchedEventRecorder>>> = (0..shards)
+            .map(|i| {
+                let mut rec = SchedEventRecorder::new(utid.clone());
+                rec.set_streaming_collector(make(i));
+                Arc::new(Mutex::new(rec))
+            })
+            .collect();
+        // Events are synthesized before the clock starts.
+        let streams: Vec<Vec<task_event>> = (0..shards)
+            .map(|s| {
+                (0..per_shard)
+                    .map(|i| synth_event(s as u64, shards as u64, i))
+                    .collect()
+            })
+            .collect();
+        let start = Instant::now();
+        let handles: Vec<_> = streams
+            .into_iter()
+            .zip(recorders.iter().cloned())
+            .map(|(events, rec)| {
+                std::thread::spawn(move || {
+                    let mut stats = ShardStats {
+                        events: 0,
+                        stalls: 0,
+                        stall_time: Duration::ZERO,
+                        worst: Duration::ZERO,
+                    };
+                    for batch in events.chunks(BATCH) {
+                        let t = Instant::now();
+                        {
+                            let mut rec = rec.lock().unwrap();
+                            for e in batch {
+                                rec.handle_event(*e);
+                            }
+                        }
+                        let d = t.elapsed();
+                        stats.events += batch.len() as u64;
+                        if d > STALL {
+                            stats.stalls += 1;
+                            stats.stall_time += d;
+                        }
+                        stats.worst = stats.worst.max(d);
+                    }
+                    stats
+                })
+            })
+            .collect();
+        let stats: Vec<ShardStats> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let wall = start.elapsed();
+        let recorders = recorders
+            .into_iter()
+            .map(|r| Arc::try_unwrap(r).ok().unwrap().into_inner().unwrap())
+            .collect();
+        (wall, stats, recorders)
+    }
+
+    fn report(leg: &str, shards: usize, wall: Duration, stats: &[ShardStats]) {
+        let events: u64 = stats.iter().map(|s| s.events).sum();
+        let stalls: u64 = stats.iter().map(|s| s.stalls).sum();
+        let stall_time: Duration = stats.iter().map(|s| s.stall_time).sum();
+        let worst = stats.iter().map(|s| s.worst).max().unwrap_or_default();
+        let ns = wall.as_nanos() as f64 / events as f64;
+        let per_shard_ns = ns * shards as f64;
+        eprintln!(
+            "BENCH {leg}: {shards} shards x {} events = {events} in {:.3} s = {:.2} M events/s host-wide \
+             ({per_shard_ns:.0} ns/event per shard); stalls > {} ms: {stalls} totalling {:.3} s \
+             = {:.1} % of the shard-seconds, worst {:.1} ms",
+            events / shards as u64,
+            wall.as_secs_f64(),
+            1e3 / ns,
+            STALL.as_millis(),
+            stall_time.as_secs_f64(),
+            100.0 * stall_time.as_secs_f64() / (wall.as_secs_f64() * shards as f64),
+            worst.as_secs_f64() * 1e3,
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn sizes() {
+        eprintln!(
+            "BENCH sizes: task_event {} B, SchedSliceRecord {} B, ThreadStateRecord {} B",
+            std::mem::size_of::<task_event>(),
+            std::mem::size_of::<SchedSliceRecord>(),
+            std::mem::size_of::<ThreadStateRecord>()
+        );
+    }
+
+    /// Leg A: a private InMemoryCollector per shard — the record build and
+    /// the shared DashMap, no shared collector lock, no encode. Also prints
+    /// the rows per event the stream produces per table.
+    fn private_in_memory(shards: usize) {
+        const PER_SHARD: u64 = 1_000_000;
+        let utid = Arc::new(UtidGenerator::new());
+        let (wall, stats, recorders) = run_shards(shards, PER_SHARD, utid, |_| {
+            Box::new(InMemoryCollector::new())
+        });
+        report("private InMemoryCollector per shard", shards, wall, &stats);
+        let (mut slices, mut states) = (0usize, 0usize);
+        for mut rec in recorders {
+            let mut collector = rec.finish(i64::MAX / 2).unwrap().unwrap();
+            let data = collector
+                .as_any_mut()
+                .and_then(|a| a.downcast_mut::<InMemoryCollector>())
+                .expect("InMemoryCollector")
+                .data();
+            slices += data.sched_slices.len();
+            states += data.thread_states.len();
+        }
+        let events = PER_SHARD * shards as u64;
+        eprintln!(
+            "BENCH rows/event: sched_slice {:.3}, thread_state {:.3} (model 0.5 + 0.75)",
+            slices as f64 / events as f64,
+            states as f64 / events as f64
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn private_in_memory_1() {
+        private_in_memory(1);
+    }
+    #[test]
+    #[ignore]
+    fn private_in_memory_8() {
+        private_in_memory(8);
+    }
+    #[test]
+    #[ignore]
+    fn private_in_memory_64() {
+        private_in_memory(64);
+    }
+
+    /// Leg B: one SharedCollector(InMemoryCollector) for every shard — the
+    /// shared lock per 10K-record flush, no encode.
+    fn shared_in_memory(shards: usize) {
+        const PER_SHARD: u64 = 1_000_000;
+        let utid = Arc::new(UtidGenerator::new());
+        let shared = SharedCollector::new(Box::new(InMemoryCollector::new()));
+        let (wall, stats, _) = run_shards(shards, PER_SHARD, utid, |_| Box::new(shared.clone()));
+        report("SharedCollector(InMemoryCollector)", shards, wall, &stats);
+    }
+
+    #[test]
+    #[ignore]
+    fn shared_in_memory_1() {
+        shared_in_memory(1);
+    }
+    #[test]
+    #[ignore]
+    fn shared_in_memory_64() {
+        shared_in_memory(64);
+    }
+
+    /// Leg C: the production path — one SharedCollector(StreamingParquetWriter)
+    /// for every shard: the shared lock per flush AND the parquet encode of
+    /// sched_slice / thread_state (inline before the encode lane, on the
+    /// lane after it). The final drain and the writer's finish are timed
+    /// apart from the consumer wall.
+    fn shared_parquet(shards: usize) {
+        const PER_SHARD: u64 = 1_000_000;
+        let dir = tempfile::TempDir::new().unwrap();
+        let utid = Arc::new(UtidGenerator::new());
+        let writer = StreamingParquetWriter::new(dir.path()).unwrap();
+        let shared = SharedCollector::new(Box::new(writer));
+        let (wall, stats, recorders) =
+            run_shards(shards, PER_SHARD, utid, |_| Box::new(shared.clone()));
+        report(
+            "SharedCollector(StreamingParquetWriter)",
+            shards,
+            wall,
+            &stats,
+        );
+        let t = Instant::now();
+        for mut rec in recorders {
+            // The returned collector handle is dropped here; the writer is
+            // finished through the one handle left below.
+            rec.finish(i64::MAX / 2).unwrap();
+        }
+        let drained = t.elapsed();
+        let t = Instant::now();
+        shared.finish().unwrap();
+        eprintln!(
+            "BENCH final drain {:.3} s + writer finish {:.3} s",
+            drained.as_secs_f64(),
+            t.elapsed().as_secs_f64()
+        );
+        let mut sizes = Vec::new();
+        for entry in std::fs::read_dir(dir.path()).unwrap() {
+            let entry = entry.unwrap();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with("sched_slice") || name.starts_with("thread_state") {
+                sizes.push(format!("{name} {} B", entry.metadata().unwrap().len()));
+            }
+        }
+        sizes.sort();
+        eprintln!("BENCH files: {}", sizes.join(", "));
+    }
+
+    #[test]
+    #[ignore]
+    fn shared_parquet_1() {
+        shared_parquet(1);
+    }
+    #[test]
+    #[ignore]
+    fn shared_parquet_8() {
+        shared_parquet(8);
+    }
+    #[test]
+    #[ignore]
+    fn shared_parquet_64() {
+        shared_parquet(64);
+    }
+}


### PR DESCRIPTION
## Summary

On a busy many-CPU host the sched/IRQ recorder silently loses events: the BPF side reports `Missed sched/IRQ events` in the millions per 10 s on 128–208-CPU hosts, at a userspace ceiling of about 2.4–2.9 M events/s per host that does not move with the ring layout (64 × 8 MiB or 8 × 64 MiB). This PR takes the parquet encode of the two hot sched tables (`sched_slice`, `thread_state`) off the shard consumers and onto the encode lane the `network_packet` table already uses, and measures the consumer path before and after: **4.6 → 18.5 M events/s at 64 shards on a 64-core host**, no longer flat with the shard count.

It builds on the network-packets consumer change (the encode lane, `src/parquet/lane.rs`; merged as #248, in `v1.18.4`) and changes nothing on the BPF side or in any schema — one commit, `sched: take the sched_slice and thread_state parquet encode off the shard consumers`.

## Where the time went

The consumer side is already sharded: one `SchedEventRecorder` per ring behind its own mutex, one SPSC channel and one `sched_rec_{i}` consumer thread per ring, the lock taken once per 4,096-event batch. The shards contend on nothing except the collector they all flush into every 10,000 records — one `SharedCollector` over one `StreamingParquetWriter`. There, every 200,000 rows of `sched_slice` and of `thread_state`, the writer sorted the batch by `(cpu, ts)` / `(utid, ts)`, built the arrow batch and ran `ArrowWriter::write` (ZSTD-3 + delta encodings) **inline under that shared lock**, on the thread of whichever shard crossed the threshold. For the length of that encode no other shard could hand off; their channels filled, their pollers blocked in `send`, and the BPF rings overflowed.

Measured in release mode on a 64-core host with an ignored benchmark module (`sched::sched_consumer_bench`): N shard threads each drive their own recorder the way the consumers do (4,096-event batches under the shard's lock) with 1 M synthetic events per shard in the shape of the finding (144 CPUs, ~29 K threads; WAKING + SWITCH pairs, every other switch a sleep — 1.25 rows per event, measured 0.500 `sched_slice` + 0.750 `thread_state`). The absolute figures are this host's; the split is the datum.

| collector | 1 shard | 8 shards | 64 shards |
|---|---|---|---|
| a private `InMemoryCollector` per shard (record build + the utid map; no shared lock, no encode) | 13.8 M/s | 45.6 M/s | 45.8 M/s |
| one `SharedCollector(InMemoryCollector)` (the shared lock per flush, no encode) | 11.1 M/s | — | 32.0 M/s |
| **before:** one `SharedCollector(StreamingParquetWriter)`, the encode inline | 4.82 M/s (70 % of the time in flush stalls, worst 31.6 ms) | 5.30 M/s (91 %, worst 59.6 ms) | **4.62 M/s** (95.3 % of the shard-seconds in 5,442 stalls, worst 812 ms) |
| **after:** the same, the two tables on encode lanes | **13.4 M/s** (no stall over 5 ms, worst 4.2 ms) | **21.6 M/s** (worst 22.5 ms) | **18.5 M/s** (worst 159 ms) |

The before row is flat with the shard count — the signature of serialized time on the shared path, not of contention — and the in-memory rows bound it from above: the encode under the lock is the ceiling, not the channel (per-ring SPSC), not the utid `DashMap` (46 M/s), not the lock itself (32 M/s). The after row rises with the shard count; its remaining waits are the shared lock's 10,000-record flushes plus the lane's two-batch queue, about 3.5× above the new figure.

## The change

- `src/parquet/lane.rs`: `EncodeLane::start` takes a `prepare: Option<fn(&mut [R])>` hook, run over each batch on the lane thread before the build — the per-batch sort the inline writer ran on the producer's thread. Test: `prepare_rewrites_each_batch_before_the_build`.
- `src/parquet/writer.rs`: `sched_slice_lane` / `thread_state_lane` replace the two `TableWriter`s; `flush_sched_slices` / `flush_thread_states` hand the `Vec` to the lane through one `push_to_lane` helper (which also carries the `network_packet` lane now: the lane is started on the table's first flush, with the table's sort as `prepare`) and return with a fresh buffer; `finish` closes the lanes where it closed the writers. `add_sched_batch` is overridden on the writer so a shard's flush appends its whole `Vec`s under the lock (one flush check each) instead of pushing a record at a time; the five small sched tables (`irq_slice`, `softirq_slice`, `wakeup_new`, `sched_migrate`, `process_exit`) keep the per-record inline path — their row rates are a fraction of the two hot tables'. Tests: `sched_lane_tests` — every row a shard hands over lands exactly once and each lane batch is sorted by the table's key; an empty batch writes nothing.
- `src/sched.rs`: the benchmark module (ignored; `cargo test --release --lib sched_consumer_bench -- --ignored --nocapture`).

No schema change: the same columns, writer properties, row-group bound (1 M rows) and `ARROW:schema` metadata; the same file names; every reader is unchanged. File sizes on the same 64-shard stream (32 M slices + 48 M thread states) across three runs: `sched_slice.parquet` 61.70 MB before, 62.23 / 61.67 MB after; `thread_state.parquet` 224.6 MB before, 235.5 / 145.0 MB after. The spread is the shards' interleaving — which rows share a 200,000-row batch is decided by 64 threads racing to the shared lock, and the sort key is per batch — not the lane; the per-batch sort is kept and tested.

## What to look at

- The `prepare` hook runs on the lane thread with the batch owned by the lane, before `build_parallel` borrows it — no aliasing with the producer, which has already returned with a fresh `Vec`.
- `add_sched_batch` on the writer: the `should_flush` check after an append can hand the lane up to `batch_size + 10,000` rows (a shard's flush is at most `STREAMING_SCHED_FLUSH_THRESHOLD` records); the lane accepts any batch size and closes row groups at the configured bound regardless.
- A shard blocked on the lane's queue (`LANE_QUEUE = 2` batches) holds the writer lock exactly as the inline encode did, so a lane that cannot keep up still shows as missed events, never as unbounded memory — the same bound the network-packets PR established.
- Not in this PR: the five small tables (inline by design), a per-shard tid → utid cache (the in-memory legs show the map is not a ceiling), and the kernel-side changes.

## Test plan

- `cargo test --release --lib`: 599 passed, 0 failed, 17 ignored (the benchmark legs).
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- The benchmark legs above, before and after, on the same host.
- After a release: the `Missed sched/IRQ events` counter under a loaded host, before/after, then the per-capture missed counts on the many-CPU hosts where the ceiling was measured.
- One consequence to plan for: a host that sat above the old ceiling now records up to ~4× the `sched_slice` / `thread_state` rows per capture it used to (the events it was dropping). Anything that post-processes those tables under a fixed time budget — `systing-analyze sched aggregate` run with a deadline, for one — sees that growth on exactly those hosts, so a budget calibrated on the old, truncated traces wants re-reading alongside this change.
