### PR TITLE
network-packets: buffer headroom, exact ids on a failed append, quieter consumers

### DIFF
--- a/src/network_recorder.rs
+++ b/src/network_recorder.rs
@@ -1103,7 +1103,10 @@ impl NetworkRecorder {
     /// part of the packet path that needs the recorder: the socket record
     /// on a socket's first sighting, the packet ids in arrival order, the
     /// trace's minimum timestamp, then ONE collector call for the whole
-    /// batch (one collector lock, one buffer extend).
+    /// batch (one collector lock, one buffer extend). The socket records go
+    /// first and the ids are handed back on a collector error, so a batch
+    /// that fails consumes no ids and [`Self::packet_events_recorded`]
+    /// counts only records the collector took.
     pub fn append_packet_batch(&mut self, batch: PreparedBatch) -> Result<()> {
         let PreparedBatch {
             mut records,
@@ -1115,8 +1118,11 @@ impl NetworkRecorder {
         if let Some(min_ts) = sockets.iter().map(|s| s.ts).min() {
             self.track_min_ts(min_ts);
         }
-        for (record, socket) in records.iter_mut().zip(&sockets) {
+        for socket in &sockets {
             self.maybe_emit_socket_record(socket)?;
+        }
+        let first_id = self.next_packet_id;
+        for record in records.iter_mut() {
             record.id = self.next_packet_id;
             self.next_packet_id += 1;
         }
@@ -1124,7 +1130,11 @@ impl NetworkRecorder {
             .streaming_collector
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("Streaming collector not set in append_packet_batch"))?;
-        collector.add_network_packet_batch(records)
+        if let Err(e) = collector.add_network_packet_batch(records) {
+            self.next_packet_id = first_id;
+            return Err(e);
+        }
+        Ok(())
     }
 
     pub fn handle_epoll_event(&mut self, event: crate::systing_core::types::epoll_event_bpf) {

--- a/src/parquet/writer.rs
+++ b/src/parquet/writer.rs
@@ -174,6 +174,10 @@ pub struct StreamingParquetWriter {
     /// The network_packet table encodes off the flushing thread: see
     /// [`EncodeLane`]. Started on the first flush, finished with the others.
     network_packet_lane: Option<EncodeLane<NetworkPacketRecord>>,
+    /// The largest packet batch a consumer has handed over. A fresh packet
+    /// buffer is sized to `batch_size` plus this, so the append that carries
+    /// the buffer past the flush bound never regrows it.
+    network_packet_headroom: usize,
     network_socket_writer: Option<TableWriter>,
     network_poll_writer: Option<TableWriter>,
     network_dns_writer: Option<TableWriter>,
@@ -297,6 +301,7 @@ impl StreamingParquetWriter {
             socket_connection_writer: None,
             network_syscall_writer: None,
             network_packet_lane: None,
+            network_packet_headroom: 0,
             network_socket_writer: None,
             network_poll_writer: None,
             network_dns_writer: None,
@@ -906,7 +911,7 @@ impl StreamingParquetWriter {
         }
         let rows = std::mem::replace(
             &mut self.network_packets,
-            Vec::with_capacity(self.batch_size),
+            Vec::with_capacity(self.batch_size + self.network_packet_headroom),
         );
         Self::push_to_lane(
             &mut self.network_packet_lane,
@@ -1595,7 +1600,15 @@ impl RecordCollector for StreamingParquetWriter {
     }
 
     fn add_network_packet_batch(&mut self, records: Vec<NetworkPacketRecord>) -> Result<()> {
-        Self::reserve_if_empty(&mut self.network_packets, self.batch_size);
+        // The buffer crosses the flush bound by up to one consumer batch, so
+        // it is sized for the bound plus the largest batch seen: the crossing
+        // append then fits, where a buffer sized to the bound alone regrew
+        // (a copy of the whole buffer) on nearly every cycle.
+        self.network_packet_headroom = self.network_packet_headroom.max(records.len());
+        Self::reserve_if_empty(
+            &mut self.network_packets,
+            self.batch_size + self.network_packet_headroom,
+        );
         self.total_records += records.len();
         self.network_packets.extend(records);
         if Self::should_flush(&self.network_packets, self.batch_size) {
@@ -3945,8 +3958,9 @@ mod packet_encode_bench {
 
     /// The record shape `NetworkRecorder::stream_packet_event` builds for a
     /// TX data-path event (the send-buffer, RTT and TSQ fields set, the
-    /// diagnostic fields None), on a 4096-socket pool.
-    fn synth_record(i: i64) -> NetworkPacketRecord {
+    /// diagnostic fields None), on a 4096-socket pool. Shared with the lane
+    /// contract test below.
+    pub(super) fn synth_record(i: i64) -> NetworkPacketRecord {
         let socket = 1 + (i / 4) % 4096;
         NetworkPacketRecord {
             id: i + 1,
@@ -4243,5 +4257,142 @@ mod sched_lane_tests {
         writer.finish().unwrap();
         assert!(!dir.path().join("sched_slice.parquet").exists());
         assert!(!dir.path().join("thread_state.parquet").exists());
+    }
+}
+
+/// The packet lane's file contract, through the production path: two
+/// consumers' batches into one [`crate::record::SharedCollector`] over a
+/// [`StreamingParquetWriter`] whose network_packet table flushes to its
+/// [`EncodeLane`] with the production writer properties.
+#[cfg(test)]
+mod packet_lane_tests {
+    use super::packet_encode_bench::synth_record;
+    use super::*;
+    use crate::parquet::ParquetSink;
+    use crate::record::SharedCollector;
+    use arrow::array::Int64Array;
+    use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+    use std::fs::File;
+    use tempfile::TempDir;
+
+    /// Two handles hand over four 16-record batches to a writer that flushes
+    /// the packet table at 25 rows — the buffer crosses the bound on the
+    /// second and fourth batch, the lane sees two batches, `finish` closes
+    /// the file — and the file the arrow reader opens carries the table's
+    /// schema and every record exactly once, in arrival order.
+    #[test]
+    fn packet_rows_through_the_lane_come_back_whole_and_in_order() {
+        let dir = TempDir::new().unwrap();
+        let sink = ParquetSink::directory(dir.path()).unwrap();
+        let shared = SharedCollector::new(Box::new(StreamingParquetWriter::with_sink(sink, 25)));
+        let mut first = shared.clone();
+        let mut second = shared;
+
+        let mut next = 0i64;
+        for _round in 0..2 {
+            for handle in [&mut first, &mut second] {
+                let records: Vec<NetworkPacketRecord> = (0..16)
+                    .map(|_| {
+                        let record = synth_record(next);
+                        next += 1;
+                        record
+                    })
+                    .collect();
+                handle.add_network_packet_batch(records).unwrap();
+            }
+        }
+        // The first handle's finish leaves the shared writer open; the last
+        // one closes the lane and the file.
+        first.finish().unwrap();
+        second.finish().unwrap();
+
+        let file = File::open(dir.path().join("network_packet.parquet")).unwrap();
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file).unwrap();
+        let names: Vec<String> = builder
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        let want: Vec<String> = trace::network_packet_schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().to_string())
+            .collect();
+        assert_eq!(names, want, "the file carries the table's schema");
+
+        let mut ids = Vec::new();
+        let mut socket_ids = Vec::new();
+        for batch in builder.build().unwrap() {
+            let batch = batch.unwrap();
+            let id = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("id is Int64");
+            let socket = batch
+                .column(2)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("socket_id is Int64");
+            for i in 0..batch.num_rows() {
+                ids.push(id.value(i));
+                socket_ids.push(socket.value(i));
+            }
+        }
+        let expected_ids: Vec<i64> = (1..=64).collect();
+        assert_eq!(ids, expected_ids, "every record once, in arrival order");
+        let expected_sockets: Vec<i64> = (0..64).map(|i| synth_record(i).socket_id).collect();
+        assert_eq!(
+            socket_ids, expected_sockets,
+            "the rows are the records handed over"
+        );
+    }
+
+    /// The packet buffer is sized for the flush bound plus the largest batch
+    /// seen, so the append that carries it past the bound fits without a
+    /// regrow, and the fresh buffer after the flush is sized the same way.
+    #[test]
+    fn the_packet_buffer_holds_the_crossing_append_without_a_regrow() {
+        let dir = TempDir::new().unwrap();
+        let sink = ParquetSink::directory(dir.path()).unwrap();
+        let mut writer = StreamingParquetWriter::with_sink(sink, 25);
+
+        let batch = |from: i64| -> Vec<NetworkPacketRecord> {
+            (from..from + 10).map(synth_record).collect()
+        };
+        writer.add_network_packet_batch(batch(0)).unwrap();
+        let capacity = writer.network_packets.capacity();
+        assert!(capacity >= 25 + 10, "sized for the bound plus one batch");
+        writer.add_network_packet_batch(batch(10)).unwrap();
+        assert_eq!(writer.network_packets.len(), 20);
+        assert!(
+            writer.network_packets.capacity() >= 30,
+            "the next append crosses the bound and already fits"
+        );
+        writer.add_network_packet_batch(batch(20)).unwrap();
+        assert_eq!(
+            writer.network_packets.len(),
+            0,
+            "the crossing append flushed"
+        );
+        assert_eq!(
+            writer.network_packets.capacity(),
+            capacity,
+            "the fresh buffer is sized the same way"
+        );
+        writer.add_network_packet_batch(batch(30)).unwrap();
+        writer.add_network_packet_batch(batch(40)).unwrap();
+        assert_eq!(writer.network_packets.capacity(), capacity, "no regrow");
+        writer.finish().unwrap();
+
+        let file = File::open(dir.path().join("network_packet.parquet")).unwrap();
+        let rows: usize = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap()
+            .map(|b| b.unwrap().num_rows())
+            .sum();
+        assert_eq!(rows, 50);
     }
 }

--- a/src/systing_core.rs
+++ b/src/systing_core.rs
@@ -13,7 +13,7 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::net::UnixDatagram;
 use std::path::{Path, PathBuf};
 use std::process;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{channel, sync_channel, Receiver, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -2144,8 +2144,15 @@ fn spawn_recorder_threads(
         // the per-event work) and takes the lock once per batch to append
         // them — the socket records, the ids and one collector call. The
         // parquet encode itself runs on the table's encode lane, never here.
+        // A failed append is reported on the first failure and then once per
+        // doubling of the count, shared across the rings: the batches all end
+        // on one lane, so a lane that has stopped fails every one of them
+        // (the capture's finish carries the lane's own error), and a line per
+        // batch from every ring would flood stderr.
+        let packet_append_failures = Arc::new(AtomicU64::new(0));
         for (i, packet_rx) in packet_rxs.into_iter().enumerate() {
             let session_recorder = recorder.clone();
+            let failures = packet_append_failures.clone();
             threads.push(
                 thread::Builder::new()
                     .name(format!("packet_rec_{i}"))
@@ -2162,7 +2169,12 @@ fn spawn_recorder_threads(
                             }
                             let mut rec = session_recorder.network_recorder.lock().unwrap();
                             if let Err(e) = rec.append_packet_batch(prepared) {
-                                eprintln!("Warning: Failed to stream network packet events: {e}");
+                                let n = failures.fetch_add(1, Ordering::Relaxed) + 1;
+                                if n.is_power_of_two() {
+                                    eprintln!(
+                                        "Warning: Failed to stream network packet events ({n} batches dropped so far): {e}"
+                                    );
+                                }
                             }
                         }
                         0


### PR DESCRIPTION
## Summary

Follow-ups on the network-packets consumer path from the review of #248. None of them changes what a successful capture writes; they close three small holes on the consumer's own bookkeeping and add the file-contract test the review asked for.

## The changes

1. **No regrow on the crossing append** (`src/parquet/writer.rs`). `add_network_packet_batch` extends the packet buffer by a whole consumer batch and flushes when the buffer has reached `batch_size`, so the buffer crosses the bound by up to one batch. A buffer sized to the bound alone therefore reallocated — and copied its 200,000 records — on the crossing append of nearly every cycle. The writer now remembers the largest batch it has been handed and sizes the buffer, and the fresh buffer after each flush, to the bound plus that headroom.
2. **Exact ids on a failed append** (`src/network_recorder.rs`). `append_packet_batch` emitted each socket record and assigned each id in one loop before the collector call, so a socket-record error dropped the whole batch with the ids it had consumed, and a collector error dropped it with every id consumed — and `packet_events_recorded()`, the exit summary's denominator, counted them. The socket records now go first, the ids are assigned after, and they are handed back when the collector refuses the batch: a failed batch consumes no ids.
3. **One warning per doubling** (`src/systing_core.rs`). A failed append was one `eprintln!` per 4,096-event batch per ring until the capture ended — on a 64-ring host behind a stopped lane, a stderr flood. The packet consumers now share one failure counter and report on the first failure and then at every power of two, with the count. The consumers keep draining their rings, as before: the batches all end on one encode lane, so a lane that has stopped fails every one of them, and the capture's `finish` returns the lane's own error.
4. **The lane's file contract, tested through the production path** (`packet_lane_tests`). Two collector handles hand batches to one `SharedCollector` over a `StreamingParquetWriter` whose packet table flushes to its `EncodeLane` with the production writer properties; the file is read back with the arrow reader and checked for the table's schema and every record exactly once, in arrival order. A second test pins the buffer sizing. The bench module's record factory is shared with them.

## A correction to #248's description

Its "closes a row group exactly where `ArrowWriter` closed one" is not exact: the lane closes a row group after the batch that reaches `max_row_group_size`, so a row group holds between the bound and the bound plus one lane batch (1,000,000 to about 1,020,000 rows at the default sizes). Readers are unaffected.

## Test plan

- `packet_lane_tests::packet_rows_through_the_lane_come_back_whole_and_in_order` and `::the_packet_buffer_holds_the_crossing_append_without_a_regrow`, new; the existing suite unchanged.
- `cargo fmt --check` passes; clippy and the tests did not run before the push (no local build for this lockfile) — the repository's Clippy / Test Suite rows are the gate and the PR stays a draft until they are green.
- No schema, version or BPF change; no new dependency.
